### PR TITLE
Remove extra padding on code blocks

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -27,12 +27,12 @@ code {
     background-color: rgb(248, 248, 248);
     border: 1px solid rgb(221, 221, 221);
     font-size: 13px;
-    line-height: 19px;
     padding: 0px 5px;
 }
 
 pre code {
-    border: 0px solid;
+    border: none;
+    padding: 0;
 }
 
 pre {

--- a/markdown.css
+++ b/markdown.css
@@ -1,4 +1,4 @@
-/* This file is part of the http://github.com/aaronbloomfield/pdr
+/* This file is part of the http://github.com/uva-cs/pdr
  * repo, and has the same license as the rest of the repo (CC BY-SA)
  *
  * The formatting is loosely based on that of github.com's README.md


### PR DESCRIPTION
| Before | After |
| ------- | ----- |
| ![uva-cs github io_pdr_tutorials_09-c_index html](https://user-images.githubusercontent.com/2766036/58491434-eca88a00-813c-11e9-9125-0eecef796cd4.png) | ![_C__Users_Winston_Documents_GitHub_pdr_tutorials_09-c_index html](https://user-images.githubusercontent.com/2766036/58491445-f500c500-813c-11e9-9d2e-4e4fe48f8032.png) |

Noticeably, the extra padding on the first line of code blocks has been removed.
Additionally, line-height for code elements has been removed, as the default comes out to be 13px * 1.4 = 18.2px: an incredibly slight change.