### PR TITLE
added note about the installation of necessary packages for other Linux distros

### DIFF
--- a/tutorials/12-objc/index.html
+++ b/tutorials/12-objc/index.html
@@ -51,6 +51,9 @@ int main (void) {
 <p>The command above was tested on the provided Virtual Box image and works. If you are on another Linux system, you can try one of the following similar commands to see if they work:</p>
 <pre><code>clang -I /usr/include/GNUstep/ *.m -lobjc -lgnustep-base
 clang -I /usr/include/GNUstep/ -I /usr/lib/gcc/x86_64-linux-gnu/5/include/ *.m -lobjc -lgnustep-base</code></pre>
+<p>For other Linux distributions you may need to install one or more of the follow packages: <code>gnustep</code>, <code>gnustep-make</code>, <code>gnustep-devel</code>. To install with apt run</p>
+<pre><code>sudo apt install &lt;PACKAGE_NAME&gt;</code></pre>
+<p>Where &lt;PACKAGE_NAME&gt; is one or more of the packages listed above.</p>
 <p>On Mac OS X, the compilation command is much simpler, and is what was previously shown. Here it is again for your convenience:</p>
 <pre><code>clang *.m -lobjc</code></pre>
 <p><strong>Difference 4: other libraries to use</strong></p>

--- a/tutorials/12-objc/index.md
+++ b/tutorials/12-objc/index.md
@@ -88,6 +88,11 @@ The command above was tested on the provided Virtual Box image and works. If you
 clang -I /usr/include/GNUstep/ *.m -lobjc -lgnustep-base
 clang -I /usr/include/GNUstep/ -I /usr/lib/gcc/x86_64-linux-gnu/5/include/ *.m -lobjc -lgnustep-base
 ```
+For other Linux distributions you may need to install one or more of the follow packages: `gnustep`, `gnustep-make`, `gnustep-devel`. To install with apt run
+```
+sudo apt install <PACKAGE_NAME>
+```
+Where \<PACKAGE_NAME> is one or more of the packages listed above.
 
 On Mac OS X, the compilation command is much simpler, and is what was previously shown. Here it is again for your convenience:
 


### PR DESCRIPTION
Installing these packages allows the command for the VirtualBox image to function as desired across different Linux platforms. Tested on Ubuntu 18 with apt. 