### PR TITLE
Remove info about in-lab extension

### DIFF
--- a/labs/lab07/index.html
+++ b/labs/lab07/index.html
@@ -35,7 +35,6 @@
 <ol style="list-style-type: decimal">
 <li>Implement the bubble sort algorithm in IBCM from the C++ code. See the in-lab section for details.</li>
 <li>Discuss any problems getting your programs to work with a TA.</li>
-<li>If you are unable to finish the lab during the in-lab time, submit an extension request.</li>
 <li>Your submitted files MUST have an .ibcm extension (not .ibcm.txt), and can NOT have any blank lines!</li>
 <li>Files to download: <a href="bubblesort.cpp.html">bubblesort.cpp</a> (<a href="bubblesort.cpp">src</a>)</li>
 <li>Files to submit: bubblesort.ibcm. Make sure it's not named bubblesort.ibcm.txt!</li>


### PR DESCRIPTION
Students are confused about having to finish the lab during lab time/having the option to submit an extension. This line is left over from previous semesters anyways and so should be removed.