### PR TITLE
Prevent entire page from scrolling on mobile

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -30,15 +30,22 @@ code {
     padding: 0px 5px;
 }
 
+pre {
+    background-color: rgb(248, 248, 248);
+    border: 1px solid rgb(221, 221, 221);
+    padding: 6px 10px;
+    /* Make the pre box scrollable rather than scrolling the whole page */
+    overflow: auto;
+}
+
 pre code {
     border: none;
     padding: 0;
 }
 
-pre {
-    background-color: rgb(248, 248, 248);
-    border: 1px solid rgb(221, 221, 221);
-    padding: 6px 10px;
+img {
+    /* Prevent image from scrolling off the page on mobile */
+    max-width: 100%;
 }
 
 /* table formatting */


### PR DESCRIPTION
Two issues were causing certain lab writeups to scroll horizontally on mobile:
* Embedded images that had a larger natural width than the viewport
* Code blocks with a lot of characters on one line

Scrolling horizontally is non-optimal as you now need to control two dimensions when scrolling, rather than just one. Therefore, this PR scales images down to the max width of the page, and constrains code block scrolling to individual `pre` blocks rather than allowing the whole page to scroll (this is the same approach taken by GitHub). Note that the following screenshots are taken using Chrome's device emulation option in the dev tools, which shows the entire width of the page rather than just the available viewport (and shrinks everything else down to accommodate).

Before:
![image-before](https://user-images.githubusercontent.com/2766036/64901981-ae909100-d66d-11e9-9e60-7740b9f37d84.png)
![code-before](https://user-images.githubusercontent.com/2766036/64901985-c49e5180-d66d-11e9-8094-94a2fc74b05c.png)

After:
![image-after](https://user-images.githubusercontent.com/2766036/64901994-d5e75e00-d66d-11e9-9288-eb760fcc0f68.png)
![code-after](https://user-images.githubusercontent.com/2766036/64902004-eef00f00-d66d-11e9-949f-b0d14cbe3f77.png)
