### PR TITLE
Improve C tutorial

### DIFF
--- a/tutorials/09-c/index.html
+++ b/tutorials/09-c/index.html
@@ -25,7 +25,7 @@ int main() {
     }
     return 0;
 }</code></pre>
-<p>A few things to note about this program: - The <code>&lt;stdio.h&gt;</code> was #included (stdio stands for Standard I/O library), which is where <code>printf()</code> (and, later, <code>scanf()</code>) live. These are the basic input and output routines in C, analogous to cout and cin in C++. More on these functions are below - There are no namespaces in C - Comments are enclosed in <code>/*</code> and <code>*/</code>. The <code>//</code> notation does not work in pure C, but most C compilers will allow it anyway - The iterating variable <code>i</code> is not declared within the <code>for</code> statement in pure C, but most C compilers will allow it anyway.</p>
+<p>A few things to note about this program: - The <code>&lt;stdio.h&gt;</code> was <code>#include</code>d (stdio stands for Standard I/O library), which is where <code>printf()</code> (and, later, <code>scanf()</code>) live. These are the basic input and output routines in C, analogous to cout and cin in C++. More on these functions are below - There are no namespaces in C - Comments are enclosed in <code>/*</code> and <code>*/</code>. The <code>//</code> notation does not work in pure C, but most C compilers will allow it anyway - The iterating variable <code>i</code> is not declared within the <code>for</code> statement in pure C, but most C compilers will allow it anyway.</p>
 <p>To use <code>malloc()</code>, which is the C version of <code>new</code>, you will need to include the <code>&lt;stdlib.h&gt;</code> file (stdlib is the standard library) - more on <code>malloc()</code> is also below.</p>
 <hr />
 <h2 id="input-and-output">Input and Output</h2>
