### PR TITLE
Update ListTest.cpp switch(17) renew iterator

### DIFF
--- a/labs/lab02/ListTest.cpp
+++ b/labs/lab02/ListTest.cpp
@@ -360,6 +360,7 @@ int   main ()
                 cout << "The list is (backward): ";
                 printList(*list,false);
                 list->makeEmpty();
+                itr = new ListItr((list->first()));
                 cout << "The list was made empty (forward): ";
                 printList(*list,true);
                 cout << "The list was made empty (backward): ";

--- a/labs/lab02/ListTest.cpp
+++ b/labs/lab02/ListTest.cpp
@@ -322,6 +322,7 @@ int   main ()
                 cout << "The old list was made empty (backward): ";
                 printList(*old_list, false);
                 cout << "The old list should be destroyed now." << endl;
+                itr = new ListItr((list->first()));
                 delete old_list;
                 break;
             }
@@ -343,8 +344,8 @@ int   main ()
                 printList(*old_list,true);
                 cout << "The old list was made empty (backward): ";
                 printList(*old_list,false);
-                cout << "The old list should be destroyed now." << endl;
-
+                cout << "The old list should be destroyed now." << endl;                
+                itr = new ListItr((list->first()));
                 delete old_list;
                 break;
             }


### PR DESCRIPTION
The makeEmpty() call in the main method leaves the iterator pointer, current, hanging. If the list before had the iterator in the center, for example, its pointer will no longer be useful. It must be redeclared before calling via the menu, but no checks are made for the add after and before (or rather it is unclear how those checks should be implemented). This is because the make empty class has no access to that iterator. It would be possible to check for the iterator being out of the space/passed the list tail/head, but this seems very verbose and unnecessary. Plus, it is innefficient. Depending on that implementation, it will fail in that case. I have not found an elegant way to solve this issue other than this. Additionally, because some may find it unclear how to implement the check case for this situation, we may find this solution is valid and more clear.

Let me know what I'm likely missing.