### PR TITLE
Render bullet points correctly in lab 5

### DIFF
--- a/labs/lab05/index.html
+++ b/labs/lab05/index.html
@@ -114,28 +114,50 @@ Enter next element: 4
 Enter next element: /
 Enter next element: -
 Enter next element: #
-Expression tree in postfix expression: 34 6 + -8 4 / - 
+Expression tree in postfix expression: 34 6 + -8 4 / -
 Expression tree in infix expression: ((34 + 6) - (-8 / 4))
-Expression tree in prefix expression: - + 34 6 / -8 4 
-The result of the expression tree is 42 </code></pre>
+Expression tree in prefix expression: - + 34 6 / -8 4
+The result of the expression tree is 42</code></pre>
 <hr />
 <h2 id="in-lab-1">In-lab</h2>
 <p>For this in-lab, you will implement a Binary search tree. The required class declarations are located in <a href="code/inlab/BinaryNode.h">BinaryNode.h</a> and <a href="code/inlab/BinarySearchTree.h">BinarySearchTree.h</a>. You may want to create private helper methods for BinarySearchTree, as done for the implementation of <code>remove</code>, which is already provided for you. Notice how the private methods take a BinaryNode as a parameter. This allows them to recur over a subtree, a common implementation technique.</p>
 <p>Do NOT alter <a href="code/inlab/BSTPathTest.cpp">BSTPathTest.cpp</a>. This program will be used to run automated tests on your implementation. Do not change it.</p>
-<p>The test program reads a sequence of a sequence of instruction/word pairs and attempts to operate on your tree. Example test files are located in the inlab directory. - Insert <word>: <code>I &lt;word&gt;</code> - Remove <word>: <code>R &lt;word&gt;</code> - Lookup <word>: <code>L &lt;word&gt;</code></p>
+<p>The test program reads a sequence of a sequence of instruction/word pairs and attempts to operate on your tree. Example test files are located in the inlab directory.</p>
+<ul>
+<li>Insert <word>: <code>I &lt;word&gt;</code></li>
+<li>Remove <word>: <code>R &lt;word&gt;</code></li>
+<li>Lookup <word>: <code>L &lt;word&gt;</code></li>
+</ul>
 <p>The Lookup instruction will call the <code>pathTo()</code> method defined on your tree. <code>pathTo()</code> must return a string representing the nodes encountered when finding an element. For instance in the following image, the bold lines indicate the path taken for locating element W.</p>
 <div class="figure">
 <img src="avl-tree-pic-1.png" alt="avl-tree-pic-1" />
 <p class="caption">avl-tree-pic-1</p>
 </div>
 <p><code>pathTo(&quot;W&quot;)</code> would then return the string <code>&quot;M P Z W&quot;</code>. Calling <code>pathTo()</code> on an element that doesn't exist would result in an empty string <code>&quot;&quot;</code>.</p>
-<p>To recap, submit the following files: - BSTPathTest.cpp: Do NOT modify, contains <code>main()</code>. - BinaryNode.h, BinarySearchTree.h: class declarations the test program requires. - BinaryNode.cpp: contains the implementation of BinaryNode. - BinarySearchTree.cpp: contains the implemention of BinarySearchTree. - Any other .cpp files required to make your program compile. - Makefile: compiles your program and produces the a.out executable.</p>
+<p>To recap, submit the following files:</p>
+<ul>
+<li>BSTPathTest.cpp: Do NOT modify, contains <code>main()</code>.</li>
+<li>BinaryNode.h, BinarySearchTree.h: class declarations the test program requires.</li>
+<li>BinaryNode.cpp: contains the implementation of BinaryNode.</li>
+<li>BinarySearchTree.cpp: contains the implemention of BinarySearchTree.</li>
+<li>Any other .cpp files required to make your program compile.</li>
+<li>Makefile: compiles your program and produces the a.out executable.</li>
+</ul>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
 <p>The objective of this post-lab is to understand the runtime characteristics and trade-offs between normal Binary search trees and AVL trees. You will have to implement an AVL tree and write a brief report to compare its performance with the Binary search tree implemented for the in-lab.</p>
 <p>The required class declarations are located in <a href="code/postlab/AVLNode.h">AVLNode.h</a> and <a href="code/postlab/AVLTree.h">AVLTree.h</a>. Much of the behavior of the AVL implementation is similar to that of the Binary search tree, aside from rotations and rebalancing. You may want to create private helper methods for AVLTree, as done for the implementation of <code>remove</code>, which is already provided for you.</p>
 <p>Do NOT alter <a href="code/postlab/AVLPathTest.cpp">AVLPathTest.cpp</a>. This program will be used to run automated tests on your implementation. Do not change it. The example test files are located in the postlab directory.</p>
-<p>To recap, submit the following files: - AVLPathTest.cpp: Do NOT modify, contains <code>main()</code>. - AVLNode.h, AVLTree.h: class declarations the test program requires. - AVLNode.cpp: contains the implementation of AVLNode. - AVLTree.cpp: contains the implemention of AVLTree. - Any other .cpp files required to make your program compile. - Makefile: compiles your program and produces the a.out executable. - analysis.pdf: The report for this lab.</p>
+<p>To recap, submit the following files:</p>
+<ul>
+<li>AVLPathTest.cpp: Do NOT modify, contains <code>main()</code>.</li>
+<li>AVLNode.h, AVLTree.h: class declarations the test program requires.</li>
+<li>AVLNode.cpp: contains the implementation of AVLNode.</li>
+<li>AVLTree.cpp: contains the implemention of AVLTree.</li>
+<li>Any other .cpp files required to make your program compile.</li>
+<li>Makefile: compiles your program and produces the a.out executable.</li>
+<li>analysis.pdf: The report for this lab.</li>
+</ul>
 <p>The report for this lab should contain the following:</p>
 <ol style="list-style-type: decimal">
 <li>Your name, the date, and your CS 2150 lab section.</li>

