### PR TITLE
Fixed Lab 9 404 error

### DIFF
--- a/labs/lab09-64bit/index.html
+++ b/labs/lab09-64bit/index.html
@@ -53,7 +53,7 @@
 </ol>
 <hr />
 <h2 id="pre-lab-1">Pre-lab</h2>
-<p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08/index.html">previous x86 lab</a>.</p>
+<p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08-64bit/index.html">previous x86 lab</a>.</p>
 <h3 id="pre-lab-program-threexplusone.s">Pre-lab program: threexplusone.s</h3>
 <p>The 3x+1 conjecture (also called the Collatz conjecture) is an open problem in mathematics, meaning that it has not yet been proven to be true. The conjecture states that if you take any positive integer, you can repeatedly apply the following function to it:</p>
 <div class="figure">

--- a/labs/lab09-64bit/index.md
+++ b/labs/lab09-64bit/index.md
@@ -54,7 +54,7 @@ Lab Procedure
 Pre-lab
 ---------------
 
-You may want to reference the "Compiling Assembly With C++" and "Vecsum" sections from the [previous x86 lab](../lab08/index.html).
+You may want to reference the "Compiling Assembly With C++" and "Vecsum" sections from the [previous x86 lab](../lab08-64bit/index.html).
 
 ### Pre-lab program: threexplusone.s ###
 


### PR DESCRIPTION
There is currently a 404 error present in the index.html and index.md files located in the lab09-64bit directory.  The error is located in directly under the "Pre-Lab" header. The offending line is "previous x86 lab," which links to ../lab08/index.html. lab08 is not a directory anymore, so I replaced it with lab08-64bit.