### PR TITLE
Convert Markdown to HTML5

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Textbook</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-textbook">Program and Data Representation: Textbook</h1>

--- a/docs/compilation.html
+++ b/docs/compilation.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: Compilation Issues</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-compilation-issues">PDR: Docs: Compilation Issues</h1>

--- a/docs/compiler_flags.html
+++ b/docs/compiler_flags.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: Useful Compiler Flags</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-useful-compiler-flags">PDR: Docs: Useful Compiler Flags</h1>

--- a/docs/convert_to_pdf.html
+++ b/docs/convert_to_pdf.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: How to convert a file to PDF</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-how-to-convert-a-file-to-pdf">PDR: Docs: How to convert a file to PDF</h1>

--- a/docs/gdb_summary.html
+++ b/docs/gdb_summary.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: GDB Command Summary</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-gdb-command-summary">PDR: Docs: GDB Command Summary</h1>

--- a/docs/gdb_vs_lldb.html
+++ b/docs/gdb_vs_lldb.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>GDB vs LLDB</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="gdb-vs-lldb">GDB vs LLDB</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Documents</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-documents">Program and Data Representation: Documents</h1>

--- a/docs/instructor.html
+++ b/docs/instructor.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: Instructor Notes</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-instructor-notes">PDR: Docs: Instructor Notes</h1>

--- a/docs/lldb_summary.html
+++ b/docs/lldb_summary.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: LLDB Command Summary</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-lldb-command-summary">PDR: Docs: LLDB Command Summary</h1>

--- a/docs/readings.html
+++ b/docs/readings.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Docs: Readings</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-docs-readings">PDR: Docs: Readings</h1>

--- a/docs/tree.html
+++ b/docs/tree.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title># Tree Document Index of the PDR Repository</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="tree-document-index-of-the-pdr-repository">Tree Document Index of the PDR Repository</h1>

--- a/exams/index.html
+++ b/exams/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Exams</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-exams">PDR: Exams</h1>

--- a/ibcm/ibcm.html
+++ b/ibcm/ibcm.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Itty Bitty Computing Machine (IBCM)</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-itty-bitty-computing-machine-ibcm">Program and Data Representation: Itty Bitty Computing Machine (IBCM)</h1>
@@ -30,10 +33,9 @@
 <li><a href="multiply.ibcm" class="uri">multiply.ibcm</a>: a program that creates an activation to allow for recursive calls. It can call itself recursively about 1,300 times before it runs out of memory. The 'stack', which contains the activation records, starts at the end of memory, and contains only the two parameters to the subroutine and the reutrn address.</li>
 <li><a href="turing.ibcm" class="uri">turing.ibcm</a>: a Turing machine simulator. The automaton simulated is a four state <a href="http://en.wikipedia.org/wiki/Busy_beaver">Busy Beaver</a> automaton, shown below. Details about the Turing completeness can be found in the <a href="http://dl.acm.org/citation.cfm?id=1953273">IBCM article</a>.</li>
 </ul>
-<div class="figure">
-<img src="busy-beaver.png" alt="Busy Beaver automaton" />
-<p class="caption">Busy Beaver automaton</p>
-</div>
+<figure>
+<img src="busy-beaver.png" alt="Busy Beaver automaton" /><figcaption>Busy Beaver automaton</figcaption>
+</figure>
 <h2 id="c-utilities">C++ Utilities</h2>
 <p>There are two C++ utility programs included, which are primarly useful for grading. In particular, they allow the programs to be run through a series of scripts (or other automated grading system).</p>
 <p><a href="ibcm-parse.cpp.html">ibcm-parse.cpp</a> (<a href="ibcm-parse.cpp">src</a>) is a program that will quickly check if the file names passed in via command line arguments look like IBCM files. In particular, it checks if the first four digits on each line are all hexadecimal digits. It does not program validity checking beyond this. It is useful to tell the students if, on submission, their programs will parse correctly in an IBCM simulator.</p>

--- a/labs/index.html
+++ b/labs/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Labs</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-labs">Program and Data Representation: Labs</h1>

