### PR TITLE
updated printTree methods in BinarySearchTree and AVLTree 

### DIFF
--- a/labs/lab05/code/inlab/BinarySearchTree.cpp
+++ b/labs/lab05/code/inlab/BinarySearchTree.cpp
@@ -94,13 +94,13 @@ void showTrunks(Trunk* p) {
 
 // Recursive function to print binary tree
 // It uses inorder traversal
-void BinarySearchTree::printTree(BinaryNode* root, Trunk* prev, bool isLeft) {
+void BinarySearchTree::printTree(BinaryNode* root, Trunk* prev, bool isRight) {
   if (root == NULL) return;
 
   string prev_str = "    ";
   Trunk* trunk = new Trunk(prev, prev_str);
 
-  printTree(root->left, trunk, true);
+  printTree(root->right, trunk, true);
 
   if (!prev)
     trunk->str = "---";
@@ -118,7 +118,7 @@ void BinarySearchTree::printTree(BinaryNode* root, Trunk* prev, bool isLeft) {
   if (prev) prev->str = prev_str;
   trunk->str = "   |";
 
-  printTree(root->right, trunk, false);
+  printTree(root->left, trunk, false);
 }
 
 void BinarySearchTree::printTree() { printTree(root, NULL, false); }

--- a/labs/lab05/code/inlab/BinarySearchTree.h
+++ b/labs/lab05/code/inlab/BinarySearchTree.h
@@ -47,7 +47,7 @@ class BinarySearchTree {
   string min(BinaryNode* node) const;
 
   // private helper for printTree to allow recursion over different nodes.
-  void printTree(BinaryNode* root, Trunk* prev, bool isLeft);
+  void printTree(BinaryNode* root, Trunk* prev, bool isRight);
 
   // Any other methods you need...
 };

--- a/labs/lab05/code/postlab/AVLTree.cpp
+++ b/labs/lab05/code/postlab/AVLTree.cpp
@@ -131,13 +131,13 @@ void showTrunks(Trunk* p) {
 
 // Recursive function to print binary tree
 // It uses inorder traversal
-void AVLTree::printTree(AVLNode* root, Trunk* prev, bool isLeft) {
+void AVLTree::printTree(AVLNode* root, Trunk* prev, bool isRight) {
   if (root == NULL) return;
 
   string prev_str = "    ";
   Trunk* trunk = new Trunk(prev, prev_str);
 
-  printTree(root->left, trunk, true);
+  printTree(root->right, trunk, true);
 
   if (!prev)
     trunk->str = "---";
@@ -155,7 +155,7 @@ void AVLTree::printTree(AVLNode* root, Trunk* prev, bool isLeft) {
   if (prev) prev->str = prev_str;
   trunk->str = "   |";
 
-  printTree(root->right, trunk, false);
+  printTree(root->left, trunk, false);
 }
 
 void AVLTree::printTree() { printTree(root, NULL, false); }

--- a/labs/lab05/code/postlab/AVLTree.h
+++ b/labs/lab05/code/postlab/AVLTree.h
@@ -60,7 +60,7 @@ class AVLTree {
   int height(AVLNode* node) const;
 
   // private helper for printTree to allow recursion over different nodes.
-  void printTree(AVLNode* root, Trunk* prev, bool isLeft);
+  void printTree(AVLNode* root, Trunk* prev, bool isRight);
 
   // Any other methods you need...
 };


### PR DESCRIPTION
To print out the tree in the correct configuration as opposed to mirrored as it previously did.