### PR TITLE
Remove dead IBCM link

### DIFF
--- a/ibcm/ibcm.md
+++ b/ibcm/ibcm.md
@@ -19,7 +19,6 @@ The primary file for the website is [index.html](index.html), and the directions
 
 The mirrors are:
 
-- [http://www.cs.virginia.edu/~cs216/ibcm/](http://www.cs.virginia.edu/~cs216/ibcm/)
 - [http://pegasus.cs.virginia.edu/ibcm/](http://pegasus.cs.virginia.edu/ibcm/)
 - [http://people.virginia.edu/~asb2t/ibcm/](http://people.virginia.edu/~asb2t/ibcm/)
 

--- a/labs/index.md
+++ b/labs/index.md
@@ -11,7 +11,7 @@ The labs for this course:
         - Vector code: [svtest.cpp](lab01/svtest.cpp.html) ([src](lab01/svtest.cpp)), [svutil.h](lab01/svutil.h.html) ([src](lab01/svutil.h)), [svutil.cpp](lab01/svutil.cpp.html) ([src](lab01/svutil.cpp))
         - Linked List code: [list.h](lab01/list.h.html) ([src](lab01/list.h)), [list.cpp](lab01/list.cpp.html) ([src](lab01/list.cpp))
     - [Tutorial 1: Introduction to Unix](../tutorials/01-intro-unix/index.html) and [Tutorial 1: Introduction to Unix: VirtualBox use](../tutorials/01-intro-unix/virtual-box.html) and [Tutorial 1: Introduction to Unix: NoMachine usage](../tutorials/01-intro-unix/nomachine.html)
-    
+
 &nbsp;
 
 - [Lab 2: Linked Lists](lab02/index.html)
@@ -57,7 +57,7 @@ The labs for this course:
 - [Lab 7: IBCM](lab07/index.html) (machine language)
     - C++ Source code: [bubblesort.cpp](lab07/bubblesort.cpp.html) ([src](lab07/bubblesort.cpp)), [counter.cpp](lab07/counter.cpp.html) ([src](lab07/counter.cpp))
     - IBCM source code: [summation.ibcm](../ibcm/summation.ibcm) and [array-summation.ibcm](../ibcm/array-summation.ibcm)
-    - The online emulator is [here](http://www.cs.virginia.edu/~cs216/ibcm), with mirrors [1](http://pegasus.cs.virginia.edu/ibcm/) and [2](http://people.virginia.edu/~asb2t/ibcm/)
+    - The online emulator is [here](http://pegasus.cs.virginia.edu/ibcm/), with a mirror [here](http://people.virginia.edu/~asb2t/ibcm/)
     - The [IBCM book chapter](../book/ibcm-chapter.pdf) (PDF)
 
 &nbsp;
@@ -96,7 +96,7 @@ The labs for this course:
     - Source code: [middleearth.h](lab11/middleearth.h.html) ([src](lab11/middleearth.h)), [middleearth.cpp](lab11/middleearth.cpp.html) ([src](lab11/middleearth.cpp)), [fileio2.cpp](lab11/fileio2.cpp.html) ([src](lab11/fileio2.cpp)), [traveling-skeleton.cpp](lab11/traveling-skeleton.cpp.html) ([src](lab11/traveling-skeleton.cpp))
     - Data files: [prelab-test-small.txt](lab11/prelab-test-small.txt), [prelab-test-full.txt](lab11/prelab-test-full.txt)
     - The [Doxygen tutorial](../tutorials/11-doxygen/index.html) and the necessary files for that: [average.cpp](../tutorials/11-doxygen/average.cpp.html) ([src](../tutorials/11-doxygen/average.cpp))
-  
+
 &nbsp;
 
 - [Lab 12: Conclusion](lab12/index.html)

--- a/labs/lab07/index.md
+++ b/labs/lab07/index.md
@@ -9,20 +9,20 @@ To become familiar with programming with IBCM, and understand how high-level lan
 
 ### Background: ###
 
-IBCM (Itty Bitty Computing Machine) is a simulated computer with a minimal instruction set.  Despite its tiny small instruction set, the IBCM can compute anything that a modern 'powerful' computer can compute. 
+IBCM (Itty Bitty Computing Machine) is a simulated computer with a minimal instruction set.  Despite its tiny small instruction set, the IBCM can compute anything that a modern 'powerful' computer can compute.
 
 ### Reading(s): ###
 
 1. Read the [slides on IBCM](../../slides/07-ibcm.html)
 2. Read [IBCM book chapter](../../book/ibcm-chapter.pdf) (PDF)
-3. Run IBCM code online [here](http://www.cs.virginia.edu/~cs216/ibcm/).  The sample code in the book chapter is also in the repo: [summation.ibcm](../../ibcm/summation.ibcm) and [array-summation.ibcm](../../ibcm/array-summation.ibcm)
+3. Run IBCM code online [here](http://pegasus.cs.virginia.edu/ibcm/).  The sample code in the book chapter is also in the repo: [summation.ibcm](../../ibcm/summation.ibcm) and [array-summation.ibcm](../../ibcm/array-summation.ibcm)
 
 Procedure
 ---------
 
 ### Pre-lab ###
 
-1. The online IBCM simulator is available online [here](http://www.cs.virginia.edu/~cs216/ibcm).  If that site is down, mirror websites are listed in the pre-lab section.
+1. The online IBCM simulator is available online [here](http://pegasus.cs.virginia.edu/ibcm/).  If that site is down, mirror websites are listed in the pre-lab section.
 2. Write the two IBCM programs described in the pre-lab section: addition.ibcm and array.ibcm.
 3. Note that some browsers have problems with the online simulator.  If in doubt, try Firefox or Chrome.
 4. Your submitted files MUST have an .ibcm extension (not .ibcm.txt), and can NOT have any blank lines!
@@ -48,7 +48,7 @@ Procedure
 7. Your submitted files MUST have an .ibcm extension (not .ibcm.txt), and can NOT have any blank lines!
 8. Files to download: [counter.cpp](counter.cpp.html) ([src](counter.cpp))
 9. Files to submit: averagetime.sh, quine.ibcm (don't name it quine.ibcm.txt!), postlab7.pdf
- 
+
 ------------------------------------------------------------
 
 Pre-lab
@@ -114,7 +114,7 @@ You ***MUST*** iterate through the array by creating the array load instruction,
 ### Submitting your code ###
 
 Your code ***MUST*** have comments in the file so that the TAs can grade it.  No comments will earn a zero for the grade.
- 
+
 ------------------------------------------------------------
 
 In-lab
@@ -148,7 +148,7 @@ Submit a report, called postlab7.pdf, that contains your thoughts on IBCM.  What
 
 ### What is a quine ###
 
-Based on the experience from the in-lab, you should now be able to write an IBCM program on your own. For the postlab, you should individually write an IBCM program that prints itself.  This type of program is known as a *quine*. 
+Based on the experience from the in-lab, you should now be able to write an IBCM program on your own. For the postlab, you should individually write an IBCM program that prints itself.  This type of program is known as a *quine*.
 
 > quine: /kwi:n/ /n./ [from the name of the logician Willard van Orman Quine, via Douglas Hofstadter] A program that generates a copy of its own source text as its complete output. Devising the shortest possible quine in some given programming language is a common hackish amusement.
 

--- a/slides/index.md
+++ b/slides/index.md
@@ -41,7 +41,7 @@ Program and Data Representation: Slides
 
 [Slide set 7: IBCM (machine language)](07-ibcm.html#/)
 
-- The online simulator is [here](http://www.cs.virginia.edu/~cs216/ibcm/) (with mirrors [1](http://pegasus.cs.virginia.edu/ibcm/) and [2](http://people.virginia.edu/~asb2t/ibcm/))
+- The online simulator is [here](http://pegasus.cs.virginia.edu/ibcm/) (with a mirror [here](http://people.virginia.edu/~asb2t/ibcm/))
 - Source code: [summation.ibcm](../ibcm/summation.ibcm), [array-summation.ibcm](../ibcm/array-summation.ibcm)
 - [IBCM book chapter](../book/ibcm-chapter.pdf) as the reading
 - There is a separate [IBCM section](../ibcm/index.html) of this repository with more IBCM information, although that additional information will not be needed in this course


### PR DESCRIPTION
The cs216 link has been dead for some time, it seems, and everyone has been using pegasus.