@@ -80,19 +80,19 @@ int main() {
 </thead>
 <tbody>
 <tr class="odd">
-<td>l (a lower-case 'L')</td>
+<td><code>l</code> (a lower-case 'L')</td>
 <td>Instead of an int or float, convert a long int or double</td>
 </tr>
 <tr class="even">
-<td>ll (two lower-case 'L's)</td>
+<td><code>ll</code> (two lower-case 'L's)</td>
 <td>..., convert a long long int or long double</td>
 </tr>
 <tr class="odd">
-<td>0 (zero)</td>
+<td><code>0</code> (zero)</td>
 <td>Zero pad the conversion to fill the field width</td>
 </tr>
 <tr class="even">
-<td>-</td>
+<td><code>-</code></td>
 <td>Left justify the field</td>
 </tr>
 <tr class="odd">
@@ -100,7 +100,7 @@ int main() {
 <td>Leave a blank space where an omitted '+' would go</td>
 </tr>
 <tr class="even">
-<td>+</td>
+<td><code>+</code></td>
 <td>Display a '+' for positive numbers</td>
 </tr>
 <tr class="odd">
@@ -108,7 +108,7 @@ int main() {
 <td>Minimum field width</td>
 </tr>
 <tr class="even">
-<td>'.' followed by a non-zero integer</td>
+<td><code>.</code> followed by a non-zero integer</td>
 <td>Number of digits of precision</td>
 </tr>
 </tbody>
@@ -134,9 +134,14 @@ int open(const char *pathname, int flags, mode_t mode);</code></pre>
 char grade;
 char school[3];
 
-scanf(&quot;AGE: %d&quot;, &amp;age);       /* Reads and discards &quot;AGE: &quot;, then converts an integer */
-scanf(&quot;GRADE: %c&quot;, &amp;grade);   /* Discards &quot;GRADE: &quot;, converts a letter grade (probably &#39;A&#39;) */
-scanf(&quot;SCHOOL: %s&quot;, school);  /* Discards &quot;SCHOOL: &quot;, converts a string */</code></pre>
+printf(&quot;AGE: &quot;);
+scanf(&quot;%d&quot;, &amp;age);    /* Converts input to an integer and stores it in age */
+
+printf(&quot;GRADE: &quot;);
+scanf(&quot;%c&quot;, &amp;grade);  /* Converts input to a letter grade (probably &#39;A&#39;) and stores it in grade */
+
+printf(&quot;SCHOOL: &quot;);
+scanf(&quot;%s&quot;, school);  /* Converts input to a string and stores it in school */</code></pre>
 <p>The third example above almost certainly overflows the buffer. <code>scanf()</code> will copy input into <code>school</code> until it sees the next whitespace character. If the input is &quot;The University of Virginia&quot;, it will save &quot;The&quot;, and overflow the buffer by one byte (due to the fact that all C-style strings have a zero byte that terminates the string). If the input is &quot;UVA&quot;, it will save &quot;UVA&quot;, but still overflow the buffer. Using the field width flag <code>%2s</code> can solve this buffer overflow problem, but then we will only save &quot;Th&quot; or &quot;UV&quot;. In order to convert whitespace, you must use the more complex conversion. It's more common to use <code>fgets()</code> for this type of input.</p>
 <hr />
 <h2 id="pointers">Pointers</h2>
@@ -197,19 +202,28 @@ void main() {
 <pre><code>struct list_item {
   struct list_item *prev, *next;
   void *datum;
-} list_item_t;</code></pre>
-<p>Note that in pure C, you will have to declare such a variable either on the last line (this is how <code>list_item_t</code> was declared) or via a <code>struct list_item foo</code> command. Note that we have to put <code>struct</code> in there (the requirement to list the <code>struct</code> (or <code>class</code> or <code>union</code>) was removed in C++, and some C compilers are lax on requiring it.</p>
+};</code></pre>
+<p>Now whenever you want a variable of type <code>list_item</code>, you declare it using <code>struct list_item</code> - for example, <code>struct list_item my_item</code>. If the extra <code>struct</code> doesn't look right to you, this is where the <code>typedef</code> keyword can come in handy.</p>
+<pre><code>/* typedef comes before struct */
+typedef struct list_item {
+  struct list_item *prev, *next;
+  void *datum;
+} list_item_t; /* what you want to call your struct goes after the closing brace */</code></pre>
+<p>With the typedef, we can now refer to our struct as simply <code>list_item_t</code>. Therefore, variable declarations become <code>list_item_t my_item</code>. Note that the <code>struct list_item *prev, *next</code> inside of the struct declaration cannot be replaced with <code>list_item_t *prev, *next</code>, as the typedef hasn't been finished by that point! We don't know the name of the typedef until after the closing brace.</p>
 <h3 id="union">union</h3>
 <p>A union is a type for which the compiler allocates space sufficient only for the largest member, not for all members. At any moment in a union instance's lifetime, only one member is valid. It is the responsibility of the programmer to ensure that the data is accessed correctly. The syntax of a union declaration is identical to that of a struct declaration, save the keyword.</p>
 <p>An anonymous union provides useful syntactic sugar as a structure member. Take the following example:</p>
-<pre><code>struct {
+<pre><code>struct example_struct {
   int type;
   union {
     int i;
     float f;
     double d;
   };
-} s;
+};
+
+struct example_struct s;
+s.type = 1;
 
 switch (s.type) {
 case 0:
@@ -229,10 +243,13 @@ case 2:
   double d;
 };
 
-struct {
+struct example_struct {
   int type;
   union ifd_t u;
-} s;
+};
+
+struct example_struct s;
+s.type = 1;
 
 switch (s.type) {
 case 0:
@@ -277,11 +294,11 @@ case 2:
 <ul>
 <li>The linked list must be dynamically allocated</li>
 </ul></li>
-<li>Print out that linked list (we don't care the order)</li>
+<li>Print out that linked list (we don't care about the order!)</li>
 <li>Properly deallocate the linked list</li>
 </ol>
 <p>That's it - the point is to have you use many of the features of C discussed here (<code>printf()</code>, <code>scanf()</code>, structs, <code>malloc()</code>, and <code>free()</code>). We aren't looking for multiple subroutines, a full list class, etc. - a long <code>main()</code> function is just fine. Don't make this more complicated than necessary!</p>
-<p>The program should be in a file called linkedlist.c. A sample execution run might look like the following:</p>
+<p>The program should be in a file called <code>linkedlist.c</code>. A sample execution run might look like the following:</p>
 <pre><code>Enter how many values to input: 4
 Enter value 1: 2
 Enter value 2: 4

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -74,7 +74,7 @@ and flags:
 | `ll` (two lower-case 'L's) | ..., convert a long long int or long double |
 | `0` (zero) | Zero pad the conversion to fill the field width |
 | `-` | Left justify the field |
-| ` ` (a space) | Leave a blank space where an omitted '+' would go |
+| ' ' (a space) | Leave a blank space where an omitted '+' would go |
 | `+` | Display a '+' for positive numbers |
 | Non-zero integer | Minimum field width |
 | `.` followed by a non-zero integer | Number of digits of precision |

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -27,7 +27,7 @@ int main() {
 ```
 
 A few things to note about this program:
-- The `<stdio.h>` was #included (stdio stands for Standard I/O library), which is where `printf()` (and, later, `scanf()`) live.  These are the basic input and output routines in C, analogous to cout and cin in C++.  More on these functions are below
+- The `<stdio.h>` was `#include`d (stdio stands for Standard I/O library), which is where `printf()` (and, later, `scanf()`) live.  These are the basic input and output routines in C, analogous to cout and cin in C++.  More on these functions are below
 - There are no namespaces in C
 - Comments are enclosed in `/*` and `*/`.  The `//` notation does not work in pure C, but most C compilers will allow it anyway
 - The iterating variable `i` is not declared within the `for` statement in pure C, but most C compilers will allow it anyway.
@@ -70,14 +70,14 @@ and flags:
 
 | Flag | Meaning |
 |-|-|
-| l	(a lower-case 'L') | Instead of an int or float, convert a long int or double |
-| ll (two lower-case 'L's) | ..., convert a long long int or long double |
-| 0 (zero) | Zero pad the conversion to fill the field width |
-| - | Left justify the field |
-| ' ' (a space) | Leave a blank space where an omitted '+' would go |
-| + | Display a '+' for positive numbers |
+| `l`	(a lower-case 'L') | Instead of an int or float, convert a long int or double |
+| `ll` (two lower-case 'L's) | ..., convert a long long int or long double |
+| `0` (zero) | Zero pad the conversion to fill the field width |
+| `-` | Left justify the field |
+| ` ` (a space) | Leave a blank space where an omitted '+' would go |
+| `+` | Display a '+' for positive numbers |
 | Non-zero integer | Minimum field width |
-| '.' followed by a non-zero integer | Number of digits of precision |
+| `.` followed by a non-zero integer | Number of digits of precision |
 
 
 Some examples:
@@ -372,12 +372,12 @@ This exercise is to be developed in C, and compiled using clang (NOT clang++!). 
 1. Read in an integer, which we'll call *n*
 2. Read in *n* more ints, and put those into a linked list
      - The linked list must be dynamically allocated
-3. Print out that linked list (we don't care the order)
+3. Print out that linked list (we don't care about the order!)
 4. Properly deallocate the linked list
 
 That's it - the point is to have you use many of the features of C discussed here (`printf()`, `scanf()`, structs, `malloc()`, and `free()`).  We aren't looking for multiple subroutines, a full list class, etc. - a long `main()` function is just fine.  Don't make this more complicated than necessary!
 
-The program should be in a file called linkedlist.c.  A sample execution run might look like the following:
+The program should be in a file called `linkedlist.c`.  A sample execution run might look like the following:
 
 ```
 Enter how many values to input: 4

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -238,7 +238,7 @@ struct list_item {
 Now whenever you want a variable of type `list_item`, you declare it using `struct list_item` - for example, `struct list_item my_item`.
 If the extra `struct` doesn't look right to you, this is where the `typedef` keyword can come in handy.
 
-```c
+```
 /* typedef comes before struct */
 typedef struct list_item {
   struct list_item *prev, *next;

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -122,9 +122,14 @@ int age;
 char grade;
 char school[3];
 
-scanf("AGE: %d", &age);       /* Reads and discards "AGE: ", then converts an integer */
-scanf("GRADE: %c", &grade);   /* Discards "GRADE: ", converts a letter grade (probably 'A') */
-scanf("SCHOOL: %s", school);  /* Discards "SCHOOL: ", converts a string */
+printf("AGE: ");
+scanf("%d", &age);    /* Converts input to an integer and stores it in age */
+
+printf("GRADE: ");
+scanf("%c", &grade);  /* Converts input to a letter grade (probably 'A') and stores it in grade */
+
+printf("SCHOOL: ");
+scanf("%s", school);  /* Converts input to a string and stores it in school */
 ```
 
 The third example above almost certainly overflows the buffer.  `scanf()` will copy input into `school` until it sees the next whitespace character.  If the input is "The University of Virginia", it will save "The", and overflow the buffer by one byte (due to the fact that all C-style strings have a zero byte that terminates the string).  If the input is "UVA", it will save "UVA", but still overflow the buffer.  Using the field width flag `%2s` can solve this buffer overflow problem, but then we will only save "Th" or "UV".  In order to convert whitespace, you must use the more complex conversion.  It's more common to use `fgets()` for this type of input.

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -232,10 +232,22 @@ The following might be a good definition for a list item data structure.  We'll 
 struct list_item {
   struct list_item *prev, *next;
   void *datum;
-} list_item_t;
+};
 ```
 
-Note that in pure C, you will have to declare such a variable either on the last line (this is how `list_item_t` was declared) or via a `struct list_item foo` command.  Note that we have to put `struct` in there (the requirement to list the `struct` (or `class` or `union`) was removed in C++, and some C compilers are lax on requiring it.
+Now whenever you want a variable of type `list_item`, you declare it using `struct list_item` - for example, `struct list_item my_item`.
+If the extra `struct` doesn't look right to you, this is where the `typedef` keyword can come in handy.
+
+```c
+/* typedef comes before struct */
+typedef struct list_item {
+  struct list_item *prev, *next;
+  void *datum;
+} list_item_t; /* what you want to call your struct goes after the closing brace */
+```
+
+With the typedef, we can now refer to our struct as simply `list_item_t`. Therefore, variable declarations become `list_item_t my_item`.
+Note that the `struct list_item *prev, *next` inside of the struct declaration cannot be replaced with `list_item_t *prev, *next`, as the typedef hasn't been finished by that point! We don't know the name of the typedef until after the closing brace.
 
 ### union ###
 
@@ -244,14 +256,17 @@ A union is a type for which the compiler allocates space sufficient only for the
 An anonymous union provides useful syntactic sugar as a structure member.  Take the following example:
 
 ```
-struct {
+struct example_struct {
   int type;
   union {
     int i;
     float f;
     double d;
   };
-} s;
+};
+
+struct example_struct s;
+s.type = 1;
 
 switch (s.type) {
 case 0:
@@ -275,10 +290,13 @@ union ifd_t {
   double d;
 };
 
-struct {
+struct example_struct {
   int type;
   union ifd_t u;
-} s;
+};
+
+struct example_struct s;
+s.type = 1;
 
 switch (s.type) {
 case 0:


### PR DESCRIPTION
* Show correct usage examples for `scanf`. The prompts need to be in a separate printf, or else scanf will try to convert the prompt along with the format specifier, which is not the intended behavior.
* Separate struct declarations and variable declarations. Structs are already a confusing concept - also declaring a variable while creating the struct makes it even harder to understand what's going on and how to use structs correctly.
* Introduce `typedef`. This change isn't really necessary but might help make students more comfortable with declaring struct variables.
* Remove usages of anonymous structs, and reinforce how to use structs after declaring them. This makes the syntax consistent throughout the tutorial and gives a clear example of how to declare struct variables and access struct members.

Some of the main issues students had during this postlab were `scanf` not working and trying to use a single `list_item_t` variable for everything. Hopefully these changes will help reduce confusion on those fronts!