--- a/labs/lab05/index.md
+++ b/labs/lab05/index.md
@@ -65,7 +65,7 @@ You must use the skeleton source files provided here as a basis for your prelab.
 - Do NOT alter [TreeCalcTest.cpp](code/prelab/TreeCalcTest.cpp.html) ([src](code/prelab/TreeCalcTest.cpp)).  This is the testing program that we will use to run automated tests on your implementations.  Do not change it.
 - In [TreeCalc.h](code/prelab/TreeCalc.h.html) ([src](code/prelab/TreeCalc.h)) and [TreeCalc.cpp](code/prelab/TreeCalc.cpp.html) ([src](code/prelab/TreeCalc.cpp)):
     - Do NOT alter the `readInput()` method.  Points will be deducted if you do so.
-    - The only modification allowed in the `printOutput()` method is to add calls to your implemented `printPrefix()`, `printPostfix()`, and `printInorder()` methods 
+    - The only modification allowed in the `printOutput()` method is to add calls to your implemented `printPrefix()`, `printPostfix()`, and `printInorder()` methods
 - You should implement all the methods as listed in the class definitions for TreeCalc
 - You may add additional supporting methods and data members to TreeCalc to complete your implementation.
     - Don't modify TreeNode -- note that TreeCalc is a friend of TreeNode, so you can put all your code in TreeCalc.
@@ -122,10 +122,10 @@ Enter next element: 4
 Enter next element: /
 Enter next element: -
 Enter next element: #
-Expression tree in postfix expression: 34 6 + -8 4 / - 
+Expression tree in postfix expression: 34 6 + -8 4 / -
 Expression tree in infix expression: ((34 + 6) - (-8 / 4))
-Expression tree in prefix expression: - + 34 6 / -8 4 
-The result of the expression tree is 42 
+Expression tree in prefix expression: - + 34 6 / -8 4
+The result of the expression tree is 42
 ```
 
 ------------------------------------------------------------
@@ -138,6 +138,7 @@ For this in-lab, you will implement a Binary search tree. The required class dec
 Do NOT alter [BSTPathTest.cpp](code/inlab/BSTPathTest.cpp). This program will be used to run automated tests on your implementation. Do not change it.
 
 The test program reads a sequence of a sequence of instruction/word pairs and attempts to operate on your tree. Example test files are located in the inlab directory.
+
 - Insert <word>: `I <word>`
 - Remove <word>: `R <word>`
 - Lookup <word>: `L <word>`
@@ -149,6 +150,7 @@ The Lookup instruction will call the `pathTo()` method defined on your tree. `pa
 `pathTo("W")` would then return the string `"M P Z W"`. Calling `pathTo()` on an element that doesn't exist would result in an empty string `""`.
 
 To recap, submit the following files:
+
 - BSTPathTest.cpp: Do NOT modify, contains `main()`.
 - BinaryNode.h, BinarySearchTree.h: class declarations the test program requires.
 - BinaryNode.cpp: contains the implementation of BinaryNode.
@@ -163,11 +165,12 @@ Post-lab
 
 The objective of this post-lab is to understand the runtime characteristics and trade-offs between normal Binary search trees and AVL trees. You will have to implement an AVL tree and write a brief report to compare its performance with the Binary search tree implemented for the in-lab.
 
-The required class declarations are located in [AVLNode.h](code/postlab/AVLNode.h) and [AVLTree.h](code/postlab/AVLTree.h). Much of the behavior of the AVL implementation is similar to that of the Binary search tree, aside from rotations and rebalancing. You may want to create private helper methods for AVLTree, as done for the implementation of `remove`, which is already provided for you. 
+The required class declarations are located in [AVLNode.h](code/postlab/AVLNode.h) and [AVLTree.h](code/postlab/AVLTree.h). Much of the behavior of the AVL implementation is similar to that of the Binary search tree, aside from rotations and rebalancing. You may want to create private helper methods for AVLTree, as done for the implementation of `remove`, which is already provided for you.
 
 Do NOT alter [AVLPathTest.cpp](code/postlab/AVLPathTest.cpp). This program will be used to run automated tests on your implementation. Do not change it. The example test files are located in the postlab directory.
 
 To recap, submit the following files:
+
 - AVLPathTest.cpp: Do NOT modify, contains `main()`.
 - AVLNode.h, AVLTree.h: class declarations the test program requires.
 - AVLNode.cpp: contains the implementation of AVLNode.
@@ -176,7 +179,7 @@ To recap, submit the following files:
 - Makefile: compiles your program and produces the a.out executable.
 - analysis.pdf: The report for this lab.
 
-The report for this lab should contain the following: 
+The report for this lab should contain the following:
 
 1. Your name, the date, and your CS 2150 lab section.
 2. A discussion of what [testfile1.txt](code/postlab/testfile1.txt), [testfile2.txt](code/postlab/testfile2.txt), and [testfile3.txt](code/postlab/testfile3.txt) suggest about the relative performance of AVL trees and Binary search trees.


### PR DESCRIPTION
Some bullet points in the lab write-up weren't rendering correctly because of missing newlines.  Add them.

|Before|After|
|-------|------|
|![list-before](https://user-images.githubusercontent.com/2766036/47162540-24f00c00-d2c2-11e8-98ff-8d21632e84b9.png)|![after](https://user-images.githubusercontent.com/2766036/47162568-30dbce00-d2c2-11e8-8b40-8e8c0871302e.png)|

I suggest viewing the diff without whitespace changes (Diff settings -> Hide whitespace changes), as my editor cleaned up some trailing spaces along the way.