--- a/labs/lab01/index.html
+++ b/labs/lab01/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 1: Introduction to C++</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-1-introduction-to-c">PDR: Laboratory 1: Introduction to C++</h1>
@@ -16,16 +19,16 @@
 <h3 id="background">Background</h3>
 <p>Every week we will have a lab meeting. Each lab will consist of three parts: a pre-lab (to be completed by Tuesday at the due time listed on the <a href="../../uva/labduedates.html">lab due dates</a> page, an in-lab (activity to be done during lab), and a post-lab. The pre-lab will typically also include a tutorial. Parts of all three of these may be required to turned in. The due dates are all listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. This will all be discussed in this lab.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a></li>
 <li>Optional: online sources as posted on the <a href="../../docs/readings.html">Readings page</a></li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If desired, the alternative readings are available on the <a href="../../docs/readings.html">Readings page</a></li>
 <li>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a>
-<ol style="list-style-type: lower-alpha">
+<ol type="a">
 <li>As part of this tutorial, you will need to decide how you want to develop in a Unix environment -- we recommend <a href="../../tutorials/01-intro-unix/virtual-box.html">VirtualBox</a>, but there are other options available</li>
 <li>If you are using VirtualBox, you will have to decide on which display manager to use</li>
 </ol></li>
@@ -36,7 +39,7 @@
 <li>Files to submit: xToN.cpp</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read through the in-lab section of this document. You should be sure to be familiar with the submission system.</li>
 <li>Clone the github repo into your lab account</li>
 <li>Complete the in-lab requirements as described in the in-lab section, below.</li>
@@ -46,7 +49,7 @@
 <li>Files to submit: lifecycle.questions.txt, vector.questions.txt, LifeCycle.cpp, LifeCycle.h, and TestLifeCycle.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>See details in the postlab section, below</li>
 <li>For this lab you will be submitting your code electronically. Your submission is due on the Friday of the week of the lab; the exact due time is listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. Be sure to include your name, email ID, the date, and the name of the file in a header comment at the beginning of each file you submit (including text files!).</li>
 <li>Files to download: <a href="list.h.html">list.h</a> (<a href="list.h">src</a>), <a href="list.cpp.html">list.cpp</a> (<a href="list.cpp">src</a>)</li>
@@ -99,7 +102,7 @@ int main( ) {
 <pre><code>file:///home/student/pdr/readme.html</code></pre>
 <p>We realize that you cannot view these directions until after you have the github repo cloned locally. So hopefully you read these ahead of time. Otherwise, the TAs will be able to help you with this part. The lab can also be viewed online at <a href="http://uva-cs.github.io/pdr/labs/lab01/index.html" class="uri">http://uva-cs.github.io/pdr/labs/lab01/index.html</a>.</p>
 <h3 id="understanding-c">Understanding C++</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Ask the TAs if you have questions about your <em>x^n</em> function.</li>
 <li>Ask the TAs if you have questions about using Unix.</li>
 <li>Object Lifecycle Program

--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 2: Linked Lists</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-2-linked-lists">PDR: Laboratory 2: Linked Lists</h1>
@@ -16,7 +19,7 @@
 <h3 id="background">Background:</h3>
 <p>The linked list is a basic data structure from which one can implement stacks, queues, sets, and many other data structures. Lists may be singly- or doubly-linked. In this lab we will implement a doubly-linked list.</p>
 <h3 id="readings">Reading(s):</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Readings on <a href="../../docs/readings.html">Readings</a> page.</li>
 <li><a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> <strong><em>OR</em></strong> <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a>; see below as to which one to choose.</li>
 <li>For the in-lab, some articles on debugging</li>
@@ -28,12 +31,12 @@
 <p>Ultimately, this is a low stress choice. Choose lldb, and only switch over to gdb if you run into VirtualBox crashing issues.</p>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Consider one of the online alternative readings shown on the <a href="../../docs/readings.html">Readings</a> page.</li>
 <li>Implement the three classes as described below: ListNode, TestListNode, and ListItr. You should have most, if not all, of the code working <strong><em>before</em></strong> coming to lab. TAs will be available to help in lab if you still have questions. Note that it is okay to not have the code perfectly working prior to lab -- for the pre-lab grade, we are going to be looking to see if you have made significant progress, not that it is fully working (that's the post-lab).</li>
 <li>If there is a particular method that is causing you a lot of trouble (i.e. you can't get it working), don't spend inordinate amounts of time on it -- move on, and come back to that one during the in-lab.</li>
 <li><strong>Making the implementation phase less frustrating:</strong> develop in small chunks, then <strong>test/debug incrementally. It is much easier to debug this way!</strong> (And also less frustrating and confusing.) Here is a sample process for implementing ListNode.cpp:
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Implement the ListNode constructor in ListNode.cpp</li>
 <li>Write a short test harness, TestListNode.cpp, which has a main(). The body of main should test the ListNode constructor. In other words, create some ListNodes in main() using the constructor.</li>
 <li>Build and run the test program you just wrote to see if it produces the results you expect. Some items you will want to check are the initialization of the next and previous pointers and the initial value of value</li>
@@ -45,7 +48,7 @@
 <li>Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Ensure you are familiar with debugging. You should look over the <a href="http://umich.edu/~eecs381/generalFAQ/Debugging.html">Debugging FAQ from UMich</a>, which is a good introduction.</li>
 <li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</li>
 <li>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</li>
@@ -55,9 +58,9 @@
 <li>Files to submit: debug.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>For this lab you will be submitting your code electronically via online grading system to postlab2. Your fully functional code must contain the following 7 files:
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>List.h and List.cpp</li>
 <li>ListNode.h and ListNode.cpp</li>
 <li>ListItr.h and ListItr.cpp</li>
@@ -74,7 +77,7 @@
 <p>Linked lists are described in the online <a href="../../docs/readings.html">Readings</a>.</p>
 <p>You will be implementing a doubly linked list, and you will be using &quot;dummy&quot; nodes as well. You will want two dummy nodes -- <strong>one for the head</strong> and <strong>one for the tail</strong>. A benefit of doing your implementation using dummy nodes is that there are fewer special cases to check for -- for example you never have to update the head pointer on an insertBefore() or a remove() -- the head pointer always points to the dummy header node. A dummy tail pointer would help out in the same respect. The downside is that you use two extra &quot;empty&quot; nodes.</p>
 <p>For this lab you will need to implement three classes:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>ListNode</li>
 <li>List</li>
 <li>ListItr</li>
@@ -85,10 +88,9 @@
 <p>We have provided a test harness for testing your whole implementation: <a href="ListTest.cpp.html">ListTest.cpp</a> (<a href="ListTest.cpp">src</a>) <strong><em>The classes you implement must work with this test harness.</em></strong></p>
 <h3 id="uml-diagram">UML Diagram</h3>
 <p>Below is a UML diagram showing how these classes interact with each other.</p>
-<div class="figure">
-<img src="list-diagram.png" alt="UML diagram" />
-<p class="caption">UML diagram</p>
-</div>
+<figure>
+<img src="list-diagram.png" alt="UML diagram" /><figcaption>UML diagram</figcaption>
+</figure>
 <p>This diagram shows a list containing two elements, the integers 3 and 7. Note that there are more methods in the List and ListItr classes than what is shown above. The head and tail pointers in the List class point to dummy nodes -- they are put there to make inserting elements into the list easier. It doesn't matter what the value of the dummy notes is set to, as it won't be used. Each ListNode points to the nodes before and after it (although the dummy nodes each have one pointer pointing to NULL).</p>
 <p>Thus, our doubly linked list will have only one List object and many ListNode objects (2 more than the number of elements in the list). A ListItr is a separate object, which points to one element in the list (possibly a dummy node). As you call the various methods in ListItr to move the iterator forward and backward, the node that it points to will change.</p>
 <h3 id="listnode">ListNode</h3>
@@ -96,7 +98,7 @@
 <h3 id="list">List</h3>
 <p>This class represents the list data structure containing ListNodes. It has a pointer to the first (head) and last (tail) ListNodes of the list, as well as a count of the number of ListNodes in the List. View the <a href="List.h.html">List.h</a> (<a href="List.h">src</a>) code for details.</p>
 <h3 id="explanations">Explanations:</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><code>List()</code> is the default constructor. It should initialize all private data members. Pointers are often initialized to NULL.</li>
 <li><code>~List()</code> is the destructor. It should make the list empty and reclaim the memory allocated in the constructor for head and tail</li>
 <li><code>List&amp; operator=(const List&amp; source)</code> is the <strong>copy assignment operator</strong>. It is called when code such as the following is encountered: lhs = rhs. The copy assignment operator that you implement will copy the contents of every ListNode in source into this (the reference to the calling List object itself)</li>
@@ -162,7 +164,7 @@ List&amp; List::operator=(const List&amp; source) { //Equals operator
 <hr />
 <h2 id="in-lab-1">In-lab</h2>
 <p>These are the same steps from the lab procedure section, above.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</li>
 <li>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</li>
 <li>Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp. Remember the standard identifying header information.</li>
@@ -173,9 +175,9 @@ List&amp; List::operator=(const List&amp; source) { //Equals operator
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
 <p>These are the same steps from the lab procedure section, above.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>For this lab you will be submitting your code electronically via online grading system to postlab2. Your fully functional code must contain the following 7 files:
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>List.h and List.cpp</li>
 <li>ListNode.h and ListNode.cpp</li>
 <li>ListItr.h and ListItr.cpp</li>

--- a/labs/lab03/index.html
+++ b/labs/lab03/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 3: Stacks</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-3-stacks">PDR: Laboratory 3: Stacks</h1>
@@ -16,13 +19,13 @@
 <h3 id="background">Background:</h3>
 <p>A stack is a basic data structure similar in use to a physical stack of papers. You can add to the top (push) and take from the top (pop), but you are not allowed to access the middle or bottom. A stack adheres to the <a href="http://en.wikipedia.org/wiki/LIFO_%28computing%29">LIFO</a> property.</p>
 <h3 id="readings">Reading(s):</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Readings can be found online on the <a href="../../docs/readings.html">Readings</a> page</li>
 <li>The <a href="http://en.wikipedia.org/wiki/Reverse_Polish_notation">Wikipedia article on Reverse Polish notation</a>, which is another name for postfix notation, has a good description along with a sample calculation.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read this entire lab document before coming to lab.</li>
 <li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 3: Unix, part 1</a>, which is the introduction and sections 1-4. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You should complete the introductory part and sections 1-4. You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the <a href="../../tutorials/01-intro-unix/index.html">Unix tutorial from the first lab</a>. The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested.</li>
 <li>Write up at least one question that you still have on Unix (or things you are still confused about) into unix.questions.txt.</li>
@@ -44,7 +47,7 @@
 <li>Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, unix.questions.txt</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Come to class with a <em>working prelab</em>.</li>
 <li>Run your postfix calculator on the test sequences posted on the board by the TAs. (These test sequences are also at the very bottom of this page.) Since your code only can handle hard-coded values, this will require a code modification and a recompilation to test each case. If your program does not calculate the correct result, use the debugger to find the errors and correct them. These modifications will be submitted to the in-lab.
 <ul>
@@ -57,11 +60,11 @@
 <li>Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Implement a stack class (into files stack.h and stack.cpp). <strong>You can NOT use a standard library container class (<code>list</code>, <code>vector</code>, <code>stack</code>, etc.) for this</strong>, but you can use the standard library's <code>string</code> class. You should use either your List class from the last lab (if it works), or write up new stack class based on either the lecture notes or the textbook pages on stacks. Your stack class can use a linked-list/pointer-based implementation, or an array-based implementation. Note that your stack class can contain a LinkedList object, and a stack class method can just pass the value onto the appropriate method in the LinkedList class. You don't need to implement all possible stack methods (in particular, you can ignore the copy constructor, <code>operator=()</code>, etc.) -- just the four mentioned in the pre-lab (push(), top(), pop(), and empty()). After this lab, it is expected that you will be able to implement a stack class in C++.</li>
 <li>Modify your postfix calculator to use the stack class that you have implemented.</li>
 <li>Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit. Your submission must contain the following code:
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Your stack code. This will likely be stack.h/cpp, and may (or may not; your choice) include all of the List.h/cpp, ListItr.h/cpp, ListNode.h/cpp files from lab 2
 <ul>
 <li>For your stack code, you are welcome to submit it in many files, as long as it will compile with <code>clang++ *.cpp</code>, and as long as the total number of files submitted does not exceed 11 files (you can submit 12 files total, but you need to submit a text file, described below, as well)</li>
@@ -202,7 +205,7 @@ great??
 <p>In the above execution, what was typed in was <code>+ 2 3 isn't 2150 great??</code> (the second line). After the end of the line (i.e., after the Enter key was pressed), the program reads in that, and prints each token on a separate line. Since there was no more into to provide, Control-D (shown as <code>^D</code>) was then pressed (the last line in that execution run). Control-D closes the stdin pipe by providing the EOF flag.</p>
 <p><strong><em>NOTE:</em></strong> When hitting Control-D, you have to enter it <em>on it's own line</em>. This means that you first have to hit Enter, then Control-D.</p>
 <h3 id="assumptions">Assumptions:</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Assume that the input, i.e. the postfix expression, is entered in on one line and that all numbers and operators are separated by a single space. We will only provide you with valid input.</li>
 <li>You can assume that users will enter the proper number of operands/operators. In other words, if an invalid postfix expression is entered, your program can do anything (including crashing) and we won't take off points.</li>
 </ol>
@@ -219,14 +222,14 @@ great??
 <p>You will also have to write up the difficulties.txt file, as described above in the lab procedure section.</p>
 <p>Note that you only have to implement the four stack methods described in the pre-lab section (and the constructor, of course): <code>push()</code>, <code>pop()</code>, <code>top()</code>, and <code>empty()</code>. The other methods (copy constructor, <code>operator=()</code>, etc.) do not need to be implemented for this lab.</p>
 <p>Most of you will implement your stack in one of the following ways:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Re-use your list class from lab 2. You may need to add one or two methods to it for extra convenience.</li>
 <li>Build a linked-list / pointer based stack as discussed in lecture. Your stack class would contain a pointer to the head node of the stack, and push and pop would modify the singly-linked list accordingly.</li>
 <li>Manually implement an array-based stack. If you choose this method, your array must be able to automatically resize if the stack grows large enough to sufficiently fill the array. This is probably the most difficult of the three options.</li>
 </ol>
 <h3 id="submitting-the-stack-list-files">Submitting the stack / list files</h3>
 <p>Depending on how you implement the stack class, you may just need the stack.h/cpp files, in addition to the three postfix calculator files (postfixCalculator.h/cpp and testPostfixCalc.cpp). Or you may need stack.h/cpp and stacknode.h/cpp in addition to the three postfix calculator files. Or you may want to include the six List/ListItr/ListNode files from lab 2 as well as stack.h/cpp and the three postfix calculator files. How you do this is up to you - as long as it works, we don't really care, provided that:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>It compiles with <code>clang++ *.cpp</code></li>
 <li>The total number of C++ files you submit is 11 or fewer (you can submit 12 files total, but you need to submit a the text file called difficulties.txt as well)</li>
 </ol>

--- a/labs/lab04/index.html
+++ b/labs/lab04/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 4: Number Representation</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-4-number-representation">PDR: Laboratory 4: Number Representation</h1>
@@ -16,12 +19,12 @@
 <h3 id="background">Background</h3>
 <p>In class we discussed how various data types -- integers, characters, and floating point numbers -- were represented in computers. In this lab we will use the debugger to examine some of these representations.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Any of the optional readings on the <a href="../../docs/readings.html">Readings</a> page, in particular, those on arrays and unions, if you feel you need a bit more background. If you are a bit confused about unions, you might want to read about them prior to the in-lab. Do a Google search for 'C++ unions'.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Any of the optional readings on the <a href="../../docs/readings.html">Readings</a> page, in particular, those on arrays and unions, if you feel you need a bit more background.</li>
 <li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 4: Unix, part 2</a>, which is sections 5-8. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You went through sections 1-4 in the last tutorial; this lab has you completing sections 5-8.</li>
 <li>Get your floating point number <a href="http://libra.cs.virginia.edu/getfloat.php">here</a>, and then complete your floating point conversion, as described in the pre-lab section, into a file called floatingpoint.pdf; you can convert a file into a PDF via the directions on the <a href="../../docs/convert_to_pdf.html">How to convert a file to PDF</a> page. <strong>Note: Many students will submit a text file that happens to be called floatingpoint.pdf. Make sure to check for this before submitting!</strong>
@@ -40,10 +43,10 @@
 <li>Files to submit: prelab4.cpp, floatingpoint.pdf</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Work through the steps in the in-lab one a time. Be sure that you understand what is happening at each step.</li>
 <li>The three parts of the in-lab, described below, have you editing both <a href="inlab4.doc" class="uri">inlab4.doc</a> and inlab4.cpp.
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Size of C++ data types</li>
 <li>Representations in memory</li>
 <li>Primitive arrays in C++</li>
@@ -53,7 +56,7 @@
 <li>Files to submit: inlab4.pdf (the PDF version of inlab4.doc), inlab4.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Write the recursive bit counter, in bitCounter.cpp, as described in the post-lab section.</li>
 <li>Complete the radix worksheet -- this worksheet is in the <a href="radixWorksheet.doc" class="uri">radixWorksheet.doc</a> file. This will be converted to PDF and called radixWorksheet.pdf.</li>
 <li>Files to download: <a href="radixWorksheet.doc" class="uri">radixWorksheet.doc</a></li>
@@ -112,11 +115,11 @@ outputBinary(1000000) //=&gt; 0000 0000 0000 1111 0100 0010 0100 0000</code></pr
 <p>The <a href="inlab4.doc" class="uri">inlab4.doc</a> worksheet asks you to fill in two tables describing certain features of primitive types in C++. The two tables are reproduced below:</p>
 <table>
 <colgroup>
-<col width="10%" />
-<col width="15%" />
-<col width="20%" />
-<col width="27%" />
-<col width="26%" />
+<col style="width: 10%" />
+<col style="width: 15%" />
+<col style="width: 20%" />
+<col style="width: 27%" />
+<col style="width: 26%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -175,10 +178,10 @@ outputBinary(1000000) //=&gt; 0000 0000 0000 1111 0100 0010 0100 0000</code></pr
 <p> </p>
 <table>
 <colgroup>
-<col width="13%" />
-<col width="20%" />
-<col width="28%" />
-<col width="37%" />
+<col style="width: 13%" />
+<col style="width: 20%" />
+<col style="width: 28%" />
+<col style="width: 37%" />
 </colgroup>
 <thead>
 <tr class="header">

--- a/labs/lab05/index.html
+++ b/labs/lab05/index.html
@@ -1,18 +1,21 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 5: Trees</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-5-trees">PDR: Laboratory 5: Trees</h1>
 <p><a href="../index.html">Go up to the Labs table of contents page</a></p>
 <h3 id="objective">Objective:</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Learn about binary trees</li>
 <li>See tree traversals in the context of a useful application</li>
 <li>Understand tree rotations</li>
@@ -26,7 +29,7 @@
 <p>The <a href="http://en.wikipedia.org/wiki/Expression_tree">Wikipedia article on Expression trees</a>, especially the <a href="http://en.wikipedia.org/wiki/Expression_tree#Construction_of_an_Expression_Tree">section on construction of expression trees</a>. Also the <a href="../../slides/05-trees.html">05: Trees</a> slide set.</p>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Complete the <a href="../../tutorials/05-make/index.html">makefile tutorial</a>. You will need to know how to write one for the in-lab and post-lab, since all the following labs will be compiled via Makefiles. There is one file that needs to be submitted from the tutorial -- you should name this file Makefile-pizza.</li>
 <li>Your file <strong>MUST</strong> be named <code>Makefile-pizza</code> - not Makefile-pizza.txt, not Makefile-Pizza, not Makefilepizza. If it is not named correctly, it will not work with our grading scripts, and you will not get credit for that part of the lab.</li>
 <li>Come to lab with a fully functional tree calculator, as described below.<br />
@@ -36,14 +39,14 @@
 <li>Files to submit: TreeCalc.h/cpp, TreeCalcTest.cpp, TreeNode.h/cpp, Makefile-pizza</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>For this lab, you will implement a Binary search tree.</li>
 <li>Your program must compile with make!</li>
 <li>Files to download: <a href="code/inlab/BinaryNode.h.html">BinaryNode.h</a> (<a href="code/inlab/BinaryNode.h">src</a>), <a href="code/inlab/BinaryNode.cpp.html">BinaryNode.cpp</a> (<a href="code/inlab/BinaryNode.cpp">src</a>), <a href="code/inlab/BinarySearchTree.h.html">BinarySearchTree.h</a> (<a href="code/inlab/BinarySearchTree.h">src</a>), <a href="code/inlab/BinarySearchTree.cpp.html">BinarySearchTree.cpp</a> (<a href="code/inlab/BinarySearchTree.cpp">src</a>), <a href="code/inlab/BSTPathTest.cpp.html">BSTPathTest.cpp</a> (<a href="code/inlab/BSTPathTest.cpp">src</a>), <a href="code/inlab/testfile1.txt">testfile1.txt</a> (<a href="code/inlab/testfile1.out.txt">output</a>), <a href="code/inlab/testfile2.txt">testfile2.txt</a> (<a href="code/inlab/testfile2.out.txt">output</a>), <a href="code/inlab/testfile3.txt">testfile3.txt</a> (<a href="code/inlab/testfile3.out.txt">output</a>). These files are contained in the inlab/ directory of the <a href="code.zip" class="uri">code.zip</a> file.</li>
 <li>Files to submit: BinarySearchTree.h, BinarySearchTree.cpp, BinaryNode.h, BinaryNode.cpp, BSTPathTest.cpp, Makefile, and any other files needed to make your code compile.</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>For this lab, you will implement an AVL tree and submit a brief lab report electronically via the submission system.</li>
 <li>Your report must be in PDF format! See the <a href="../../docs/convert_to_pdf.html">How to convert a file to PDF</a> page for details.</li>
 <li>Files to download: <a href="code/postlab/AVLNode.h.html">AVLNode.h</a> (<a href="code/postlab/AVLNode.h">src</a>), <a href="code/postlab/AVLNode.cpp.html">AVLNode.cpp</a> (<a href="code/postlab/AVLNode.cpp">src</a>), <a href="code/postlab/AVLTree.h.html">AVLTree.h</a> (<a href="code/postlab/AVLTree.h">src</a>), <a href="code/postlab/AVLTree.cpp.html">AVLTree.cpp</a> (<a href="code/postlab/AVLTree.cpp">src</a>), <a href="code/postlab/AVLPathTest.cpp.html">AVLPathTest.cpp</a> (<a href="code/postlab/AVLPathTest.cpp">src</a>), <a href="code/postlab/testfile1.txt">testfile1.txt</a> (<a href="code/postlab/testfile1.out.txt">output</a>), <a href="code/postlab/testfile2.txt">testfile2.txt</a> (<a href="code/postlab/testfile2.out.txt">output</a>), <a href="code/postlab/testfile3.txt">testfile3.txt</a> (<a href="code/postlab/testfile3.out.txt">output</a>). These files are contained in the postlab/ directory of the <a href="code.zip" class="uri">code.zip</a> file.</li>
@@ -77,7 +80,7 @@
 </ul>
 <p>Note that the last three files should not be modified at all! If you have additional code to include, put it in TreeCalc.cpp or TreeCalc.h (you should not need to use additional classes). Just in case it wasn't clear yet, all your modifications should be in the TreeCalc.h and TreeCalc.cpp files.</p>
 <p>Your fully functional tree calculator code should do the following:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read user input in postfix order (assume well-formed expressions) into a stack</li>
 <li>Build an expression tree using the items in the stack (see <a href="http://en.wikipedia.org/wiki/Expression_tree#Construction_of_an_Expression_Tree">here</a> for the algorithm)</li>
 <li>Print the resulting expression tree as a <em>postfix</em> expression in the EXACT output format as shown in the next section. Spaces matter!</li>
@@ -129,10 +132,9 @@ The result of the expression tree is 42</code></pre>
 <li>Lookup <word>: <code>L &lt;word&gt;</code></li>
 </ul>
 <p>The Lookup instruction will call the <code>pathTo()</code> method defined on your tree. <code>pathTo()</code> must return a string representing the nodes encountered when finding an element. For instance in the following image, the bold lines indicate the path taken for locating element W.</p>
-<div class="figure">
-<img src="avl-tree-pic-1.png" alt="avl-tree-pic-1" />
-<p class="caption">avl-tree-pic-1</p>
-</div>
+<figure>
+<img src="avl-tree-pic-1.png" alt="avl-tree-pic-1" /><figcaption>avl-tree-pic-1</figcaption>
+</figure>
 <p><code>pathTo(&quot;W&quot;)</code> would then return the string <code>&quot;M P Z W&quot;</code>. Calling <code>pathTo()</code> on an element that doesn't exist would result in an empty string <code>&quot;&quot;</code>.</p>
 <p>The BinarySearchTree.cpp file already contains a few methods implemented for you (including remove()). To aid in debugging, we provide a printTree() method and associated helper methods that will print out your tree to the console in a nice format. This will prove useful if you are having trouble and want to see what your tree is doing over several operations. You can call printTree() to see this output and safely ignore all of the helper methods.</p>
 <p>To recap, submit the following files:</p>
@@ -177,7 +179,7 @@ balance(node):
 <li>analysis.pdf: The report for this lab.</li>
 </ul>
 <p>The report for this lab should contain the following:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Your name, the date, and your CS 2150 lab section.</li>
 <li>A discussion of what <a href="code/postlab/testfile1.txt">testfile1.txt</a>, <a href="code/postlab/testfile2.txt">testfile2.txt</a>, and <a href="code/postlab/testfile3.txt">testfile3.txt</a> suggest about the relative performance of AVL trees and Binary search trees.</li>
 <li>A description of the space-time tradeoff between the two implementations.</li>

--- a/labs/lab06/index.html
+++ b/labs/lab06/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 6: Hashing</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-6-hashing">PDR: Laboratory 6: Hashing</h1>
@@ -16,12 +19,12 @@
 <h3 id="background">Background</h3>
 <p>A <a href="https://en.wikipedia.org/wiki/Hash_table">hash table</a> is a dictionary in which keys are mapped to array positions by a <em>hash function</em>. Having more than one key map to the same position is called a <em>collision</em>. There are many ways to resolve collisions, but they may be divided into two primary strategies: separate chaining and open addressing.</p>
 <h3 id="readings">Reading(s):</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Learn how to use C++ file streams to read from data files. See the <a href="http://www.cplusplus.com/doc/tutorial/files/">Input/output with files article</a> on <a href="http://www.cplusplus.com/">cplusplus.com</a>. You can also see the code in the provided <a href="code/getWordInGrid.cpp.html">getWordInGrid.cpp</a> (<a href="code/getWordInGrid.cpp">src</a>) file which uses streams as well. You may want to use the <a href="http://www.cplusplus.com/reference/fstream/ifstream/">good()</a> method in the ifstream class -- you can put it in a <code>while</code> loop: <code>while (foo.good())</code>.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Implement a solution to the word puzzle problem described below.</li>
 <li>Your program should take in two file names as command-line arguments, and should NOT ask for any input. The command-line arguments are the dictionary filename and the grid filename, in that order.</li>
 <li>Place the timer calls before and after your code. Note that the time you spend building the hash table should not be inside the timer calls -- only the code that finds the words in the grid. An actual time from a running of your program should be listed as a comment at the top of wordPuzzle.cpp.</li>
@@ -40,7 +43,7 @@
 <li>Files to submit: Makefile, wordPuzzle.cpp, timer.h/cpp, hashTable.h/cpp (see below for details)</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read through the in-lab section below. Make sure you understand what the new clang++ flag (-O2) does, and how to handle input and output.</li>
 <li>Verify with the TA the correct placement of the timer calls.</li>
 <li>Verify that your program gets the correct solution for the 250x250 grid using words.txt as the dictionary, and the 300x300 grid using words2.txt as the dictionary. The output files for these runs are in the <a href="data/">labs/lab06/data/ directory</a>.</li>
@@ -53,7 +56,7 @@
 <li>Files to submit: averagetime.sh, inlab6.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Optimize your implementation of the word puzzle solver. Your program should produce the same output as the sample output files in the <a href="data/">labs/lab06/data/ directory</a> (your program can contain output such as timer results, as described in the in-lab section). The input (i.e., the command-line parameters) is the exact same as for the pre-lab.</li>
 <li>The various optimizations allowed are listed in the description of the word puzzle problem as well as the post-lab section. You will have to include a description of the optimization methods used in the post-lab report. Your Makefile should be modified for the post-lab (probably just adding -O2).</li>
 <li>Create postlab6.pdf file (see the post-lab section for formatting details), containing the post-lab report (see below).</li>
@@ -231,7 +234,7 @@ diff output.txt words2.sorted.out.txt</code></pre>
 <p>If you single-space your report, you can divide the page lengths listed below by a factor of 2. If you single space your report and include a lot of blank space with tables, that's not what we are looking for here.</p>
 <p>Include the big-theta running time of your application, and a full explanation as to why. This should be half a page or so. This should address only the word-search portion of your application -- not the reading of input files, hash table creation, etc. This big-Theta runtime should take into account any and all optimizations that you made. Please do this in terms of <em>r</em> (rows), <em>c</em> (columns), and <em>w</em> (words). You can assume that the maximum word size is some small constant.</p>
 <p>Include the timing information for your application (as described at the end of the in-lab section). This should also be half a page or more. You can do this on any machine and data files, just use the same machine and files for all tests. Be sure to specify which files and machine you used. Show timing results (use the timer placement as we used in lab) for:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Your original application</li>
 <li>Pick a new hash function designed to make performance worse in terms of time. What new hash function did you choose and why was your performance worse?</li>
 <li>Pick a new hash table size designed to make performance worse in terms of time. What hash table size did you choose and why was your performance worse.</li>

--- a/labs/lab07/index.html
+++ b/labs/lab07/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 7: IBCM Programming</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-7-ibcm-programming">PDR: Laboratory 7: IBCM Programming</h1>
@@ -16,14 +19,14 @@
 <h3 id="background">Background:</h3>
 <p>IBCM (Itty Bitty Computing Machine) is a simulated computer with a minimal instruction set. Despite its tiny small instruction set, the IBCM can compute anything that a modern 'powerful' computer can compute.</p>
 <h3 id="readings">Reading(s):</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/07-ibcm.html">slides on IBCM</a></li>
 <li>Read <a href="../../book/ibcm-chapter.pdf">IBCM book chapter</a> (PDF)</li>
 <li>Run IBCM code online <a href="http://pegasus.cs.virginia.edu/ibcm/">here</a>. The sample code in the book chapter is also in the repo: <a href="../../ibcm/summation.ibcm">summation.ibcm</a> and <a href="../../ibcm/array-summation.ibcm">array-summation.ibcm</a></li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The online IBCM simulator is available online <a href="http://pegasus.cs.virginia.edu/ibcm/">here</a>. If that site is down, mirror websites are listed in the pre-lab section.</li>
 <li>Write the two IBCM programs described in the pre-lab section: addition.ibcm and array.ibcm.</li>
 <li>Note that some browsers have problems with the online simulator. If in doubt, try Firefox or Chrome.</li>
@@ -32,7 +35,7 @@
 <li>Files to submit: addition.ibcm, array.ibcm. Make sure they are not named addition.ibcm.txt and array.ibcm.txt!</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Implement the bubble sort algorithm in IBCM from the C++ code. See the in-lab section for details.</li>
 <li>Discuss any problems getting your programs to work with a TA.</li>
 <li>Your submitted files MUST have an .ibcm extension (not .ibcm.txt), and can NOT have any blank lines!</li>
@@ -40,7 +43,7 @@
 <li>Files to submit: bubblesort.ibcm. Make sure it's not named bubblesort.ibcm.txt!</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The tutorial for this lab is the remainder of the <a href="http://en.wikibooks.org/wiki/Bash_Shell_Scripting">Wikibooks article on Bash Shell Scripting</a>.</li>
 <li>Complete the shell script described in the post-lab section.</li>
 <li>Your shell script MUST use <code>a.out</code> as the executable name</li>
@@ -65,7 +68,7 @@
 <p>You will be developing a somewhat more complicated IBCM program in the in-lab. So, as preparation, study the IBCM documentation and lecture notes. Additionally, you will be expected to come to the in-lab with two working IBCM programs. You will not get much from the lab unless you are thoroughly familiar with the documentation and lecture notes, so make sure you are familiar with the material!</p>
 <h3 id="writing-ibcm-code">Writing IBCM Code</h3>
 <p>You <strong>MUST</strong> comment your IBCM code copiously. This means (practically) every line should have a comment describing what you are doing. Note that you cannot have a line that is only comments, as the emulator will have trouble reading that line! The examples provided in the handouts posted on the course website and discussed in class illustrate a good way of doing this, where there are columns for each of the following:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>the hexadecimal values that will go into that memory location</li>
 <li>the address of that memory location</li>
 <li>labels for jumps or variable names</li>
@@ -103,7 +106,7 @@
 <h3 id="bubble-sort">Bubble sort</h3>
 <p>Download and look at the <a href="bubblesort.cpp.html">bubblesort.cpp</a> (<a href="bubblesort.cpp">src</a>) algorithm. This algorithm is what needs to be implemented in IBCM, although you should <strong>NOT</strong> implement the output in the IBCM version.</p>
 <p>To encode this program, follow these steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Write up high-level pseudo-code for your design on paper (make sure that it is absolutely correct, or you will probably regret it later)</li>
 <li>Refine this pseudo-code, making it closer to the assembly code level</li>
 <li>Alter your code into IBCM assembly code with labels instead of addresses</li>

--- a/labs/lab08-32bit/index.html
+++ b/labs/lab08-32bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 8: x86 Assembly Language, part 1 (32 bit)</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-8-x86-assembly-language-part-1-32-bit">PDR: Laboratory 8: x86 Assembly Language, part 1 (32 bit)</h1>
@@ -17,13 +20,13 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a <a href="http://en.wikipedia.org/wiki/Complex_instruction_set_computing">CISC</a> instruction set that has been extended multiple times (e.g. <a href="http://en.wikipedia.org/wiki/MMX_%28instruction_set%29">MMX</a>) into a larger instruction set. In 2004 it was extended to allow for a 64 bit memory space.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-assembly-32bit.html">slides on 32 bit x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-32bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-32bit-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>You should be familiar with the readings described above. They detail the x86 material that this lab requires.</li>
 <li>Complete the tutorial, which consists of reading two book chapters that are contained in this repository: <a href="../../book/x86-32bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-32bit-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 <li>Read through the section, below, on compiling C++ with assembly on different architectures, as well as the vecsum program.</li>
@@ -38,14 +41,14 @@
 <li>Files to submit mathlib.s, mathfun.cpp, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Address at least one of the topics shown in the in-lab section. Be sure to address all the issues in that topic! You will have to complete both of these topics for the post-lab report.</li>
 <li>We are looking for a brief write-up indicating that you addressed at least one of the topics, and the results that you found. You do not need to make it a full fledged report yet (that's the post-lab).</li>
 <li>Files to download: none (other than the results of your pre-lab)</li>
 <li>Files to submit: inlab8.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Finish addressing the topics listed in the in-lab section. We are looking for a quality write-up here, as detailed in the post-lab section. Be sure to address all the issues in each topic!<br />
 </li>
 <li>Files to download: none (other than the results of your pre-lab and in-lab)</li>
@@ -55,7 +58,7 @@
 <h2 id="platform-architectures">Platform Architectures</h2>
 <h3 id="different-architectures">Different Architectures</h3>
 <p>There are four different platforms that students are potentially developing their code on:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>32-bit Linux (what is on the VirtualBox image)</li>
 <li>64-bit Linux (what the submission server is running, as well as what is installed on the computers in Rice 340 and Olsson 001)</li>
 <li>32-bit Mac OS X (although we doubt anybody actually has this anymore)</li>
@@ -83,11 +86,11 @@
 <p>Below is a table summarizing the changes</p>
 <table style="width:97%;">
 <colgroup>
-<col width="13%" />
-<col width="8%" />
-<col width="8%" />
-<col width="8%" />
-<col width="58%" />
+<col style="width: 13%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 58%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -185,13 +188,13 @@
 <p>The questions posed below are example questions to answer. Some of them may overlap. Others may not be necessary. And there may be questions not listed that are worth answering. The purpose of posing those questions is to help you think about what topics and ideas you should address in your response - it's not meant to be a rigid structure that you absolutely must follow. We are going to look at whether you have addressed the general idea of each of the list topics.</p>
 <h3 id="parameter-passing">Parameter passing</h3>
 <p>Show and explain assembly code generated by the compiler for a simple function and function call that passes parameters by a variety of means. Be sure to show what is happening both in the caller (the function which makes a call to another function) and in the callee (the function which is called by another function, possibly a recursive call). You do not need to describe parts of the C calling convention we described in class (e.g. saving registers, saving the base pointer, how the call instruction works). The focus here is on examining in detail what happens when parameters are passed.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>You should explain how ints, chars, pointers, floats, and objects that contain more than one data member such as user-defined classes are passed by value and by reference.</li>
 <li>In addition, show how arrays (you may pick any type) are passed in C++. Be sure to show <em>both</em> how these values are passed into a function <em>and</em> how the callee accesses the parameters inside of the function. Recall that you can use gdb to pause execution in the assembly code, and then see actual memory addresses -- see the pre-lab for details. This question asks about exactly where the data values are placed, so you will need to determine at least a register-relative address, just saying the parameter is accessed as [var] is not enough. Be sure to ask if you do not understand.</li>
 <li>How does passing values by reference work in assembly? Is it different than passing values by pointer?</li>
 </ol>
 <h3 id="objects">Objects</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Explain how data layout, data member access, and method invocation works in C++ objects. For data layout, how are they kept in memory? How does C++ keep different fields of an object &quot;together&quot;? For data access, how does the assembly know which data member to access? We know how local variables and parameters are accessed (offsets from the base pointer) -- describe how this is done for data fields. For method invocation, we know how functions are invoked. But what about methods -- how does the assembly know which object it is being called out of? Remember that assembly is not object oriented.</li>
 <li>Describe where data is laid out for a sample C++ class. You should include at least five data members in your class. Be sure to include data members of different types (ints, chars, and other user-defined classes) and different access levels (public and private) in your class. We are looking for something descriptive here -- for example, if you define a char and an int (total of 5 bytes needed), how is it laid out in memory?</li>
 <li>Next, demonstrate how data members are accessed both from inside a member function and from outside. In other words, describe what the assembly code does to access member functions in both of these situations.</li>

--- a/labs/lab08-64bit/index.html
+++ b/labs/lab08-64bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 8: x86 Assembly Language, part 1 (64 bit)</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-8-x86-assembly-language-part-1-64-bit">PDR: Laboratory 8: x86 Assembly Language, part 1 (64 bit)</h1>
@@ -17,14 +20,14 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a <a href="http://en.wikipedia.org/wiki/Complex_instruction_set_computing">CISC</a> instruction set that has been extended multiple times (e.g. <a href="http://en.wikipedia.org/wiki/MMX_%28instruction_set%29">MMX</a>) into a larger instruction set. In 2004 it was extended to allow for a 64 bit memory space.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-assembly-64bit.html">slides on 64 bit x86</a></li>
 <li>The x86 book chapters on <a href="../../book/x86-64bit-asm-chapter.pdf">x86</a> and the <a href="../../book/x86-64bit-ccc-chapter.pdf">C calling convention</a> as the reading</li>
 <li>An optional online reading is <a href="https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf">x86-64 Machine-Level Programming</a> from CMU, although they use the other assembly language format</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>You should be familiar with the readings described above. They detail the x86 material that this lab requires.</li>
 <li>Complete the tutorial, which consists of reading <a href="https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf">x86-64 Machine-Level Programming</a> from CMU</li>
 <li>Read through the section, below, on compiling C++ with assembly on different architectures, as well as the vecsum program.</li>
@@ -40,7 +43,7 @@
 <li>Files to submit mathlib.s, mathfun.cpp, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Make sure you have completed the reading on the C calling convention.</li>
 <li>Follow the in-lab instructions in this document. Your assignment is to write a function in x86 assembly called mergeSort. The merge function is provided in mergeSort.s.</li>
 <li>Your code must compile with <code>make</code>. It must work on a 64-bit Linux machine.</li>
@@ -49,7 +52,7 @@
 <li>Files to submit: mergeSort.s, testMergeSort.cpp, Makefile</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Write a report that explains the topics listed in the post-lab section below. Be sure to address all the issues in each topic!</li>
 <li>Files to download: none (other than the results of your pre-lab and in-lab)</li>
 <li>Files to submit: postlab8.pdf</li>
@@ -58,7 +61,7 @@
 <h2 id="platform-architectures">Platform Architectures</h2>
 <h3 id="different-architectures">Different Architectures</h3>
 <p>There are two different platforms that students are potentially developing their code on:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>64-bit Linux (what is on the VirtualBox image and what the submission server is running, as well as what is installed on the computers in Rice 340 and Olsson 001)</li>
 <li>64-bit Mac OS X</li>
 </ol>
@@ -82,11 +85,11 @@
 <p>Below is a table summarizing the changes</p>
 <table style="width:97%;">
 <colgroup>
-<col width="13%" />
-<col width="8%" />
-<col width="8%" />
-<col width="8%" />
-<col width="58%" />
+<col style="width: 13%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 58%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -180,14 +183,14 @@ Sorted array: -39 -7 2 8 12</code></pre>
 <p>The questions below are what you must address in your post-lab report. Make sure you answer each part and include sufficient evidence. You should create a simple class to help you answer the following questions. In your class, be sure to include several methods and at least 5 data members of different types and access levels (public and private).</p>
 <h3 id="parameter-passing">Parameter passing</h3>
 <p>Show and explain assembly code generated by the compiler for a simple function and function call that passes parameters by a variety of means. Show what is happening both in the caller and in the callee. You do not need to describe parts of the C calling convention we described in class (e.g. saving registers, saving the base pointer, how the call instruction works). The focus here is on examining in detail what happens when parameters are passed.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>How are variables (ints, chars, pointers, floats, etc.) passed by value? How are they passed by reference? Create several functions and examine the parameter registers to help you answer this question.</li>
 <li>Create a simple function that takes in an object. How are objects passed by value? How are they passed by reference? Specifically, what is contained in the parameter registers in each case?</li>
 <li>Create an array in your main method, and write a function that takes it in as a parameter. How are arrays passed into functions? How does the callee access the parameters? Where are the data values placed? Hint: you will need to determine at least a register-relative address.</li>
 <li>Is passing values by reference different than passing by pointer? If they are the same, what exactly is passed in the parameter register? If they are different, how so?</li>
 </ol>
 <h3 id="objects">Objects</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>How is object data laid out in memory? Create an object in your main method, and view where each data member is located in memory. How does C++ keep different fields of an object &quot;together&quot;?</li>
 <li>Explain how data member access works for objects. How does the assembly know which data member to access? We know how local variables and parameters are accessed (offsets from the base pointer) -- describe how this is done for data fields.</li>
 <li>How does method invocation work for objects? Specifically, how does the assembly know which object it is being called out of? Remember that assembly is not object oriented.</li>

--- a/labs/lab09-32bit/32-bit/index.html
+++ b/labs/lab09-32bit/32-bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 9: x86 Assembly Language, part 2</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-9-x86-assembly-language-part-2">PDR: Laboratory 9: x86 Assembly Language, part 2</h1>
@@ -16,13 +19,13 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a CISC instruction set that has been extended multiple times (e.g. MMX) into a larger instruction set.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-x86.html">slides on x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 </ol>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If you need to, read through the pre-lab pages from the previous lab on compiling C++ with assembly, as well as the vecsum program.</li>
 <li>In particular, you should be familiar with the differences between the various platforms, and the required submission format (it's Linux), as described in the pre-lab section.</li>
 <li>Follow the pre-lab instructions in this document. They require you to write a program in x86 assembly called threexplusone.s.</li>
@@ -34,14 +37,14 @@
 <li>Files to submit: threexplusone.s, threexinput.cpp, timer.cpp, timer.h, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Address one of the topics in the list of the in-lab section. Be sure to address all the issues in that topic! You will have to complete two (total) of these topics for the post-lab report.</li>
 <li>We are looking for a brief write-up indicating that you addressed one of the topics, and the results that you found. You do not need to make it a full fledged report yet (that's the post-lab).</li>
 <li>Files to download: none (other than the results of your pre-lab)</li>
 <li>Files to submit: inlab9.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Finish addressing two of the topics listed in the in-lab section (the first topic is the one you started in the in-lab; the second one is new for the post-lab). We are looking for a quality write-up here, as detailed below.</li>
 <li>You must complete two total topics; the first one is what you started (and possibly finished) from the in-lab; the second one is new for the post-lab</li>
 <li>While this seems like a long post-lab, these list items should have been worked on during the pre-lab and the in-lab, which makes the post-lab much shorter.</li>
@@ -55,10 +58,9 @@
 <p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08/index.html">previous x86 lab</a>.</p>
 <h3 id="pre-lab-program-threexplusone.s">Pre-lab program: threexplusone.s</h3>
 <p>The 3x+1 conjecture (also called the Collatz conjecture) is an open problem in mathematics, meaning that it has not yet been proven to be true. The conjecture states that if you take any positive integer, you can repeatedly apply the following function to it:</p>
-<div class="figure">
-<img src="formula.png" alt="formula.png" />
-<p class="caption">formula.png</p>
-</div>
+<figure>
+<img src="formula.png" alt="formula.png" /><figcaption>formula.png</figcaption>
+</figure>
 <p>The conjecture is that eventually, the result will reach 1. For example, consider <em>x</em> = 13:</p>
 <ul>
 <li><em>f</em>(13) = 3 * 13 + 1 = 40</li>
@@ -94,7 +96,7 @@
 <p>You will need to include at least one optimization beyond just figuring out how to write your subroutine with fewer instructions. You should put the optimizations used as a comment in the beginning of your assembly file.</p>
 <p>Note that we, too, can write the function in C++ and compile it with <code>-O2 --S --masm=intel</code>. And we will be looking at that assembly code when we grade the pre-lab. If you write your program this way, it constitutes an honor violation, so please hand-code the assembly yourself.</p>
 <p>In an effort to time how fast your assembly routine runs, you should download the timer code from the hash table lab (lab 6: <a href="../lab06/code/timer.cpp.html">timer.cpp</a> (<a href="../lab06/code/timer.cpp">src</a>) and <a href="../lab06/code/timer.h.html">timer.h</a> (<a href="../lab06/code/timer.h">src</a>)). In your threexinput.cpp file, you will need to perform the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Asks the user for an input value, <em>x</em>, which is the parameter to pass to the subroutine.</li>
 <li>Asks the user for an input value, <em>n</em>, which is the number of times to call the subroutine.</li>
 <li>Runs the subroutine <em>n</em> times with the parameter <em>x</em> as the input.</li>
@@ -120,11 +122,11 @@
 <h3 id="topic-list">Topic List</h3>
 <p>For the in-lab, you have to address one topic; either the required one or an optional one. For the post-lab, you will have to address two total topics: the one you addressed from the in-lab, and one additional one for the post-lab. Note that everybody has to address the dynamic dispatch one, but it is your call whether you do that for the in-lab or the post-lab.</p>
 <h4 id="required">Required</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Dynamic dispatch: Describe how dynamic dispatch is implemented. Note that dynamic dispatch is NOT the same thing as dynamic memory! Show this using a simple class hierarchy that includes virtual functions. Use more than one virtual function per class.</li>
 </ol>
 <h4 id="optional">Optional</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>Inheritance (data layout, construction, and destruction): Create an instance of an object that inherits data members from another class, and also includes data members of its own. Show in memory where data members are laid out in that object. Then explain how construction and destruction happens in this class hierarchy. Explain what happens when a user-defined object is instantiated and what happens when it goes out of scope. What if anything is &quot;destroyed&quot; by the destructor? Show this process happening in the assembly code using a simple class hierarchy. Point out in the assembly code exactly where the destructors and constructors are getting called.</p></li>
 <li><p>Optimized code: Compare code generated normally to optimized code. To create optimized code, you will need to use the <code>-O2</code> compiler flag. Can you make any guesses as to why the optimized code looks as it does? What is being optimized? Be sure to show your original sample code as well as the optimized version. Try loops and function calls to see what &quot;optimizing&quot; does. Be aware that if instructions are &quot;not necessary&quot; to the final output of the program then they may be optimized away completely! This does not lead to very interesting comparisons. Describe at least four (non-trivial) differences you see between 'normal' code and optimized code.</p></li>
 <li><p>Templates: What does the code look like for the instantiation of a simple templated class you wrote? What if you instantiate the class for different data types, what code is generated then? Is it the same or different? If the same, why? If different, why? Compare code for a user-defined templated class or function to a templated class from the STL (e.g. classes such as vectors or functions such as sort).</p></li>

--- a/labs/lab09-32bit/index.html
+++ b/labs/lab09-32bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 9: x86 Assembly Language, part 2 (32 bit)</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-9-x86-assembly-language-part-2-32-bit">PDR: Laboratory 9: x86 Assembly Language, part 2 (32 bit)</h1>
@@ -17,13 +20,13 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a CISC instruction set that has been extended multiple times (e.g. MMX) into a larger instruction set.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-x86.html">slides on x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-32bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-32bit-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 </ol>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If you need to, read through the pre-lab pages from the previous lab on compiling C++ with assembly, as well as the vecsum program.</li>
 <li>In particular, you should be familiar with the differences between the various platforms, and the required submission format (it's Linux), as described in the pre-lab section.</li>
 <li>Follow the pre-lab instructions in this document. They require you to write a program in x86 assembly called threexplusone.s.</li>
@@ -35,14 +38,14 @@
 <li>Files to submit: threexplusone.s, threexinput.cpp, timer.cpp, timer.h, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Address one of the topics in the list of the in-lab section. Be sure to address all the issues in that topic! You will have to complete two (total) of these topics for the post-lab report.</li>
 <li>We are looking for a brief write-up indicating that you addressed one of the topics, and the results that you found. You do not need to make it a full fledged report yet (that's the post-lab).</li>
 <li>Files to download: none (other than the results of your pre-lab)</li>
 <li>Files to submit: inlab9.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Finish addressing two of the topics listed in the in-lab section (the first topic is the one you started in the in-lab; the second one is new for the post-lab). We are looking for a quality write-up here, as detailed below.</li>
 <li>You must complete two total topics; the first one is what you started (and possibly finished) from the in-lab; the second one is new for the post-lab</li>
 <li>While this seems like a long post-lab, these list items should have been worked on during the pre-lab and the in-lab, which makes the post-lab much shorter.</li>
@@ -56,10 +59,9 @@
 <p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08/index.html">previous x86 lab</a>.</p>
 <h3 id="pre-lab-program-threexplusone.s">Pre-lab program: threexplusone.s</h3>
 <p>The 3x+1 conjecture (also called the Collatz conjecture) is an open problem in mathematics, meaning that it has not yet been proven to be true. The conjecture states that if you take any positive integer, you can repeatedly apply the following function to it:</p>
-<div class="figure">
+<figure>
 <img src="formula.png" />
-
-</div>
+</figure>
 <p>The conjecture is that eventually, the result will reach 1. For example, consider <em>x</em> = 13:</p>
 <ul>
 <li><em>f</em>(13) = 3 * 13 + 1 = 40</li>
@@ -95,7 +97,7 @@
 <p>You will need to include at least one optimization beyond just figuring out how to write your subroutine with fewer instructions. You should put the optimizations used as a comment in the beginning of your assembly file.</p>
 <p>Note that we, too, can write the function in C++ and compile it with <code>-O2 --S --masm=intel</code>. And we will be looking at that assembly code when we grade the pre-lab. If you write your program this way, it constitutes an honor violation, so please hand-code the assembly yourself.</p>
 <p>In an effort to time how fast your assembly routine runs, you should download the timer code from the hash table lab (lab 6: <a href="../lab06/code/timer.cpp.html">timer.cpp</a> (<a href="../lab06/code/timer.cpp">src</a>) and <a href="../lab06/code/timer.h.html">timer.h</a> (<a href="../lab06/code/timer.h">src</a>)). In your threexinput.cpp file, you will need to perform the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Asks the user for an input value, <em>x</em>, which is the parameter to pass to the subroutine.</li>
 <li>Asks the user for an input value, <em>n</em>, which is the number of times to call the subroutine.</li>
 <li>Runs the subroutine <em>n</em> times with the parameter <em>x</em> as the input.</li>
@@ -121,11 +123,11 @@
 <h3 id="topic-list">Topic List</h3>
 <p>For the in-lab, you have to address one topic; either the required one or an optional one. For the post-lab, you will have to address two total topics: the one you addressed from the in-lab, and one additional one for the post-lab. Note that everybody has to address the dynamic dispatch one, but it is your call whether you do that for the in-lab or the post-lab.</p>
 <h4 id="required">Required</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Dynamic dispatch: Describe how dynamic dispatch is implemented. Note that dynamic dispatch is NOT the same thing as dynamic memory! Show this using a simple class hierarchy that includes virtual functions. Use more than one virtual function per class.</li>
 </ol>
 <h4 id="optional">Optional</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>Inheritance (data layout, construction, and destruction): Create an instance of an object that inherits data members from another class, and also includes data members of its own. Show in memory where data members are laid out in that object. Then explain how construction and destruction happens in this class hierarchy. Explain what happens when a user-defined object is instantiated and what happens when it goes out of scope. What if anything is &quot;destroyed&quot; by the destructor? Show this process happening in the assembly code using a simple class hierarchy. Point out in the assembly code exactly where the destructors and constructors are getting called.</p></li>
 <li><p>Optimized code: Compare code generated normally to optimized code. To create optimized code, you will need to use the <code>-O2</code> compiler flag. Can you make any guesses as to why the optimized code looks as it does? What is being optimized? Be sure to show your original sample code as well as the optimized version. Try loops and function calls to see what &quot;optimizing&quot; does. Be aware that if instructions are &quot;not necessary&quot; to the final output of the program then they may be optimized away completely! This does not lead to very interesting comparisons. Describe at least four (non-trivial) differences you see between 'normal' code and optimized code.</p></li>
 <li><p>Templates: What does the code look like for the instantiation of a simple templated class you wrote? What if you instantiate the class for different data types, what code is generated then? Is it the same or different? If the same, why? If different, why? Compare code for a user-defined templated class or function to a templated class from the STL (e.g. classes such as vectors or functions such as sort).</p></li>

--- a/labs/lab09-64bit/32-bit/index.html
+++ b/labs/lab09-64bit/32-bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 9: x86 Assembly Language, part 2</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-9-x86-assembly-language-part-2">PDR: Laboratory 9: x86 Assembly Language, part 2</h1>
@@ -16,13 +19,13 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a CISC instruction set that has been extended multiple times (e.g. MMX) into a larger instruction set.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-x86.html">slides on x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 </ol>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If you need to, read through the pre-lab pages from the previous lab on compiling C++ with assembly, as well as the vecsum program.</li>
 <li>In particular, you should be familiar with the differences between the various platforms, and the required submission format (it's Linux), as described in the pre-lab section.</li>
 <li>Follow the pre-lab instructions in this document. They require you to write a program in x86 assembly called threexplusone.s.</li>
@@ -34,14 +37,14 @@
 <li>Files to submit: threexplusone.s, threexinput.cpp, timer.cpp, timer.h, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Address one of the topics in the list of the in-lab section. Be sure to address all the issues in that topic! You will have to complete two (total) of these topics for the post-lab report.</li>
 <li>We are looking for a brief write-up indicating that you addressed one of the topics, and the results that you found. You do not need to make it a full fledged report yet (that's the post-lab).</li>
 <li>Files to download: none (other than the results of your pre-lab)</li>
 <li>Files to submit: inlab9.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Finish addressing two of the topics listed in the in-lab section (the first topic is the one you started in the in-lab; the second one is new for the post-lab). We are looking for a quality write-up here, as detailed below.</li>
 <li>You must complete two total topics; the first one is what you started (and possibly finished) from the in-lab; the second one is new for the post-lab</li>
 <li>While this seems like a long post-lab, these list items should have been worked on during the pre-lab and the in-lab, which makes the post-lab much shorter.</li>
@@ -55,10 +58,9 @@
 <p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08/index.html">previous x86 lab</a>.</p>
 <h3 id="pre-lab-program-threexplusone.s">Pre-lab program: threexplusone.s</h3>
 <p>The 3x+1 conjecture (also called the Collatz conjecture) is an open problem in mathematics, meaning that it has not yet been proven to be true. The conjecture states that if you take any positive integer, you can repeatedly apply the following function to it:</p>
-<div class="figure">
-<img src="formula.png" alt="formula.png" />
-<p class="caption">formula.png</p>
-</div>
+<figure>
+<img src="formula.png" alt="formula.png" /><figcaption>formula.png</figcaption>
+</figure>
 <p>The conjecture is that eventually, the result will reach 1. For example, consider <em>x</em> = 13:</p>
 <ul>
 <li><em>f</em>(13) = 3 * 13 + 1 = 40</li>
@@ -94,7 +96,7 @@
 <p>You will need to include at least one optimization beyond just figuring out how to write your subroutine with fewer instructions. You should put the optimizations used as a comment in the beginning of your assembly file.</p>
 <p>Note that we, too, can write the function in C++ and compile it with <code>-O2 --S --masm=intel</code>. And we will be looking at that assembly code when we grade the pre-lab. If you write your program this way, it constitutes an honor violation, so please hand-code the assembly yourself.</p>
 <p>In an effort to time how fast your assembly routine runs, you should download the timer code from the hash table lab (lab 6: <a href="../lab06/code/timer.cpp.html">timer.cpp</a> (<a href="../lab06/code/timer.cpp">src</a>) and <a href="../lab06/code/timer.h.html">timer.h</a> (<a href="../lab06/code/timer.h">src</a>)). In your threexinput.cpp file, you will need to perform the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Asks the user for an input value, <em>x</em>, which is the parameter to pass to the subroutine.</li>
 <li>Asks the user for an input value, <em>n</em>, which is the number of times to call the subroutine.</li>
 <li>Runs the subroutine <em>n</em> times with the parameter <em>x</em> as the input.</li>
@@ -120,11 +122,11 @@
 <h3 id="topic-list">Topic List</h3>
 <p>For the in-lab, you have to address one topic; either the required one or an optional one. For the post-lab, you will have to address two total topics: the one you addressed from the in-lab, and one additional one for the post-lab. Note that everybody has to address the dynamic dispatch one, but it is your call whether you do that for the in-lab or the post-lab.</p>
 <h4 id="required">Required</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Dynamic dispatch: Describe how dynamic dispatch is implemented. Note that dynamic dispatch is NOT the same thing as dynamic memory! Show this using a simple class hierarchy that includes virtual functions. Use more than one virtual function per class.</li>
 </ol>
 <h4 id="optional">Optional</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>Inheritance (data layout, construction, and destruction): Create an instance of an object that inherits data members from another class, and also includes data members of its own. Show in memory where data members are laid out in that object. Then explain how construction and destruction happens in this class hierarchy. Explain what happens when a user-defined object is instantiated and what happens when it goes out of scope. What if anything is &quot;destroyed&quot; by the destructor? Show this process happening in the assembly code using a simple class hierarchy. Point out in the assembly code exactly where the destructors and constructors are getting called.</p></li>
 <li><p>Optimized code: Compare code generated normally to optimized code. To create optimized code, you will need to use the <code>-O2</code> compiler flag. Can you make any guesses as to why the optimized code looks as it does? What is being optimized? Be sure to show your original sample code as well as the optimized version. Try loops and function calls to see what &quot;optimizing&quot; does. Be aware that if instructions are &quot;not necessary&quot; to the final output of the program then they may be optimized away completely! This does not lead to very interesting comparisons. Describe at least four (non-trivial) differences you see between 'normal' code and optimized code.</p></li>
 <li><p>Templates: What does the code look like for the instantiation of a simple templated class you wrote? What if you instantiate the class for different data types, what code is generated then? Is it the same or different? If the same, why? If different, why? Compare code for a user-defined templated class or function to a templated class from the STL (e.g. classes such as vectors or functions such as sort).</p></li>

--- a/labs/lab09-64bit/index.html
+++ b/labs/lab09-64bit/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 9: x86 Assembly Language, part 2 (64 bit)</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-9-x86-assembly-language-part-2-64-bit">PDR: Laboratory 9: x86 Assembly Language, part 2 (64 bit)</h1>
@@ -17,13 +20,13 @@
 <h3 id="background">Background</h3>
 <p>The Intel x86 assembly language is currently one of the most popular assembly languages and runs on many architectures from the x86 line through the Pentium 4. It is a CISC instruction set that has been extended multiple times (e.g. MMX) into a larger instruction set.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../slides/08-x86.html">slides on x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-64bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-64bit-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
 </ol>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If you need to, read through the pre-lab pages from the previous lab on compiling C++ with assembly, as well as the vecsum program.</li>
 <li>In particular, you should be familiar with the differences between the various platforms, and the required submission format (it's Linux), as described in the pre-lab section.</li>
 <li>Follow the pre-lab instructions in this document. They require you to write a program in x86 assembly called threexplusone.s.</li>
@@ -35,14 +38,14 @@
 <li>Files to submit: threexplusone.s, threexinput.cpp, timer.cpp, timer.h, Makefile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Address one of the topics in the list of the in-lab section. Be sure to address all the issues in that topic! You will have to complete two (total) of these topics for the post-lab report.</li>
 <li>We are looking for a brief write-up indicating that you addressed one of the topics, and the results that you found. You do not need to make it a full fledged report yet (that's the post-lab).</li>
 <li>Files to download: none (other than the results of your pre-lab)</li>
 <li>Files to submit: inlab9.pdf</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Finish addressing two of the topics listed in the in-lab section (the first topic is the one you started in the in-lab; the second one is new for the post-lab). We are looking for a quality write-up here, as detailed below.</li>
 <li>You must complete two total topics; the first one is what you started (and possibly finished) from the in-lab; the second one is new for the post-lab</li>
 <li>While this seems like a long post-lab, these list items should have been worked on during the pre-lab and the in-lab, which makes the post-lab much shorter.</li>
@@ -56,10 +59,9 @@
 <p>You may want to reference the &quot;Compiling Assembly With C++&quot; and &quot;Vecsum&quot; sections from the <a href="../lab08-64bit/index.html">previous x86 lab</a>.</p>
 <h3 id="pre-lab-program-threexplusone.s">Pre-lab program: threexplusone.s</h3>
 <p>The 3x+1 conjecture (also called the Collatz conjecture) is an open problem in mathematics, meaning that it has not yet been proven to be true. The conjecture states that if you take any positive integer, you can repeatedly apply the following function to it:</p>
-<div class="figure">
+<figure>
 <img src="formula.png" />
-
-</div>
+</figure>
 <p>The conjecture is that eventually, the result will reach 1. For example, consider <em>x</em> = 13:</p>
 <ul>
 <li><em>f</em>(13) = 3 * 13 + 1 = 40</li>
@@ -95,7 +97,7 @@
 <p>You will need to include at least one optimization beyond just figuring out how to write your subroutine with fewer instructions. You should put the optimizations used as a comment in the beginning of your assembly file.</p>
 <p>Note that we, too, can write the function in C++ and compile it with <code>clang++ -O2 -m64 -S -mllvm --x86-asm-syntax=intel</code>. And we will be looking at that assembly code when we grade the pre-lab. If you write your program this way, it constitutes an honor violation, so please hand-code the assembly yourself.</p>
 <p>In an effort to time how fast your assembly routine runs, you should download the timer code from the hash table lab (lab 6: <a href="../lab06/code/timer.cpp.html">timer.cpp</a> (<a href="../lab06/code/timer.cpp">src</a>) and <a href="../lab06/code/timer.h.html">timer.h</a> (<a href="../lab06/code/timer.h">src</a>)). In your threexinput.cpp file, you will need to perform the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Asks the user for an input value, <em>x</em>, which is the parameter to pass to the subroutine.</li>
 <li>Asks the user for an input value, <em>n</em>, which is the number of times to call the subroutine.</li>
 <li>Runs the subroutine <em>n</em> times with the parameter <em>x</em> as the input.</li>
@@ -121,11 +123,11 @@
 <h3 id="topic-list">Topic List</h3>
 <p>For the in-lab, you have to address one topic; either the required one or an optional one. For the post-lab, you will have to address two total topics: the one you addressed from the in-lab, and one additional one for the post-lab. Note that everybody has to address the dynamic dispatch one, but it is your call whether you do that for the in-lab or the post-lab.</p>
 <h4 id="required">Required</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Dynamic dispatch: Describe how dynamic dispatch is implemented. Note that dynamic dispatch is NOT the same thing as dynamic memory! Show this using a simple class hierarchy that includes virtual functions. Use more than one virtual function per class.</li>
 </ol>
 <h4 id="optional">Optional</h4>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>Inheritance (data layout, construction, and destruction): Create an instance of an object that inherits data members from another class, and also includes data members of its own. Show in memory where data members are laid out in that object. Then explain how construction and destruction happens in this class hierarchy. Explain what happens when a user-defined object is instantiated and what happens when it goes out of scope. What if anything is &quot;destroyed&quot; by the destructor? Show this process happening in the assembly code using a simple class hierarchy. Point out in the assembly code exactly where the destructors and constructors are getting called.</p></li>
 <li><p>Optimized code: Compare code generated normally to optimized code. To create optimized code, you will need to use the <code>-O2</code> compiler flag. Can you make any guesses as to why the optimized code looks as it does? What is being optimized? Be sure to show your original sample code as well as the optimized version. Try loops and function calls to see what &quot;optimizing&quot; does. Be aware that if instructions are &quot;not necessary&quot; to the final output of the program then they may be optimized away completely! This does not lead to very interesting comparisons. Describe at least four (non-trivial) differences you see between 'normal' code and optimized code.</p></li>
 <li><p>Templates: What does the code look like for the instantiation of a simple templated class you wrote? What if you instantiate the class for different data types, what code is generated then? Is it the same or different? If the same, why? If different, why? Compare code for a user-defined templated class or function to a templated class from the STL (e.g. classes such as vectors or functions such as sort).</p></li>

--- a/labs/lab10/index.html
+++ b/labs/lab10/index.html
@@ -1,18 +1,21 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 10: Huffman Coding</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-10-huffman-coding">PDR: Laboratory 10: Huffman Coding</h1>
 <p><a href="../index.html">Go up to the Labs table of contents page</a></p>
 <h3 id="objective">Objective</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>To become familiar with prefix codes</li>
 <li>To implement a useful application using a variety of data structures</li>
 <li>To analyze the efficiency of your implementation.</li>
@@ -26,7 +29,7 @@
 </ul>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The pre-lab is the compression phase of the Huffman coding.</li>
 <li>You may NOT use a STL class for the heap (such as priority_queue), but you may use other STL classes (i.e. non-heap related classes).</li>
 <li>Implement the Huffman encoding routine discussed in the pre-lab section.</li>
@@ -36,7 +39,7 @@
 <li>Files to submit: heap.cpp, heap.h, huffmanenc.cpp, Makefile (you can submit additional .cpp/.h files, if needed, as long as it compiles with <code>make</code>)</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The in-lab is the decompression phase of the Huffman coding.</li>
 <li>Implement the Huffman decoding routine discussed in the in-lab section.</li>
 <li>Your program must compile with make!</li>
@@ -45,7 +48,7 @@
 <li>Files to submit: huffmandec.cpp, Makefile (you can submit additional .cpp/.h files, if needed, as long as it compiles with <code>make</code>)</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Complete the post-lab report, as described in the post-lab section.</li>
 <li>Ensure that the pre-lab code (compression) and post-lab code (decompression) work properly, as they will be submitted again</li>
 <li>Create a new Makefile, as specified in the post-lab section</li>
@@ -54,7 +57,7 @@
 <hr />
 <h2 id="huffman-encoding-and-decoding">Huffman Encoding and Decoding</h2>
 <p>The basic steps in compression (for the pre-lab) are:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the source file and determine the frequencies of the characters in the file.</li>
 <li>Store the character frequencies in a heap (priority queue).</li>
 <li>Build a tree of prefix codes (a Huffman code) that determines the unique bit codes for each character.</li>
@@ -63,7 +66,7 @@
 </ol>
 <p>We are also writing additional information to the file (compression ratio and tree cost), as described herein.</p>
 <p>The basic steps in decompression (for the in-lab) are:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read in the prefix code structure from the compressed file. You can NOT assume that you can re-use the tree currently in memory, as we will be testing your in-lab code on files that you have not encoded.</li>
 <li>Re-create the Huffman tree from the code structure read in from the file.</li>
 <li>Read in one bit at a time from the compressed file and move through the prefix code tree until a leaf node is reached.</li>
@@ -123,10 +126,9 @@ There were 13 bits in the compressed file.
 This gives a compression ratio of 4.30769.
 The cost of the Huffman tree is 1.85714 bits per character.</code></pre>
 <p>The Huffman tree that this forms is the same as the one shown in the slide set (specifically, <a href="../../slides/10-heaps-huffman.html#/lab10tree">here</a>), and is dupliated below.</p>
-<div class="figure">
+<figure>
 <img src="prelab-tree.png" />
-
-</div>
+</figure>
 <p>Below is an equivalent version of the same file. Note that the characters are not in the same order in the previous example, the whitespace for the middle part is quite different, the English explanation in the third part says the same thing but in a different format, and the particular prefix codes are different (but note that the lengths are the same). Your in-lab code will need to be able to read in both of these files (as well as others in the <a href="examples/">labs/lab10/examples/ directory</a>). For writing your pre-lab, you should consider having a space or a newline between the Huffman encoded characters, as that will make your code easier to check and debug.</p>
 <pre><code>d 11
 c 101
@@ -175,7 +177,7 @@ The Huffman tree cost: 1.85 bits per character</code></pre>
 <p>For the post-lab, we want you to do a time and space complexity analysis of your compression and decompression code. You'll submit a written report that describes your implementation choices, and also documents your analysis of time and space complexity. See below for a discussion about the space/time complexity.</p>
 <p>The deliverable for the post-lab is a PDF document named postlab10.pdf. It must be in PDF format! See <a href="../../docs/convert_to_pdf.html">How to convert a file to PDF</a> for details.</p>
 <p>A written post-lab report (a page is fine) that includes the following. You can double-space your report, but no funky stuff with the formatting (standard size fonts, standard margins, etc.). And if you double-space your report, you need to increase the number of pages appropriately.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>A description of your implementation. Describe the data structures used in your implementation and <em>why</em> you selected them.</li>
 <li>An efficiency analysis of <em>all steps</em> in Huffman encoding/decoding.
 <ul>

--- a/labs/lab11/index.html
+++ b/labs/lab11/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 11: Graphs</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-11-graphs">PDR: Laboratory 11: Graphs</h1>
@@ -16,14 +19,14 @@
 <h3 id="background">Background</h3>
 <p>A graph is a set of vertices connected by edges. In a directed graph, an edge is an ordered pair of vertices, where you can follow an edge from one vertex to another. In a directed acyclic graph (DAG), no path starts and ends at the same vertex. A topological sort orders the vertices in a DAG such that any edge from vertex i to vertex j satisfies i &lt; j.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The <a href="http://en.wikipedia.org/wiki/Topological_sort">Wikipedia page on Topological sort</a></li>
 <li>The <a href="http://en.wikipedia.org/wiki/Travelling_salesman_problem">Wikipedia page on the Traveling Salesperson problem</a></li>
 <li><a href="../../slides/11-graphs.html">The slides on graphs</a></li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Go through the <a href="../../tutorials/11-doxygen/index.html">Doxygen tutorial</a>, as described in the pre-lab section.</li>
 <li>Study the topological sort algorithm described in the readings</li>
 <li>Look at the <a href="middleearth.h.html">middleearth.h</a> (<a href="middleearth.h">src</a>) and <a href="middleearth.cpp.html">middleearth.cpp</a> (<a href="middleearth.cpp">src</a>) files. You should understand <strong>AND DOCUMENT</strong> both of these two files. See the comments in the middleearth.cpp file, as well as the in-lab section, for details as to what these methods do. You should not modify any of the code in this file; only the comments.
@@ -41,7 +44,7 @@
 <li>Files to submit: topological.cpp, middleearth.h/cpp, Makefile, Doxyfile</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Implement a brute-force traveling salesperson solution, as described in the in-lab section.</li>
 <li>Create a Makefile that will fully compile your code. You should not specify the resulting executable name (i.e., no <code>-o</code> output for the final link step). It will default to a.out, which is what is desired.</li>
 <li>Document your C++ files with doxygen commands. You must <strong>ALSO</strong> include commented middleearth.h and middleearth.cpp (this should have been done in the pre-lab).</li>
@@ -50,7 +53,7 @@
 <li>Files to submit: traveling.cpp, middleearth.h, middleearth.cpp, Makefile, Doxyfile</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Complete the post-lab report, as described in the post-lab section.</li>
 <li>Files to download: none (other than your pre-lab and in-lab files)</li>
 <li>Files to submit: postlab11.pdf</li>
@@ -83,10 +86,9 @@
 <h2 id="pre-lab-problem-topological-sort">Pre-lab Problem: Topological Sort</h2>
 <p>It turns out that one of our teaching assistants did not take all of the pre-requisite computer science courses! That TA is all ready to graduate, but it turns that CS 1110 was never taken. The department came down hard, and decided to make that TA take all of the courses over again, to have the proper pre-requisite classes completed for each successive class. But the TA just got a job at Microsoft, and can only take one course a semester while working full time. In what order should the teaching assistant take the list of required courses to properly fulfill the pre-requisites this time around?</p>
 <p>Given the following course pre-requisite graph:</p>
-<div class="figure">
-<img src="pre-reqs.svg" alt="pre-reqs.svg" />
-<p class="caption">pre-reqs.svg</p>
-</div>
+<figure>
+<img src="pre-reqs.svg" alt="pre-reqs.svg" /><figcaption>pre-reqs.svg</figcaption>
+</figure>
 <p>There are multiple valid orders that the courses can be taken in; each is a valid topological sorts:</p>
 <ul>
 <li>cs1110 cs2110 cs2102 cs3330 cs2150 cs4414</li>
@@ -123,7 +125,7 @@ cs1110 cs2102
 <p>If you want more background on the Traveling Salesperson problem, you can see <a href="http://www-e.uni-magdeburg.de/mertens/TSP/TSP.html">here</a>.</p>
 <p>The world we have chosen is <a href="http://en.wikipedia.org/wiki/Middle-earth">Middle-Earth</a>, the location of J.R.R. Tolkien's Hobbit and Lord of the Rings books and movies. The middleearth.h and middleearth.cpp files, that you commented in the pre-lab, contain a class that will create a random 2-dimensional world. The &quot;randomness&quot; means that it will pick a given number of cities (or places), and randomly place them in the &quot;world&quot;. You can travel from any city to any other city, for a given cost (the distance). The city names are all from the books and movies, and can be seen at the beginning of the middleearth.cpp file -- there is a textual description in the code as to what all the places are. The randomness of the world means that cities that are nowhere near each other in the books/movies might be right next to each other in the random world.</p>
 <p>When your program is completed, you will need to specify five command-line parameters to execute the traveling salesperson problem. The parameters are, in order:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>The x-size (i.e. width) of the world. We'll use 20 throughout this lab.</li>
 <li>The y-size (i.e. height) of the world. We'll use 20 throughout this lab.</li>
 <li>The number of cities in the world. There are currently 40 names specified at the top of middleearth.cpp, so you can't specify more than 40 cities.</li>
@@ -144,7 +146,7 @@ cs1110 cs2102
 <p>The <code>getDistance()</code> method will return the distance, as a float, between the two provided cities. In an effort to make your code as efficient as possible, <code>getDistance()</code> has the same running time as a hash table (usually Θ(1)). Lastly, <code>getItinerary()</code> will return a vector of the cities that you must visit. Note that the first city provided is the start (and thus end) city -- you should remove this from the vector before you consider all possible cycles through the graph.</p>
 <h3 id="how-to-proceed">How to proceed</h3>
 <p>We provide the skeleton code for the algorithm -- your job is to complete traveling.cpp.</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>First complete <code>printRoute()</code>, as that will be useful when debugging your code. It should print a route in the form: <code>Dunharrow -&gt; Cirith Ungol -&gt; Hobbiton -&gt; Grey Havens -&gt; Lothlorien -&gt; Dunharrow</code>. Note that we aren't picky about exactly how it's printed, as long as it prints all the cities.</li>
 <li>Next, complete <code>computeDistance()</code>. You can create a sample string vector to test it, and verify it against the distances in the output of <code>printTable()</code> (see above).</li>
 <li>Start on the <code>main()</code> method. Make sure that you can print out all the permutations of the list of destinations. Note that for n cities, there are n! possible permutations. Remember that the start city should not be permuted!</li>
@@ -174,7 +176,7 @@ student@cassiopeia:~/labs/lab11$ </code></pre>
 <p>If the random seed (the fourth parameter) is 14, then the path lengths and paths for the various itinerary lengths are listed below. Because we are explicitly setting the random seed, it should produce the exact same results each time -- and thus your code should also produce the same results.</p>
 <p><strong>Important note:</strong> The method for determining the random seed is different on different systems. So using a random seed of 14 (which is what we used), you may get different results on different systems. We provide the Virtual Box results here, and other 32-bit and 64-bit Linux installations <em>should</em> be similar. But your results may differ! In particular, if you have a different flavor of Linux installed, use a Mac, etc. The machines in Olsson 001 have the same results as shown below. Also note that the direction of your path can be reversed -- it's the same distance (and thus still the shortest path), even if the path order is reversed. You should use the output of your <code>printTable()</code> over what is listed below.</p>
 <p>The Linux results for a random seed of 14, world size of 20x20 with 20 cities, and various path lengths:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Minimum path has distance 16.4499: Dunharrow -&gt; The Grey Havens -&gt; Dunharrow</li>
 <li>Minimum path has distance 38.5555: Dunharrow -&gt; Hobbiton -&gt; The Grey Havens -&gt; Dunharrow</li>
 <li>Minimum path has distance 39.1172: Dunharrow -&gt; Cirith Ungol -&gt; Hobbiton -&gt; The Grey Havens -&gt; Dunharrow</li>

--- a/labs/lab12/index.html
+++ b/labs/lab12/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Laboratory 12: Course Conclusion</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-laboratory-12-course-conclusion">PDR: Laboratory 12: Course Conclusion</h1>
@@ -16,21 +19,21 @@
 <h3 id="background">Background</h3>
 <p>All of CS 2150.</p>
 <h3 id="readings">Reading(s)</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>War and Peace</li>
 <li>Les Misérables</li>
 <li>Another <a href="http://en.wikipedia.org/wiki/List_of_longest_novels">really long book</a> of your choice.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read the <a href="../../tutorials/12-objc/index.html">Objective C tutorial</a>; you will need to download the <a href="../..//tutorials/12-objc/helloworld.m.html">helloworld.m</a> (<a href="../..//tutorials/12-objc/helloworld.m">src</a>) file, and submit a linkedlist.m file (the description of what to put in that file is in the tutorial).</li>
 <li>Write the Objective C program described in the &quot;Hack Some Objective C code&quot; section of the tutorial, which implements a singly-linked list.</li>
 <li>Files to download: <a href="../..//tutorials/12-objc/helloworld.m.html">helloworld.m</a> (<a href="../..//tutorials/12-objc/helloworld.m">src</a>) .</li>
 <li>Files to submit: linkedlist.m; if your program uses multiple .m or .h files, that's fine. There is no Makefile submitted with this lab.</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>For this in-lab, we won't be taking up much of your time.</li>
 <li>How much wrath do you have to vent about the course? How much did it ruin your life? How much did you learn? Let us know -- fill out the course surveys! You can access them through Collab (or SIS? We aren't actually given any information about how students access the course evaluations). On a more serious note, we are very interested in your feedback about the course, and would greatly appreciate your filling out of the course evaluation.</li>
 <li>The one text file you must submit for this lab is called suggestion.txt, and it should contain one <em>constructive</em> suggestion as to how to improve this course. Here, constructive means that it could actually be accomplished (so you can't just say &quot;ditch C++&quot; without some sort of suggestion as to what to place in its stead).</li>

--- a/license.html
+++ b/license.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Licensing Details</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="markdown.css" type="text/css" />
+  <link rel="stylesheet" href="markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-licensing-details">PDR: Licensing Details</h1>

--- a/readme-old.html
+++ b/readme-old.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="markdown.css" type="text/css" />
+  <link rel="stylesheet" href="markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation">Program and Data Representation</h1>
@@ -31,7 +34,7 @@
 </ul>
 <h2 id="contributing-to-this-repository"><a name="contributing"></a>Contributing to this Repository</h2>
 <p>Updates to the repository are restricted to approved individuals only, to prevent anybody from messing with the slides right before a lecture. However, others can still contribute to this repository -- to do so, take the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Create a github account, if you do not have one</li>
 <li>Fork this repository: you can click on the &quot;Fork&quot; link in the upper right, or just click <a href="https://github.com/markfloryan/pdr/fork">here</a></li>
 <li>Clone your forked repository on to your local machine</li>
@@ -62,19 +65,19 @@
 </ul>
 <h2 id="canvas-notes"><a name="canvasnotes"></a>Canvas notes</h2>
 <p>Some of the slides allow pen-based markup of the slides. To add a canvas to a slide (to allow drawing with a mouse or a stylus), you must do a few things:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>The slide can NOT be Markdown, it must be all pure HTML</p></li>
 <li><p>Include the js/canvas.js and css/dhtmlwindow.js scripts, as well as the dhtmlwindow.css CSS file (the two dhtmlwindow.* files are for the calibration feature):</p></li>
 </ol>
 <pre><code>&lt;script type=&quot;text/javascript&quot; src=&quot;js/dhtmlwindow.js&quot;&gt;&lt;/script&gt;
 &lt;script type=&quot;text/javascript&quot; src=&quot;js/canvas.js&quot;&gt;&lt;/script&gt;
 &lt;link rel=&quot;stylesheet&quot; href=&quot;css/dhtmlwindow.css&quot; type=&quot;text/css&quot;&gt;</code></pre>
-<ol start="3" style="list-style-type: decimal">
+<ol start="3" type="1">
 <li><p>Add an <code>onload=&quot;canvasinit()&quot;</code> to the <code>&lt;body&gt;</code> tag: <code>&lt;body onload=&quot;canvasinit()&quot;&gt;</code></p></li>
 <li><p>Add the following immediately after the <code>&lt;body&gt;</code> tag (this is for the calibration feature):</p></li>
 </ol>
 <pre><code>&lt;div id=&quot;dhtmlwindowholder&quot;&gt;&lt;span style=&quot;display:none&quot;&gt;&lt;/span&gt;&lt;/div&gt;</code></pre>
-<ol start="5" style="list-style-type: decimal">
+<ol start="5" type="1">
 <li>Add the following code at the end of the .html file (just before the three script tags):</li>
 </ol>
 <pre><code>&lt;div id=&quot;calibratediv&quot; style=&quot;display:none&quot;&gt;
@@ -85,7 +88,7 @@
    &lt;p style=&quot;text-align:center&quot;&gt;Click the center of the target&lt;br&gt;&lt;a href=&quot;#&quot; 
        onClick=&quot;calibratewin.close(); return false&quot;&gt;Close window&lt;/a&gt;&lt;/p&gt;
 &lt;/div&gt;</code></pre>
-<ol start="6" style="list-style-type: decimal">
+<ol start="6" type="1">
 <li>Then, on each slide that you want a canvas on, you add the following:</li>
 </ol>
 <pre><code>&lt;script type=&quot;text/javascript&quot;&gt;insertCanvas();&lt;/script&gt;</code></pre>

--- a/readme.html
+++ b/readme.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="markdown.css" type="text/css" />
+  <link rel="stylesheet" href="markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation">Program and Data Representation</h1>
@@ -31,7 +34,7 @@
 </ul>
 <h2 id="contributing-to-this-repository"><a name="contributing"></a>Contributing to this Repository</h2>
 <p>Updates to the repository are restricted to approved individuals only, to prevent anybody from messing with the slides right before a lecture. However, others can still contribute to this repository -- to do so, take the following steps:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Create a github account, if you do not have one</li>
 <li>Fork this repository: you can click on the &quot;Fork&quot; link in the upper right, or just click <a href="https://github.com/uva-cs/pdr/fork">here</a></li>
 <li>Clone your forked repository on to your local machine</li>

--- a/slides/32bit.html
+++ b/slides/32bit.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>32-bit Assembly Materials</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="bit-assembly-materials">32-bit Assembly Materials</h1>

--- a/slides/graphs/index.html
+++ b/slides/graphs/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Slides: Slide Graph Diagrams</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-slides-slide-graph-diagrams">PDR: Slides: Slide Graph Diagrams</h1>

--- a/slides/index.html
+++ b/slides/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Slides</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-slides">Program and Data Representation: Slides</h1>

--- a/tutorials/01-intro-unix/index.html
+++ b/tutorials/01-intro-unix/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Tutorial 1: Introduction to UNIX</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-tutorial-1-introduction-to-unix">PDR: Tutorial 1: Introduction to UNIX</h1>
@@ -63,10 +66,9 @@
 <li>Through SecureCRT to the departmental machines: log in as above. A few notes: when you load up the editor, enter <code>emacs helloworld.cpp</code> -- note that you are not loading the GUI (as this is a text-based terminal you are using), and you are not using an ampersand (<code>&amp;</code>). When you have to switch back to using the shell, you will need to exit Emacs (<code>C-x C-c</code> -- see below), run the command, and then re-start Emacs.</li>
 </ul>
 <p>You should now have emacs loaded and running -- if not, then something is wrong. If you are using the VirtualBox image, it will look like the following. Other systems will look similar.</p>
-<div class="figure">
-<img src="screenshot-1.png" alt="Emacs screenshot" />
-<p class="caption">Emacs screenshot</p>
-</div>
+<figure>
+<img src="screenshot-1.png" alt="Emacs screenshot" /><figcaption>Emacs screenshot</figcaption>
+</figure>
 <p>All of the mouse commands in Emacs have keyboard shortcuts. Eventually, you will want to learn the shortcuts, as they are much faster to enter once they are known. For the commands below, the keyboard shortcut commands are listed -- partly so you can get used to seeing and using them, and partly because for those using SecureCRT, they cannot use the mouse.</p>
 <p>The first commands in Emacs that we will learn will use the control key. For example, the exit command (to leave emacs) is listed as <code>C-x C-c</code>. This means hit Control-x then Control-c. We will be going over Emacs command in more detail later. For now, remember that if you get stuck, hit <code>C-g</code> (Control-g) a few times, and that should un-stick it.</p>
 <p>We recommend you create a new directory in your desktop for the rest of this tutorial (<code>mkdir tutorial</code>). Either way, <code>cd</code> into that directory.</p>
@@ -84,27 +86,23 @@ int main() {
 <p>After a successful compilation, do an <code>ls</code> -- you will see a second file, called <code>a.exe</code> (<code>a.out</code> if you are using Linux, OS X, or one of the lava machines). This is the compiled version of that program. To run it, enter <code>./a.exe</code> (or <code>./a.out</code>). Note the period and slash before the <code>a.exe</code> -- why this is there (and how to get rid of it) we will see later in the semester.</p>
 <p>Another useful command is the undo command: <code>C-_</code>. This means hold down the control and shift keys, and hit the dash/underscore key.</p>
 <p>Right now your Emacs should look approximately like this (with the helloworld.cpp file loaded):</p>
-<div class="figure">
-<img src="emacs-screenshot-new.png" alt="Emacs screenshot" />
-<p class="caption">Emacs screenshot</p>
-</div>
+<figure>
+<img src="emacs-screenshot-new.png" alt="Emacs screenshot" /><figcaption>Emacs screenshot</figcaption>
+</figure>
 <p>The following is useful for older versions of Emacs. Read over it and familiarize yourself with it, specifically the meta-commands, but note that if you see text coloring and line-numbers, you are good to go.</p>
 <p>There are two more Emacs commands that will be very useful as we continue in the course. The Emacs editor is very powerful, but you would never know it by looking at the code that you just entered. It really just looks like Notepad right now:</p>
-<div class="figure">
-<img src="screenshot-2.png" alt="Emacs screenshot" />
-<p class="caption">Emacs screenshot</p>
-</div>
+<figure>
+<img src="screenshot-2.png" alt="Emacs screenshot" /><figcaption>Emacs screenshot</figcaption>
+</figure>
 <p>Let's color the text and turn on line numbers -- both very useful things to have when you are editing code. We've seen control commands (such as <code>C-x C-s</code> for saving a file). Next up are commands called meta-commands, because they use the meta (or escape) key. A meta-command looks like <code>M-x linum-mode</code>. Thus, to enter the command, hit the escape key, RELEASE THE ESCAPE KEY, and hit <code>x</code>. Note that with the control commands, you hold down the control key while pressing the other key -- with meta commands, you press and then release the escape key, and then hit <code>x</code>. At that point, the bottom of your Emacs screen will look like the following:</p>
-<div class="figure">
-<img src="screenshot-3.png" alt="Emacs screenshot" />
-<p class="caption">Emacs screenshot</p>
-</div>
+<figure>
+<img src="screenshot-3.png" alt="Emacs screenshot" /><figcaption>Emacs screenshot</figcaption>
+</figure>
 <p>Note the <code>M-x</code> at the bottom -- Emacs is ready to receive an 'extended' meta command. Type in <code>linum-mode</code>, hit Enter, and the line number that the cursor is on will appear in the status bar at the bottom of the Emacs screen. Note that it is going to be annoying to have to type all of that in each time. This, if you hit the tab key after entering <code>line</code>, it will complete the rest of the command for you. While this may seem like a lot of typing, once you get used to it, these commands can be entered significantly faster than the mouse clicks needed to do this in other editors. There are ways you can have line numbers always displayed when you enter Emacs -- we'll get to these later in the semester. Note that you can enter <code>M-x linum-mode</code> as many times as you want -- it will just toggle the display of the line numbers on and off.</p>
 <p>The other command that is useful is to color the program text. Use the command <code>M-x font-lock-mode</code>. Note that if you hit the tab key after entering <code>font</code>, it doesn't fully complete it (you still have to enter 'mode'). Your C++ program should now be colored, and your Emacs window should look like the following.</p>
-<div class="figure">
-<img src="screenshot-4.png" alt="Emacs screenshot" />
-<p class="caption">Emacs screenshot</p>
-</div>
+<figure>
+<img src="screenshot-4.png" alt="Emacs screenshot" /><figcaption>Emacs screenshot</figcaption>
+</figure>
 <p>In addition to the font coloring of the C++ program code, note that the word 'Font' is between 'C++' and 'Abbrev' on the status bar (as we are now using font colors), and the line number is shown to the right of that (the cursor is on line 1 in the image).</p>
 <h2 id="summary">Summary</h2>
 <p>In summary, you should be familiar with the following Emacs commands:</p>

--- a/tutorials/01-intro-unix/vb-image-details.html
+++ b/tutorials/01-intro-unix/vb-image-details.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>VirtualBox image creation details</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="virtualbox-image-creation-details">VirtualBox image creation details</h1>

--- a/tutorials/01-intro-unix/virtual-box.html
+++ b/tutorials/01-intro-unix/virtual-box.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Tutorial 1: Introduction to UNIX: VirtualBox Use</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-tutorial-1-introduction-to-unix-virtualbox-use">PDR: Tutorial 1: Introduction to UNIX: VirtualBox Use</h1>
@@ -14,7 +17,7 @@
 <p>VirtualBox is a free program that allows you to run another operating system on your machine without needing to reinstall anything. You just have to install the VirtualBox client, which installs like any other program and is available for many different platforms (Windows, Mac, Linux). We provide you with a pre-configured VirtualBox image that contains an Ubuntu Linux installation that you can use for this course.</p>
 <h3 id="emulating-64-bit">Emulating 64-bit</h3>
 <p>When stepping through the steps below, you need to select 64-bit Linux/Ubuntu, and <strong>NOT</strong> 32-bit. If the <em>only</em> options that appear at that step are 32-bit OSes, then you need to enable your computer to emulate 64-bit OSes. Two of these things are done in the BIOS (hit delete, F1, or F10 when your computer starts). Because everybody's BIOS is different, we cannot provide specific instructions as to which exact steps to take. However, you need to enable the following two features in the BIOS:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Intel Virtualization Technology</li>
 <li>VT-d</li>
 </ol>

--- a/tutorials/02-gdb/index.html
+++ b/tutorials/02-gdb/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: GDB Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-gdb-tutorial">PDR: GDB Tutorial</h1>

--- a/tutorials/02-lldb/index.html
+++ b/tutorials/02-lldb/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: LLDB Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-lldb-tutorial">PDR: LLDB Tutorial</h1>

--- a/tutorials/05-make/index.html
+++ b/tutorials/05-make/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Makefile Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-makefile-tutorial">PDR: Makefile Tutorial</h1>
@@ -53,8 +56,8 @@ clang++ -c testPostfixCalc.cpp</code></pre>
 <p>The following is a list of some predefined macros in make (taken from the <a href="http://www.gnu.org/software/make/manual/">GNU Make Manual</a>, specifically <a href="http://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#Implicit-Variables">section 10.3</a>):</p>
 <table style="width:32%;">
 <colgroup>
-<col width="18%" />
-<col width="13%" />
+<col style="width: 18%" />
+<col style="width: 13%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -178,7 +181,7 @@ cd folder1
 mkdir folder2
     cd folder2 
 @echo I am in folder 2</code></pre>
-<p>When make is invoked, after performing an action, make will output the action to the screen. If you do not want an action to be displayed after invoking make, you can use '@' before the command. This is useful if you want to echo something but not have echo appear; however, the <span class="citation">@echo</span> statement must be on a separate line.</p>
+<p>When make is invoked, after performing an action, make will output the action to the screen. If you do not want an action to be displayed after invoking make, you can use '@' before the command. This is useful if you want to echo something but not have echo appear; however, the <span class="citation" data-cites="echo">@echo</span> statement must be on a separate line.</p>
 <p>In the pizza directory, pizza.cpp contains <code>main()</code> which uses the PizzaToppings, PizzaDough, and TomatoSauce classes. PizzaToppings is a class which makes use of the Cheese, Pepperoni, Peppers, and Mushrooms classes.</p>
 <p>Note the following rules in the provided Makefile:</p>
 <pre><code>pizza: pizza.o pizzadough.o tomatosauce.o toppings.o \

--- a/tutorials/09-c/index.html
+++ b/tutorials/09-c/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: C Tutorial for C++ programmers</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-c-tutorial-for-c-programmers">PDR: C Tutorial for C++ programmers</h1>
@@ -69,8 +72,8 @@ int main() {
 <p>and flags:</p>
 <table style="width:6%;">
 <colgroup>
-<col width="2%" />
-<col width="2%" />
+<col style="width: 2%" />
+<col style="width: 2%" />
 </colgroup>
 <thead>
 <tr class="header">
@@ -288,7 +291,7 @@ case 2:
 <hr />
 <h2 id="exercise">Exercise</h2>
 <p>This exercise is to be developed in C, and compiled using clang (NOT clang++!). The exercise is to implement a <strong><em>very simple</em></strong> linked list. Your program should do the following:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read in an integer, which we'll call <em>n</em></li>
 <li>Read in <em>n</em> more ints, and put those into a linked list
 <ul>

--- a/tutorials/11-doxygen/index.html
+++ b/tutorials/11-doxygen/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Doxygen Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-doxygen-tutorial">PDR: Doxygen Tutorial</h1>
@@ -48,31 +51,27 @@ double average (double x, double y) {
 <p>We run doxygen via the <code>doxygen</code> command -- no command line parameters are needed (assuming the <code>Doxyfile</code> file is in the same directory, which it is in this case). The configuration file you created above produces documentation in two forms -- HTML and RTF. With a modification to the configuration file (which we won't see here), it can produce documentation in other formats as well (LaTeX, man pages, XML, etc.).</p>
 <p>RTF (rich text format) is a file type that can be loaded up into your favorite word processing program. Once you have run doxygen, the comments are formatted into a file called <code>doc/rtf/refman.rtf</code> -- try loading up that file. Note that a number of the fields in the file (such as &quot;Title&quot; and &quot;Author&quot;) are not yet filled in -- this is addressed below. If you were to print the documentation, such as a programming reference, then you might use this format.</p>
 <p>The other version, and the one we are going to look at, is the HTML documentation. This is the most convenient for viewing online. After you run doxygen, these files are in the <code>doc/html</code> directory -- view the <code>doc/html/index.html</code> file. If you look at the documentation for this function (from the main page, follow the &quot;Files&quot; link on the title bar, and then the &quot;average.cpp&quot; link), you will see what is below. Note that there is more to that page than this image; what is below just shows the extracted documentation for <code>average()</code>.</p>
-<div class="figure">
+<figure>
 <img src="screenshot.png" />
-
-</div>
+</figure>
 <p>Do you see how the tags are separated into the different parts of this comment block?</p>
 <h3 id="call-graphs">Call Graphs</h3>
 <p>Doxygen can create call graphs for your code. We are going to change three options to &quot;YES&quot;: <code>HAVE_DOT</code> (line 2,052), <code>CALL_GRAPH</code> (line 2,168), and <code>CALLER_GRAPH</code> (line 2,179). The first one turns on graph creation (&quot;dot&quot; is the command-line for the graphviz package); the second and third turn on specific types of graphs.</p>
 <p>Now, run <code>doxygen</code> again, and view the page describe above (the one that shows the contents of average.cpp). You will see a few new graphs added. Keep in mind that, as the input source code (average.cpp) was rather small, these graphs are not going to be particularly all that large, either.</p>
 <p>The first graph is a dependency graph:</p>
-<div class="figure">
+<figure>
 <img src="graph-1.png" />
-
-</div>
+</figure>
 <p>This shows what the average.cpp file depends on. Specifically, this is what <code>#include</code> lines it has, which is only iostream in this case.</p>
 <p>The second graph is a callee graph for <code>average()</code>:</p>
-<div class="figure">
+<figure>
 <img src="graph-2.png" />
-
-</div>
+</figure>
 <p>This shows that functions and methods call <code>average()</code> -- in this case, it's only <code>main()</code>.</p>
 <p>The third graph is a caller graph for <code>main()</code>:</p>
-<div class="figure">
+<figure>
 <img src="graph-3.png" />
-
-</div>
+</figure>
 <p>This shows the functions that <code>main()</code> calls -- in this case, it's only <code>average()</code>.</p>
 <p>As the source code gets larger, so do the graphs. In fact, there is a maximum limit as to how big the graphs are. Specifically, the <code>DOT_GRAPH_MAX_NODES</code> option in the Doxyfile (initial value of 50) limits how many nodes can be represented in a single graph. In all the three examples shown above, there are only two nodes. After you start getting toward 100 nodes, the graph starts becoming too large to see on a screen, and it's utility as a visualization tool is lost.</p>
 <h3 id="continuing-onward">Continuing Onward</h3>

--- a/tutorials/12-objc/index.html
+++ b/tutorials/12-objc/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: Objective C Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-objective-c-tutorial">PDR: Objective C Tutorial</h1>
@@ -63,7 +66,7 @@ clang -I /usr/include/GNUstep/ -I /usr/lib/gcc/x86_64-linux-gnu/5/include/ *.m -
 <h3 id="hack-some-objective-c-code">Hack some Objective C code</h3>
 <p>What tutorial would be complete without a data structure to implement?</p>
 <p>Your task is to implement a data structure in Objective C -- a <strong>very simple singly</strong> linked list for integers. The program is basically the same as that which was required in the <a href="../09-c/index.html">C tutorial</a>. The requirements for the program are:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Read in an integer, which we'll call <em>n</em></li>
 <li>Read in <em>n</em> more ints, and put those into a linked list
 <ul>
@@ -86,7 +89,7 @@ Enter value 4: 8
 <p>The linked list program will need to be submitted as part of the lab; no Makefile is being submitted. As long as it compiles with the following compilation command, we really don't care what the files are named (within reason). The compile command that we will use to compile your code on Linux is <code>clang -I /usr/include/GNUstep/ *.m -lobjc -lgnustep-base</code>; this is equivalent to <code>clang *.m -lobjc</code> on Mac OS X.</p>
 <p>This is not meant to be a complicated program! We don't care about the order that the list is printed (forward or reverse is fine); you don't need to implement iterators, or anything too complicated. Our code had just <code>main()</code> method, and a ListNode class with a handful of methods. Your <code>insert()</code> code should be in <code>main()</code>, not in your class. Likewise your code to remove the elements, and to print the list should be in <code>main()</code>.</p>
 <p>A few requirements for the program:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>It must have a ListNode (or whatever you want to call it) class, which <strong>must have some basic methods</strong>: getters, setters, that sort of thing.</li>
 <li>You do not need to implement a List class; you can directly create (and destroy) ListNode objects right from your <code>main()</code> function.</li>
 <li>Since this is not Objective C++, it will need to use C input and output, so <code>printf()</code> and <code>scanf()</code> are your friends</li>
@@ -95,7 +98,7 @@ Enter value 4: 8
 <li>The point of this pre-lab is to work with calling various methods in Objective C (getters, setters, etc.). Directly accessing the fields is not what we are looking for.</li>
 </ol>
 <p>A few notes while working on the program:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Pointers can point to Objective C types (objects, structs, etc.) just like in C and C++</li>
 <li>See the <a href="http://en.wikibooks.org/wiki/Objective-C_Programming/syntax#The_interface">Point class</a>, in the <a href="http://en.wikibooks.org/wiki/Objective-C_Programming/syntax">Wikibooks syntax tutorial</a>, for a code class example.</li>
 <li>The <code>this</code> pointer in Objective C is called <code>self</code></li>

--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Tutorials</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-tutorials">Program and Data Representation: Tutorials</h1>

--- a/tutorials/other/ssh-scp.html
+++ b/tutorials/other/ssh-scp.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: ssh and scp Tutorial</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-ssh-and-scp-tutorial">PDR: ssh and scp Tutorial</h1>
@@ -18,12 +21,12 @@
 <p>There are Windows versions of <code>ssh</code> and <code>scp</code> as well; one set of these applications are called SecureCRT and SecureFX (UVa provides them for free in its Software Central). <a href="http://www.putty.org/">PuTTY</a> is a free and low-overhead ssh client for Windows.</p>
 <p><strong>Lastly, if your VirtualBox image/macOS/WSL/native Linux environment etc is <em>destroyed or unusable</em> by some means, using <code>ssh</code> and <code>scp</code> with the lab servers is an excellent alternative way to do your course assignments.</strong></p>
 <h2 id="using-ssh-to-login-to-a-lab-server-from-your-local-machine">Using ssh to login to a lab server from your local machine</h2>
-<p>Open the <code>bash</code> terminal on your laptop (via either the course image in VirtualBox, macOS, WSL, native Linux environment etc). Have your lab account password available (if you did not change it from the default password, it should be in email sent to <em>yourComputingID</em><span class="citation">@virginia.edu</span> from root@virginia.edu). Run the command <code>ssh yourComputingID@labunix01.cs.virginia.edu</code> (you may substitute <code>01</code> with <code>02</code> or <code>03</code>, these will all work the same and are synchronized, it does not matter which number you use). You will be prompted to enter your lab account password, and as you enter it <strong>you may notice that nothing appears to happen on the screen</strong>; do not worry, this is how <code>bash</code> hides your password from being shown in plain text, rather than using the &quot;common&quot; practice of printing <code>*</code>s for each character you enter. When you are done entering the password, press enter and you should see the prompt on your terminal change to something along the lines of <code>yourComputingID@labunix01:~$</code>. Try running <code>ls</code> to ensure your files from the lab desktops are all present, and go ahead and run <code>clang++</code> on one of your <code>.cpp</code> files to see that you can successfully compile code while logged in (you do not <em>need</em> to do this, but it's a good practice to ensure your environment works as you expect it to). <code>w</code> or <code>users</code> will show you who else is online...</p>
+<p>Open the <code>bash</code> terminal on your laptop (via either the course image in VirtualBox, macOS, WSL, native Linux environment etc). Have your lab account password available (if you did not change it from the default password, it should be in email sent to <em>yourComputingID</em><span class="citation" data-cites="virginia.edu">@virginia.edu</span> from root@virginia.edu). Run the command <code>ssh yourComputingID@labunix01.cs.virginia.edu</code> (you may substitute <code>01</code> with <code>02</code> or <code>03</code>, these will all work the same and are synchronized, it does not matter which number you use). You will be prompted to enter your lab account password, and as you enter it <strong>you may notice that nothing appears to happen on the screen</strong>; do not worry, this is how <code>bash</code> hides your password from being shown in plain text, rather than using the &quot;common&quot; practice of printing <code>*</code>s for each character you enter. When you are done entering the password, press enter and you should see the prompt on your terminal change to something along the lines of <code>yourComputingID@labunix01:~$</code>. Try running <code>ls</code> to ensure your files from the lab desktops are all present, and go ahead and run <code>clang++</code> on one of your <code>.cpp</code> files to see that you can successfully compile code while logged in (you do not <em>need</em> to do this, but it's a good practice to ensure your environment works as you expect it to). <code>w</code> or <code>users</code> will show you who else is online...</p>
 <p>You can use <code>emacs</code>, <code>vim</code> etc to work on your course assignments while logged on. To exit the <code>ssh</code> session, simply press <code>Ctrl+D</code> or run <code>logout</code>. You should be returned to your local machine's <code>bash</code> terminal.</p>
 <p>If you are having problems getting <code>ssh</code> to work for you, come speak to us during office hours/with Piazza/submitting a support request! Whichever means you deem appropriate.</p>
 <h2 id="using-scp-to-copy-files-back-and-forth-between-your-local-machine-and-a-lab-server">Using scp to copy files back-and-forth between your local machine and a lab server</h2>
 <p><strong>NOTE:</strong> <strong>Use <code>scp</code> <em>only on your local machine (e.g. laptop)</em> for all of your file-transferring needs, to-and-from. <code>scp</code> is more trouble than it's worth to try to use on the lab machines themselves, so do not plan on using the commands listed here from a lab machine; if you know what you are getting into, you are welcome to try to do that on your own (<code>sftp</code> or <code>rsync</code> are the more likely commands to look into for that scenario).</strong></p>
-<p>Open the <code>bash</code> terminal on your laptop (via either the course image in VirtualBox, macOS, WSL, native Linux environment etc). Have your lab account password available (if you did not change it from the default password, it should be in email sent to <em>yourComputingID</em><span class="citation">@virginia.edu</span> from root@virginia.edu).</p>
+<p>Open the <code>bash</code> terminal on your laptop (via either the course image in VirtualBox, macOS, WSL, native Linux environment etc). Have your lab account password available (if you did not change it from the default password, it should be in email sent to <em>yourComputingID</em><span class="citation" data-cites="virginia.edu">@virginia.edu</span> from root@virginia.edu).</p>
 <p>Below are 4 scenarios which most students tend to use <code>scp</code> for (remember that you can substitute <code>01</code> with <code>02</code> or <code>03</code> in specifying the lab server to use):</p>
 <p>1. Transferring a <strong>single file</strong> <strong><em>from</em></strong> the lab machine <strong><em>to</em></strong> your local machine</p>
 <p>Run the command</p>

--- a/utils/convert-markdown-to-html
+++ b/utils/convert-markdown-to-html
@@ -9,7 +9,7 @@ for infile in `find . -type f -name '*.md' | grep -v 'reveal\.js'`; do
     # calculate relative path from any file in a subdirectory to another (CSS) in the root directory
     pathprefix=`echo ${infile:2} | tr -d -c '/' | sed -r 's/\//..\//g'`
     # perform the conversion from MD to HTML, linking CSS in the process
-    pandoc -V "pagetitle:$lineone" -f markdown -c ${pathprefix}markdown.css -t html -o $outfile $infile
+    pandoc -V "pagetitle:$lineone" -f markdown -c ${pathprefix}markdown.css -t html5 -o $outfile $infile
     # remove the 'align="left"' tags that some versions of pandoc add to the <td> and <th> tags
     sed -i s/'<td align="left">'/'<td>'/g $outfile
     sed -i s/'<th align="left">'/'<th>'/g $outfile

--- a/utils/index.html
+++ b/utils/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: Utilities</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-utilities">Program and Data Representation: Utilities</h1>

--- a/uva/collab-landing-page.html
+++ b/uva/collab-landing-page.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>github repo</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="github-repo">github repo</h1>

--- a/uva/frivolous-regrades.html
+++ b/uva/frivolous-regrades.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Frivolous Regrade Policy</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="frivolous-regrade-policy">Frivolous Regrade Policy</h1>
@@ -17,7 +20,7 @@
 <p>This policy only applies to exam regrades at this time. Your constructive feedback on this is welcomed -- you can submit a <a href="https://libra.cs.virginia.edu/~pedagogy/support.php">support requests</a>, <a href="https://libra.cs.virginia.edu/~pedagogy/submit.php">lab submission</a> or <a href="https://collab.itc.virginia.edu/portal/site/7d8b39e0-ac9d-48c1-ab42-c3ca20dfb23c/page/a2056666-5b8f-40b6-8591-f73174a47bbf">anonymous feedback</a> (note that the problem with anonyous feedback is that there is no way to respond to your concern).</p>
 <h2 id="submitting-a-regrade-request">Submitting a Regrade Request</h2>
 <p>If a regrade request is submitted, it is the student's responsibility to do the following:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>List out each question for which a regrade is being requested.</li>
 <li>Clearly justify the request by citing the grading guidelines for each question.</li>
 <li>Display working knowledge of the question when arguing this position.</li>

--- a/uva/grades.html
+++ b/uva/grades.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Grading Explanations, Fall 2019</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="grading-explanations-fall-2019">Grading Explanations, Fall 2019</h1>
@@ -19,9 +22,8 @@
 <li>Final exam (25%)</li>
 </ul>
 <h2 id="the-process-of-grade-determination">The Process of Grade Determination</h2>
-<div class="figure">
+<figure>
 <img src="images/magic-8-ball.png" />
-
-</div>
+</figure>
 </body>
 </html>

--- a/uva/index.html
+++ b/uva/index.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Program and Data Representation: CS 2150 Specific Content</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="program-and-data-representation-cs-2150-specific-content">Program and Data Representation: CS 2150 Specific Content</h1>
@@ -61,12 +64,12 @@
 <p>The links in the right-most column link directly to the lecture recording on Collab, and you have to be logged into Collab first before the link will work. Some plugins (such as NoScript) will block that link from working.</p>
 <table>
 <colgroup>
-<col width="8%" />
-<col width="8%" />
-<col width="8%" />
-<col width="31%" />
-<col width="13%" />
-<col width="29%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 8%" />
+<col style="width: 31%" />
+<col style="width: 13%" />
+<col style="width: 29%" />
 </colgroup>
 <thead>
 <tr class="header">

--- a/uva/labduedates.html
+++ b/uva/labduedates.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>PDR: CS2150: Lab Due Dates Page</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pdr-cs2150-lab-due-dates-page">PDR: CS2150: Lab Due Dates Page</h1>

--- a/uva/syllabus.html
+++ b/uva/syllabus.html
@@ -1,12 +1,15 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="pandoc" />
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>CS 2150: Program and Data Representation: Course Syllabus</title>
   <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../markdown.css" type="text/css" />
+  <link rel="stylesheet" href="../markdown.css">
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="cs-2150-program-and-data-representation-course-syllabus">CS 2150: Program and Data Representation: Course Syllabus</h1>
@@ -80,7 +83,7 @@
 <p><strong>Attendance:</strong> Attendance in labs is mandatory; attendance in lecture is not. Not attending lab will result in a zero for the in-lab. You cannot change labs without prior permission - we do not have enough computers to accommodate this. Please see the <a href="course-introduction.html#/">first set of lecture slides</a> about lab attendance, in particular with regards to the fact that there is a lab the week of Thanksgiving break (in fall semesters) or the weeks before and after spring break (in spring semesters).</p>
 <p><strong>Professionalism:</strong> We are all adults, and should act like such. Acting in an unprofessional manner that disrupts the class will first incur a stern talking-to. After that, a grade penalty may be assessed. Examples include: disrupting class, trolling people on Piazza, abusing the support request system, etc. This is meant to keep people from repeatedly disrupting class; we are not trying to be super strict on this. And yes, a warning will first be given prior to any other action.</p>
 <p><strong>Honor Policy:</strong> There have been a large number of honor violations in this class and other low-level CS courses recently. Outside the normal UVa honor policy rules, we have these additional rules:</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>If you are looking at another student's source code for ANY reason (including code from a student from a previous semester), you are in violation of the honor policy. You may look at another student's source code after the program has been submitted by BOTH parties.</li>
 <li>If you try to hack my submission system, you will be brought up on honor charges, failed for the course, and I will personally call the police. This includes any sort of hacking such as: fork bombs to crash the system, opening up network sockets, looking around the file system, etc. The system has capabilities to detect and/or prevent these from happening, and a file cannot be removed once it is submitted (you can re-submit a file, but the old one is still saved). An honest mistake on a program, or a program crash, is not what we are talking about here - instead, an intentional and malicious hacking attempt is what will bring down the wrath.</li>
 <li>There are multiple midterm periods where students take exams, with a break between the the individual section times. Discussing the exam with a student who has not taken it is a violation of the honor policy.</li>


### PR DESCRIPTION
Does what it says on the tin. `utils/convert-markdown-to-html` has the actual code change.

This increases legibility on mobile devices.

Closes #19.