### PR TITLE
Add a script for running source-highlight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,13 @@ markdown:
 	@git checkout uva/old/*.html
 	@echo done!
 
+highlight:
+	@echo Highlighting source files...
+	@chmod 755 utils/highlight-source-files
+	@utils/highlight-source-files
+	@git checkout uva/old/*.html
+	@echo done!
+
 clean:
 	/bin/rm -rf *~ */*~ */*/*~ */*/*/*~
 	/bin/rm -f uva/*.aux uva/*.log
-

--- a/Makefile.html
+++ b/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/Makefile.html
+++ b/Makefile.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">markdown:</span>
+	@echo Converting markdown files to html format<span style="color:#990000">...</span>
+	@chmod <span style="color:#993399">755</span> utils/convert-markdown-to-html
+	@utils/convert-markdown-to-html
+	@git checkout uva/old<span style="color:#990000">/*</span>.html
+	@echo <b><span style="color:#0000FF">done</span></b><span style="color:#990000">!</span>
+
+<span style="color:#990000">highlight:</span>
+	@echo Highlighting <b><span style="color:#0000FF">source</span></b> files<span style="color:#990000">...</span>
+	@chmod <span style="color:#993399">755</span> utils/highlight-source-files
+	@utils/highlight-source-files
+	@git checkout uva/old<span style="color:#990000">/*</span>.html
+	@echo <b><span style="color:#0000FF">done</span></b><span style="color:#990000">!</span>
+
+<span style="color:#990000">clean:</span>
+	/bin/rm -rf <span style="color:#990000">*~</span> <span style="color:#990000">*/*~</span> <span style="color:#990000">*/*/*~</span> <span style="color:#990000">*/*/*/*~</span>
+	/bin/rm -f uva<span style="color:#990000">/*</span>.aux uva<span style="color:#990000">/*</span>.log
+</pre>
+</body>
+</html>

--- a/exams/exam1-s08.cpp.html
+++ b/exams/exam1-s08.cpp.html
@@ -1,125 +1,125 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>exam1-s08.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// CS 216 exam 1 code</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// CS 216 exam 1 code</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">/* This function will print out the results of the memory diagram</font></i>
-<i><font color="#9A1900"> * question (question 13).  The lines that are commented out in the</font></i>
-<i><font color="#9A1900"> * function are the ones that cause errors: the first a compile-time</font></i>
-<i><font color="#9A1900"> * error, the last two a run-time error.</font></i>
-<i><font color="#9A1900"> */</font></i>
-<font color="#009900">void</font> <b><font color="#000000">memoryDiagramQuestion</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Memory diagram question output: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#009900">int</font> a <font color="#990000">=</font> <font color="#993399">7</font><font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>b <font color="#990000">=</font> <font color="#990000">&amp;</font>a<font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">&amp;</font>c <font color="#990000">=</font> a<font color="#990000">;</font>
-    <font color="#009900">int</font> d<font color="#990000">[</font><font color="#993399">5</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#FF0000">{</font> <font color="#993399">1</font><font color="#990000">,</font> <font color="#993399">2</font><font color="#990000">,</font> <font color="#993399">3</font><font color="#990000">,</font> <font color="#993399">4</font><font color="#990000">,</font> <font color="#993399">5</font> <font color="#FF0000">}</font><font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>e <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <font color="#009900">int</font><font color="#990000">[</font><font color="#993399">5</font><font color="#990000">];</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>f <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">&amp;</font>g <font color="#990000">=</font> <font color="#990000">*</font>f<font color="#990000">;</font>
-    <i><font color="#9A1900">//c = b;</font></i>
-    c <font color="#990000">=</font> <font color="#990000">*</font>b<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"a:  "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"b:  "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*b: "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"c:  "</font> <font color="#990000">&lt;&lt;</font> c <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"d:  "</font> <font color="#990000">&lt;&lt;</font> d <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"e:  "</font> <font color="#990000">&lt;&lt;</font> e <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*e: "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>e <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"f:  "</font> <font color="#990000">&lt;&lt;</font> f <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">//cout &lt;&lt; "*f:  " &lt;&lt; *f &lt;&lt; endl;</font></i>
-    <i><font color="#9A1900">//cout &lt;&lt; "g:  " &lt;&lt; g &lt;&lt; endl;</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">/* This function will print out the results of the memory diagram</span></i>
+<i><span style="color:#9A1900"> * question (question 13).  The lines that are commented out in the</span></i>
+<i><span style="color:#9A1900"> * function are the ones that cause errors: the first a compile-time</span></i>
+<i><span style="color:#9A1900"> * error, the last two a run-time error.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">memoryDiagramQuestion</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Memory diagram question output: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> a <span style="color:#990000">=</span> <span style="color:#993399">7</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>b <span style="color:#990000">=</span> <span style="color:#990000">&amp;</span>a<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>c <span style="color:#990000">=</span> a<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> d<span style="color:#990000">[</span><span style="color:#993399">5</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#FF0000">{</span> <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">2</span><span style="color:#990000">,</span> <span style="color:#993399">3</span><span style="color:#990000">,</span> <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">5</span> <span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>e <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">int</span><span style="color:#990000">[</span><span style="color:#993399">5</span><span style="color:#990000">];</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>f <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>g <span style="color:#990000">=</span> <span style="color:#990000">*</span>f<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">//c = b;</span></i>
+    c <span style="color:#990000">=</span> <span style="color:#990000">*</span>b<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"a:  "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"b:  "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*b: "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"c:  "</span> <span style="color:#990000">&lt;&lt;</span> c <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"d:  "</span> <span style="color:#990000">&lt;&lt;</span> d <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"e:  "</span> <span style="color:#990000">&lt;&lt;</span> e <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*e: "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>e <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"f:  "</span> <span style="color:#990000">&lt;&lt;</span> f <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">//cout &lt;&lt; "*f:  " &lt;&lt; *f &lt;&lt; endl;</span></i>
+    <i><span style="color:#9A1900">//cout &lt;&lt; "g:  " &lt;&lt; g &lt;&lt; endl;</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// The array that is declared in question 3</font></i>
-<font color="#009900">int</font> x<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">][</font><font color="#993399">2</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#FF0000">{</font> <font color="#FF0000">{</font><font color="#993399">1</font><font color="#990000">,</font><font color="#993399">2</font><font color="#FF0000">}</font><font color="#990000">,</font> <font color="#FF0000">{</font><font color="#993399">3</font><font color="#990000">,</font><font color="#993399">4</font><font color="#FF0000">}</font><font color="#990000">,</font> <font color="#FF0000">{</font><font color="#993399">5</font><font color="#990000">,</font><font color="#993399">6</font><font color="#FF0000">}</font> <font color="#FF0000">}</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// The array that is declared in question 3</span></i>
+<span style="color:#009900">int</span> x<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">][</span><span style="color:#993399">2</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">{</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">2</span><span style="color:#FF0000">}</span><span style="color:#990000">,</span> <span style="color:#FF0000">{</span><span style="color:#993399">3</span><span style="color:#990000">,</span><span style="color:#993399">4</span><span style="color:#FF0000">}</span><span style="color:#990000">,</span> <span style="color:#FF0000">{</span><span style="color:#993399">5</span><span style="color:#990000">,</span><span style="color:#993399">6</span><span style="color:#FF0000">}</span> <span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// The union used for questin 12</font></i>
-<b><font color="#0000FF">union</font></b> foo <font color="#FF0000">{</font>
-    <font color="#009900">int</font> x<font color="#990000">;</font>               <i><font color="#9A1900">// used to write the int value</font></i>
-    <font color="#009900">float</font> f<font color="#990000">;</font>             <i><font color="#9A1900">// used to read the floating point value</font></i>
-    <font color="#009900">int</font> <font color="#990000">*</font>p<font color="#990000">;</font>              <i><font color="#9A1900">// used to print out the values in hex</font></i>
-    <font color="#009900">unsigned</font> <font color="#009900">char</font> c<font color="#990000">[</font><font color="#993399">4</font><font color="#990000">];</font>  <i><font color="#9A1900">// used to swap the bytes</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// The union used for questin 12</span></i>
+<b><span style="color:#0000FF">union</span></b> foo <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> x<span style="color:#990000">;</span>               <i><span style="color:#9A1900">// used to write the int value</span></i>
+    <span style="color:#009900">float</span> f<span style="color:#990000">;</span>             <i><span style="color:#9A1900">// used to read the floating point value</span></i>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>p<span style="color:#990000">;</span>              <i><span style="color:#9A1900">// used to print out the values in hex</span></i>
+    <span style="color:#009900">unsigned</span> <span style="color:#009900">char</span> c<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">];</span>  <i><span style="color:#9A1900">// used to swap the bytes</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">/* This function will compute the result of the endian number question</font></i>
-<i><font color="#9A1900"> * (question 12).  Because the x86 writes both the floating point</font></i>
-<i><font color="#9A1900"> * number and the int value both in the same endian format, the bytes</font></i>
-<i><font color="#9A1900"> * have to be switched to simulate what was asked in the question.</font></i>
-<i><font color="#9A1900"> */</font></i>
-<font color="#009900">void</font> <b><font color="#000000">endianNumberQuestion</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
+<i><span style="color:#9A1900">/* This function will compute the result of the endian number question</span></i>
+<i><span style="color:#9A1900"> * (question 12).  Because the x86 writes both the floating point</span></i>
+<i><span style="color:#9A1900"> * number and the int value both in the same endian format, the bytes</span></i>
+<i><span style="color:#9A1900"> * have to be switched to simulate what was asked in the question.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">endianNumberQuestion</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
 
-    <i><font color="#9A1900">// Write the int to the union, and print out the value in hex.  This</font></i>
-    <i><font color="#9A1900">// is also the value expected for the first part of the 'partial</font></i>
-    <i><font color="#9A1900">// credit' option for this question.</font></i>
-    <font color="#008080">foo</font> bar<font color="#990000">;</font>
-    bar<font color="#990000">.</font>x <font color="#990000">=</font> <font color="#993399">2113</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Decimal value: "</font> <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Hex value before endian swap: "</font> <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>p <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// Write the int to the union, and print out the value in hex.  This</span></i>
+    <i><span style="color:#9A1900">// is also the value expected for the first part of the 'partial</span></i>
+    <i><span style="color:#9A1900">// credit' option for this question.</span></i>
+    <span style="color:#008080">foo</span> bar<span style="color:#990000">;</span>
+    bar<span style="color:#990000">.</span>x <span style="color:#990000">=</span> <span style="color:#993399">2113</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Decimal value: "</span> <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Hex value before endian swap: "</span> <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>p <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// Any machine will write both floating point numbers and int</font></i>
-    <i><font color="#9A1900">// numbers in the same endian format.  To simulate the exam question</font></i>
-    <i><font color="#9A1900">// (which has one type written in one endian format, and the other</font></i>
-    <i><font color="#9A1900">// one written in the other endian format), the bytes have to be</font></i>
-    <i><font color="#9A1900">// switched.  Note that it doesn't matter if this is running on a</font></i>
-    <i><font color="#9A1900">// big-endian machine or a little-endian machine, as the byte swap</font></i>
-    <i><font color="#9A1900">// will just switch the bytes to the 'other' format.</font></i>
-    <font color="#009900">unsigned</font> <font color="#009900">char</font> g<font color="#990000">;</font>
-    g <font color="#990000">=</font> bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">];</font>
-    bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">=</font> bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">];</font>
-    bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">]</font> <font color="#990000">=</font> g<font color="#990000">;</font>
-    g <font color="#990000">=</font> bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">];</font>
-    bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">=</font> bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">];</font>
-    bar<font color="#990000">.</font>c<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">]</font> <font color="#990000">=</font> g<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// Any machine will write both floating point numbers and int</span></i>
+    <i><span style="color:#9A1900">// numbers in the same endian format.  To simulate the exam question</span></i>
+    <i><span style="color:#9A1900">// (which has one type written in one endian format, and the other</span></i>
+    <i><span style="color:#9A1900">// one written in the other endian format), the bytes have to be</span></i>
+    <i><span style="color:#9A1900">// switched.  Note that it doesn't matter if this is running on a</span></i>
+    <i><span style="color:#9A1900">// big-endian machine or a little-endian machine, as the byte swap</span></i>
+    <i><span style="color:#9A1900">// will just switch the bytes to the 'other' format.</span></i>
+    <span style="color:#009900">unsigned</span> <span style="color:#009900">char</span> g<span style="color:#990000">;</span>
+    g <span style="color:#990000">=</span> bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">];</span>
+    bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">];</span>
+    bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> g<span style="color:#990000">;</span>
+    g <span style="color:#990000">=</span> bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+    bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">];</span>
+    bar<span style="color:#990000">.</span>c<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> g<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// Extract the floating point value</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Hex value after endian swap: "</font> <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>p <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Floating point value: "</font> <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>f <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// Extract the floating point value</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Hex value after endian swap: "</span> <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>p <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Floating point value: "</span> <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>f <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// This is the second part of the 'partial credit' option for this</font></i>
-    <i><font color="#9A1900">// question.</font></i>
-    bar<font color="#990000">.</font>x <font color="#990000">=</font> <font color="#993399">0x419c0000</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"0x419c0000 as a float: "</font> <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>f <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// This is the second part of the 'partial credit' option for this</span></i>
+    <i><span style="color:#9A1900">// question.</span></i>
+    bar<span style="color:#990000">.</span>x <span style="color:#990000">=</span> <span style="color:#993399">0x419c0000</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"0x419c0000 as a float: "</span> <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>f <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Calls the two defined functions above, and then exits.</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#000000">endianNumberQuestion</font></b><font color="#990000">();</font>
-    <b><font color="#000000">memoryDiagramQuestion</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Calls the two defined functions above, and then exits.</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#000000">endianNumberQuestion</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">memoryDiagramQuestion</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
 
-<i><font color="#9A1900">/* Output:</font></i>
+<i><span style="color:#9A1900">/* Output:</span></i>
 
-<i><font color="#9A1900">Decimal value: 2113</font></i>
-<i><font color="#9A1900">Hex value before endian swap: 0x841</font></i>
-<i><font color="#9A1900">Hex value after endian swap: 0x41080000</font></i>
-<i><font color="#9A1900">Floating point value: 8.5</font></i>
-<i><font color="#9A1900">0x419c0000 as a float: 19.5</font></i>
-<i><font color="#9A1900">Memory diagram question output:</font></i>
-<i><font color="#9A1900">a:  7</font></i>
-<i><font color="#9A1900">b:  0xbfc8e07c</font></i>
-<i><font color="#9A1900">*b: 7</font></i>
-<i><font color="#9A1900">c:  7</font></i>
-<i><font color="#9A1900">d:  0xbfc8e068</font></i>
-<i><font color="#9A1900">e:  0x804a008</font></i>
-<i><font color="#9A1900">*e: 0</font></i>
-<i><font color="#9A1900">f:  0</font></i>
+<i><span style="color:#9A1900">Decimal value: 2113</span></i>
+<i><span style="color:#9A1900">Hex value before endian swap: 0x841</span></i>
+<i><span style="color:#9A1900">Hex value after endian swap: 0x41080000</span></i>
+<i><span style="color:#9A1900">Floating point value: 8.5</span></i>
+<i><span style="color:#9A1900">0x419c0000 as a float: 19.5</span></i>
+<i><span style="color:#9A1900">Memory diagram question output:</span></i>
+<i><span style="color:#9A1900">a:  7</span></i>
+<i><span style="color:#9A1900">b:  0xbfc8e07c</span></i>
+<i><span style="color:#9A1900">*b: 7</span></i>
+<i><span style="color:#9A1900">c:  7</span></i>
+<i><span style="color:#9A1900">d:  0xbfc8e068</span></i>
+<i><span style="color:#9A1900">e:  0x804a008</span></i>
+<i><span style="color:#9A1900">*e: 0</span></i>
+<i><span style="color:#9A1900">f:  0</span></i>
 
-<i><font color="#9A1900">*/</font></i>
-</tt></pre>
+<i><span style="color:#9A1900">*/</span></i>
+</pre>
 </body>
 </html>

--- a/exams/exam1-s08.cpp.html
+++ b/exams/exam1-s08.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/ibcm/ibcm-parse.cpp.html
+++ b/ibcm/ibcm-parse.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/ibcm/ibcm-parse.cpp.html
+++ b/ibcm/ibcm-parse.cpp.html
@@ -1,80 +1,134 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>ibcm-parse.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* A program that will quickly check if the file names passed in via</font></i>
-<i><font color="#9A1900"> * command line arguments look like IBCM files.  In particular, it</font></i>
-<i><font color="#9A1900"> * checks if the first four digits on each line are all hexadecimal</font></i>
-<i><font color="#9A1900"> * digits.  It does not program validity checking beyond this.  It is</font></i>
-<i><font color="#9A1900"> * useful to tell the students if, on submission, their programs will</font></i>
-<i><font color="#9A1900"> * parse correctly in an IBCM simulator.</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* A program that will quickly check if the file names passed in via</span></i>
+<i><span style="color:#9A1900"> * command line arguments look like IBCM files.  In particular, it</span></i>
+<i><span style="color:#9A1900"> * checks if the first four digits on each line are all hexadecimal</span></i>
+<i><span style="color:#9A1900"> * digits.  It does not program validity checking beyond this.  It is</span></i>
+<i><span style="color:#9A1900"> * useful to tell the students if, on submission, their programs will</span></i>
+<i><span style="color:#9A1900"> * parse correctly in an IBCM simulator.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;ctype.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;ctype.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">*</font>argv<font color="#990000">[])</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> line<font color="#990000">;</font>
-    <font color="#009900">int</font> linenum <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#009900">bool</font> allowComments <font color="#990000">=</font> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <i><font color="#9A1900">// make sure they gave some command-line parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">==</font> <font color="#993399">1</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": no input files"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> argc<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <i><font color="#9A1900">// a comment has a '//' as the first two characters on a line</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font><font color="#FF0000">"-allowcomments"</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            allowComments <font color="#990000">=</font> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">continue</font></b><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        <i><font color="#9A1900">// open the file</font></i>
-        <font color="#008080">ifstream</font> <b><font color="#000000">file</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">]);</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>file<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": no such file"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-        <i><font color="#9A1900">// read in the entire file...</font></i>
-        <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> file<font color="#990000">.</font><b><font color="#000000">good</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            <i><font color="#9A1900">// read in a line from the file</font></i>
-            <b><font color="#000000">getline</font></b> <font color="#990000">(</font>file<font color="#990000">,</font> line<font color="#990000">);</font>
-            linenum<font color="#990000">++;</font>
-            <i><font color="#9A1900">// is it the last line of the file?</font></i>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>line<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">==</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(!</font>file<font color="#990000">.</font><b><font color="#000000">good</font></b><font color="#990000">())</font> <font color="#990000">)</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <i><font color="#9A1900">// is it a comment?</font></i>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> allowComments <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>line<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&gt;=</font> <font color="#993399">2</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font>
-                    <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'/'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'/'</font><font color="#990000">)</font> <font color="#990000">)</font>
-                <b><font color="#0000FF">continue</font></b><font color="#990000">;</font>
-            <i><font color="#9A1900">// is the line too short?</font></i>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> line<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;</font> <font color="#993399">4</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-                cout <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" has too short a line on line number "</font> <font color="#990000">&lt;&lt;</font> linenum <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"("</font> <font color="#990000">&lt;&lt;</font> line<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">")"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-            <font color="#FF0000">}</font>
-            <i><font color="#9A1900">// are the first four digits hex characters?</font></i>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> j <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> j <font color="#990000">&lt;</font> <font color="#993399">4</font><font color="#990000">;</font> j<font color="#990000">++</font> <font color="#990000">)</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">isxdigit</font></b><font color="#990000">(</font>line<font color="#990000">[</font>j<font color="#990000">])</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" invalid hexadecimal digit on line "</font> <font color="#990000">&lt;&lt;</font> linenum <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" character "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">(</font>j<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-                <font color="#FF0000">}</font>
-        <font color="#FF0000">}</font>
-        <i><font color="#9A1900">// all done with this file!</font></i>
-        file<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span><span style="color:#009900">char</span><span style="color:#990000">*</span> name<span style="color:#990000">);</span>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">(</span>string<span style="color:#990000">&amp;</span> line<span style="color:#990000">);</span>
+
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">*</span>argv<span style="color:#990000">[])</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> line<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> linenum <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> allowComments <span style="color:#990000">=</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// make sure they gave some command-line parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": no input files"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> argc<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <i><span style="color:#9A1900">// print the help description</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-help"</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+
+        <i><span style="color:#9A1900">// a comment has a '#' as the first character on a line or</span></i>
+        <i><span style="color:#9A1900">// a comment has a '//' as the first two characters on a line</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span><span style="color:#FF0000">"-allowcomments"</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            allowComments <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">][</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'-'</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": no such argument"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+
+        <i><span style="color:#9A1900">// open the file</span></i>
+        <span style="color:#008080">ifstream</span> <b><span style="color:#000000">file</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">]);</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>file<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": no such file"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+        <i><span style="color:#9A1900">// read in the entire file...</span></i>
+        <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> file<span style="color:#990000">.</span><b><span style="color:#000000">good</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <i><span style="color:#9A1900">// read in a line from the file</span></i>
+            <b><span style="color:#000000">getline</span></b> <span style="color:#990000">(</span>file<span style="color:#990000">,</span> line<span style="color:#990000">);</span>
+            linenum<span style="color:#990000">++;</span>
+            <i><span style="color:#9A1900">// is it the last line of the file?</span></i>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">==</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(!</span>file<span style="color:#990000">.</span><b><span style="color:#000000">good</span></b><span style="color:#990000">())</span> <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <i><span style="color:#9A1900">// is the line empty or all whitespace?</span></i>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">(</span>line<span style="color:#990000">)</span> <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+            <i><span style="color:#9A1900">// is it a `//` comment?</span></i>
+            <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> allowComments <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&gt;=</span> <span style="color:#993399">2</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span>
+                    <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'/'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'/'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+            <i><span style="color:#9A1900">// is it a `#` comment?</span></i>
+            <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> allowComments <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span>
+                    <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'#'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+            <i><span style="color:#9A1900">// is the line too short?</span></i>
+            <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;</span> <span style="color:#993399">4</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                cout <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" has too short a line on line number "</span> <span style="color:#990000">&lt;&lt;</span> linenum <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"("</span> <span style="color:#990000">&lt;&lt;</span> line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">")"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+            <span style="color:#FF0000">}</span>
+            <i><span style="color:#9A1900">// are the first four digits hex characters?</span></i>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> j <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> j <span style="color:#990000">&lt;</span> <span style="color:#993399">4</span><span style="color:#990000">;</span> j<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">isxdigit</span></b><span style="color:#990000">(</span>line<span style="color:#990000">[</span>j<span style="color:#990000">])</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" invalid hexadecimal digit '"</span> <span style="color:#990000">&lt;&lt;</span> line<span style="color:#990000">[</span>j<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' on line "</span> <span style="color:#990000">&lt;&lt;</span> linenum <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" character "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">(</span>j<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+                <span style="color:#FF0000">}</span>
+        <span style="color:#FF0000">}</span>
+        <i><span style="color:#9A1900">// all done with this file!</span></i>
+        file<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+
+<span style="color:#009900">void</span> <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span><span style="color:#009900">char</span> <span style="color:#990000">*</span>name<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">bool</span> helpPrinted<span style="color:#990000">;</span> <i><span style="color:#9A1900">// Static values are initialized to 0 or 0-equivalent</span></i>
+    <b><span style="color:#0000FF">if</span></b><span style="color:#990000">(</span>helpPrinted<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
+
+    helpPrinted <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> name <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" [option] &lt;inputfile&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Options:"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-allowcomments]</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Allows file specified by &lt;inputfile&gt; to contain"</span> <span style="color:#990000">&lt;&lt;</span> endl
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t\t\t\t</span><span style="color:#FF0000">lines beginning with `//` and `#`."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-help]</span><span style="color:#CC33CC">\t\t\t</span><span style="color:#FF0000">Prints this help message."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+
+<span style="color:#009900">bool</span> <b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">(</span>string<span style="color:#990000">&amp;</span> line<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// is the line empty?</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> line<span style="color:#990000">.</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// does the line contain spaces or carriage returns?</span></i>
+    <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> line<span style="color:#990000">.</span><b><span style="color:#000000">find_first_not_of</span></b><span style="color:#990000">(</span><span style="color:#FF0000">' '</span><span style="color:#990000">)</span> <span style="color:#990000">!=</span> line<span style="color:#990000">.</span>npos <span style="color:#990000">&amp;&amp;</span>
+              line<span style="color:#990000">.</span><b><span style="color:#000000">find_first_not_of</span></b><span style="color:#990000">(</span><span style="color:#FF0000">'</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">'</span><span style="color:#990000">)</span> <span style="color:#990000">!=</span> line<span style="color:#990000">.</span>npos <span style="color:#990000">&amp;&amp;</span> 
+              line<span style="color:#990000">.</span><b><span style="color:#000000">find_first_not_of</span></b><span style="color:#990000">(</span><span style="color:#FF0000">'</span><span style="color:#CC33CC">\r</span><span style="color:#FF0000">'</span><span style="color:#990000">)</span> <span style="color:#990000">!=</span> line<span style="color:#990000">.</span>npos<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// otherwise, the line is basically empty</span></i>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/ibcm/ibcm-simulator.cpp.html
+++ b/ibcm/ibcm-simulator.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/ibcm/ibcm-simulator.cpp.html
+++ b/ibcm/ibcm-simulator.cpp.html
@@ -1,479 +1,493 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>ibcm-simulator.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* A program that will simulate an IBCM program, and it has a number</font></i>
-<i><font color="#9A1900"> * of command line switches that control its execution.  This program</font></i>
-<i><font color="#9A1900"> * is useful for automating the execution of a number of IBCM programs</font></i>
-<i><font color="#9A1900"> * without having to load each one into the web interface.  It will</font></i>
-<i><font color="#9A1900"> * also print out traces of the entire program execution, if desired.</font></i>
-<i><font color="#9A1900"> * Run with the `-help` flag to see the full list of options.</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* A program that will simulate an IBCM program, and it has a number</span></i>
+<i><span style="color:#9A1900"> * of command line switches that control its execution.  This program</span></i>
+<i><span style="color:#9A1900"> * is useful for automating the execution of a number of IBCM programs</span></i>
+<i><span style="color:#9A1900"> * without having to load each one into the web interface.  It will</span></i>
+<i><span style="color:#9A1900"> * also print out traces of the entire program execution, if desired.</span></i>
+<i><span style="color:#9A1900"> * Run with the `-help` flag to see the full list of options.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;assert.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
+<b><span style="color:#000080">#ifndef</span></b> IS_LITTLE_ENDIAN
+<b><span style="color:#000080">#ifndef</span></b> IS_BIG_ENDIAN
+<b><span style="color:#000080">#error</span></b> Must <span style="color:#008080">define</span> IS_LITTLE_ENDIAN <span style="color:#008080">or</span> IS_BIG_ENDIAN <span style="color:#008080">via</span> the `<span style="color:#990000">-</span>D` flag to the compiler
+<b><span style="color:#000080">#define</span></b> IS_LITTLE_ENDIAN
+<b><span style="color:#000080">#endif</span></b>
+<b><span style="color:#000080">#endif</span></b>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;assert.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdint.h&gt;</span>
 
-<font color="#009900">int</font> compState <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> simState <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> printState <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> printStats <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> dumpState <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> verbose <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">unsigned</font> <font color="#009900">int</font> numinst <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">int</font> printTicks <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#009900">unsigned</font> <font color="#009900">int</font> maxticks <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#008080">string</font> outputFile <font color="#990000">=</font> <font color="#FF0000">"ibcm.bin"</font><font color="#990000">;</font>
-<font color="#008080">string</font> inputFile<font color="#990000">;</font>
-<font color="#009900">unsigned</font> <font color="#009900">short</font> mem<font color="#990000">[</font><font color="#993399">4096</font><font color="#990000">];</font> <i><font color="#9A1900">// TODO: this should be made to work on systems where shorts are not 16 bits long</font></i>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">printHelp</font></b><font color="#990000">(</font><font color="#009900">char</font> <font color="#990000">*</font>name<font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">checkEndian</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">compileCode</font></b> <font color="#990000">(</font><font color="#008080">string</font> infilename<font color="#990000">,</font> <font color="#008080">string</font> outfilename<font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">simulateIBCM</font></b> <font color="#990000">();</font>
-<font color="#009900">void</font> <b><font color="#000000">readBinaryIBCMFile</font></b> <font color="#990000">(</font><font color="#008080">string</font> infilename<font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">dumpIBCMFile</font></b> <font color="#990000">();</font>
-<font color="#009900">char</font><font color="#990000">*</font> <b><font color="#000000">decodeIBCMInstruction</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">short</font> inst<font color="#990000">);</font>
+<span style="color:#009900">int</span> compState <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> simState <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> printState <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> printStats <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> dumpState <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> verbose <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> numinst <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span> printTicks <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> maxticks <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#008080">string</span> outputFile <span style="color:#990000">=</span> <span style="color:#FF0000">"ibcm.bin"</span><span style="color:#990000">;</span>
+<span style="color:#008080">string</span> inputFile<span style="color:#990000">;</span>
+<span style="color:#008080">uint16_t</span> mem<span style="color:#990000">[</span><span style="color:#993399">4096</span><span style="color:#990000">];</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">*</font>argv<font color="#990000">[])</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#000000">checkEndian</font></b><font color="#990000">();</font>
-    <b><font color="#000000">assert</font></b> <font color="#990000">(</font><b><font color="#0000FF">sizeof</font></b><font color="#990000">(</font><font color="#009900">short</font><font color="#990000">)</font> <font color="#990000">==</font> <font color="#993399">2</font><font color="#990000">);</font>
-    ios<font color="#990000">::</font><b><font color="#000000">sync_with_stdio</font></b><font color="#990000">();</font> <i><font color="#9A1900">// Synchronize C++ and C I/O subsystems!</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font>i <font color="#990000">&lt;</font> argc<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-comp"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            compState<font color="#990000">=</font><font color="#993399">1</font><font color="#990000">;</font>
-            inputFile<font color="#990000">=</font>argv<font color="#990000">[</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">];</font> <i><font color="#9A1900">// TODO: check that this doesn't go past the array bounds</font></i>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-sim"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            simState<font color="#990000">=</font><font color="#993399">1</font><font color="#990000">;</font>
-            inputFile<font color="#990000">=</font>argv<font color="#990000">[</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">];</font> <i><font color="#9A1900">// TODO: check that this doesn't go past the array bounds</font></i>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-dump"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            dumpState<font color="#990000">=</font><font color="#993399">1</font><font color="#990000">;</font>
-            inputFile<font color="#990000">=</font>argv<font color="#990000">[</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">];</font> <i><font color="#9A1900">// TODO: check that this doesn't go past the array bounds</font></i>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-o"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            outputFile<font color="#990000">=</font>argv<font color="#990000">[</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">];</font> <i><font color="#9A1900">// TODO: check that this doesn't go past the array bounds</font></i>
-            i<font color="#990000">++;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-verbose"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            verbose<font color="#990000">++;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-help"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#000000">printHelp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]);</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-print"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            printState <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-stats"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            printStats <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">],</font> <font color="#FF0000">"-maxticks"</font><font color="#990000">)==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-            maxticks <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>argv<font color="#990000">[++</font>i<font color="#990000">]);</font> <i><font color="#9A1900">// TODO: check the format of the int</font></i>
-        <font color="#FF0000">}</font>
-        i<font color="#990000">++;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">//Check for proper combination of params</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>simState<font color="#990000">==</font><font color="#993399">0</font> <font color="#990000">&amp;&amp;</font> compState<font color="#990000">==</font><font color="#993399">0</font> <font color="#990000">&amp;&amp;</font> inputFile<font color="#990000">==</font><font color="#FF0000">""</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        <i><font color="#9A1900">//cerr &lt;&lt; "No option specified..." &lt;&lt; endl;</font></i>
-        <b><font color="#000000">printHelp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]);</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> compState <font color="#990000">)</font>
-        <b><font color="#000000">compileCode</font></b> <font color="#990000">(</font>inputFile<font color="#990000">,</font> outputFile<font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> simState <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">readBinaryIBCMFile</font></b> <font color="#990000">(</font>inputFile<font color="#990000">);</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> printState <font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#000000">dumpIBCMFile</font></b> <font color="#990000">();</font>
-            cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        <b><font color="#000000">simulateIBCM</font></b><font color="#990000">();</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> printStats <font color="#990000">)</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Total of "</font> <font color="#990000">&lt;&lt;</font> numinst <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" instructions executed."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> printState <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">dumpIBCMFile</font></b> <font color="#990000">();</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> dumpState <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">readBinaryIBCMFile</font></b> <font color="#990000">(</font>inputFile<font color="#990000">);</font>
-        <b><font color="#000000">dumpIBCMFile</font></b> <font color="#990000">();</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span><span style="color:#009900">char</span> <span style="color:#990000">*</span>name<span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">checkEndian</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">compileCode</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> infilename<span style="color:#990000">,</span> <span style="color:#008080">string</span> outfilename<span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">simulateIBCM</span></b> <span style="color:#990000">();</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">readBinaryIBCMFile</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> infilename<span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">dumpIBCMFile</span></b> <span style="color:#990000">();</span>
+<span style="color:#009900">char</span><span style="color:#990000">*</span> <b><span style="color:#000000">decodeIBCMInstruction</span></b><span style="color:#990000">(</span><span style="color:#008080">uint16_t</span> inst<span style="color:#990000">);</span>
 
-<font color="#009900">void</font> <b><font color="#000000">printHelp</font></b><font color="#990000">(</font><font color="#009900">char</font> <font color="#990000">*</font>name<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Usage: "</font> <font color="#990000">&lt;&lt;</font> name <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" [option] ..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Options:"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-comp &lt;inputfile&gt;]</font><font color="#CC33CC">\t</font><font color="#FF0000">Signals the program to compile the IBCM file speicfied by &lt;inputfile&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-sim &lt;inputfile&gt;]</font><font color="#CC33CC">\t</font><font color="#FF0000">Signals the program to simulate the IBCM program specified by &lt;inputfile&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-o &lt;outfile&gt;]</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Specify the name of the outfile produced by compiling &lt;inputfile&gt;"</font> <font color="#990000">&lt;&lt;</font> endl
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t\t\t\t</font><font color="#FF0000">The defaut value for &lt;outfile&gt; is </font><font color="#CC33CC">\"</font><font color="#FF0000">ibcm.bin.</font><font color="#CC33CC">\"</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-verbose]</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Prints useful debugging information while compiling and emulating"</font> <font color="#990000">&lt;&lt;</font> endl
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t\t\t\t</font><font color="#FF0000">he specified IBCM program."</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" Specify twice for more output."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-dump &lt;inputfile&gt;]</font><font color="#CC33CC">\t</font><font color="#FF0000">Outputs a binary IBCM file in text format."</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" Also specify -verbose for decompilation."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-print]</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Prints a listing of the program before and after the simulation."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-maxticks &lt;n&gt;]</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Set the maximum number of ticks."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">[-stats]</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Prints stats of the executed program, including the number of ticks."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">*</span>argv<span style="color:#990000">[])</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#000000">checkEndian</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">assert</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">sizeof</span></b><span style="color:#990000">(</span><span style="color:#009900">short</span><span style="color:#990000">)</span> <span style="color:#990000">==</span> <span style="color:#993399">2</span><span style="color:#990000">);</span>
+    ios<span style="color:#990000">::</span><b><span style="color:#000000">sync_with_stdio</span></b><span style="color:#990000">();</span> <i><span style="color:#9A1900">// Synchronize C++ and C I/O subsystems!</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span>i <span style="color:#990000">&lt;</span> argc<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-comp"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            compState<span style="color:#990000">=</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+            inputFile<span style="color:#990000">=</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">];</span> <i><span style="color:#9A1900">// TODO: check that this doesn't go past the array bounds</span></i>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-sim"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            simState<span style="color:#990000">=</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+            inputFile<span style="color:#990000">=</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">];</span> <i><span style="color:#9A1900">// TODO: check that this doesn't go past the array bounds</span></i>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-dump"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            dumpState<span style="color:#990000">=</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+            inputFile<span style="color:#990000">=</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">];</span> <i><span style="color:#9A1900">// TODO: check that this doesn't go past the array bounds</span></i>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-o"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            outputFile<span style="color:#990000">=</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">];</span> <i><span style="color:#9A1900">// TODO: check that this doesn't go past the array bounds</span></i>
+            i<span style="color:#990000">++;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-verbose"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            verbose<span style="color:#990000">++;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-help"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-print"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            printState <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-stats"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            printStats <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">],</span> <span style="color:#FF0000">"-maxticks"</span><span style="color:#990000">)==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            maxticks <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[++</span>i<span style="color:#990000">]);</span> <i><span style="color:#9A1900">// TODO: check the format of the int</span></i>
+        <span style="color:#FF0000">}</span>
+        i<span style="color:#990000">++;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">//Check for proper combination of params</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>simState<span style="color:#990000">==</span><span style="color:#993399">0</span> <span style="color:#990000">&amp;&amp;</span> compState<span style="color:#990000">==</span><span style="color:#993399">0</span> <span style="color:#990000">&amp;&amp;</span> inputFile<span style="color:#990000">==</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <i><span style="color:#9A1900">//cerr &lt;&lt; "No option specified..." &lt;&lt; endl;</span></i>
+        <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> compState <span style="color:#990000">)</span>
+        <b><span style="color:#000000">compileCode</span></b> <span style="color:#990000">(</span>inputFile<span style="color:#990000">,</span> outputFile<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> simState <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">readBinaryIBCMFile</span></b> <span style="color:#990000">(</span>inputFile<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> printState <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#000000">dumpIBCMFile</span></b> <span style="color:#990000">();</span>
+            cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        <b><span style="color:#000000">simulateIBCM</span></b><span style="color:#990000">();</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> printStats <span style="color:#990000">)</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Total of "</span> <span style="color:#990000">&lt;&lt;</span> numinst <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" instructions executed."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> printState <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">dumpIBCMFile</span></b> <span style="color:#990000">();</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> dumpState <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">readBinaryIBCMFile</span></b> <span style="color:#990000">(</span>inputFile<span style="color:#990000">);</span>
+        <b><span style="color:#000000">dumpIBCMFile</span></b> <span style="color:#990000">();</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> <b><font color="#000000">checkEndian</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">static</font></b> <font color="#009900">int</font> firsttime <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>firsttime<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">union</font></b> <font color="#FF0000">{</font>
-            <font color="#009900">char</font> charword<font color="#990000">[</font><font color="#993399">4</font><font color="#990000">];</font>
-            <font color="#009900">unsigned</font> <font color="#009900">int</font> intword<font color="#990000">;</font>
-        <font color="#FF0000">}</font> check<font color="#990000">;</font>
-        check<font color="#990000">.</font>charword<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        check<font color="#990000">.</font>charword<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">2</font><font color="#990000">;</font>
-        check<font color="#990000">.</font>charword<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
-        check<font color="#990000">.</font>charword<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">4</font><font color="#990000">;</font>
-<b><font color="#000080">#ifdef</font></b> IS_BIG_ENDIAN
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>check<font color="#990000">.</font>intword <font color="#990000">!=</font> <font color="#993399">0x01020304</font><font color="#990000">)</font> <font color="#FF0000">{</font>  <i><font color="#9A1900">/* big */</font></i>
-            cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"ERROR: Host machine is not Big Endian.</font><font color="#CC33CC">\n</font><font color="#FF0000">Exiting."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">205</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#ifdef</font></b> IS_LITTLE_ENDIAN
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>check<font color="#990000">.</font>intword <font color="#990000">!=</font> <font color="#993399">0x04030201</font><font color="#990000">)</font> <font color="#FF0000">{</font>  <i><font color="#9A1900">/* little */</font></i>
-            cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"ERROR: Host machine is not Little Endian.</font><font color="#CC33CC">\n</font><font color="#FF0000">Exiting."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">206</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#error</font></b> ERROR<font color="#990000">:</font> must define <font color="#008080">either</font> IS_LITTLE_ENDIAN <font color="#008080">or</font> IS_BIG_ENDIAN
-<b><font color="#000080">#endif</font></b> <i><font color="#9A1900">// IS_LITTLE_ENDIAN</font></i>
-<b><font color="#000080">#endif</font></b> <i><font color="#9A1900">// IS_BIG_ENDIAN</font></i>
-        firsttime <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printHelp</span></b><span style="color:#990000">(</span><span style="color:#009900">char</span> <span style="color:#990000">*</span>name<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">bool</span> helpPrinted<span style="color:#990000">;</span> <i><span style="color:#9A1900">// Static values are initialized to 0 or 0-equivalent</span></i>
+    <b><span style="color:#0000FF">if</span></b><span style="color:#990000">(</span>helpPrinted<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">ishexdigit</font></b> <font color="#990000">(</font><font color="#009900">int</font> c<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <b><font color="#000000">isdigit</font></b><font color="#990000">(</font>c<font color="#990000">)</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>c <font color="#990000">&gt;=</font> <font color="#FF0000">'a'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>c <font color="#990000">&lt;=</font> <font color="#FF0000">'f'</font><font color="#990000">)</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>c <font color="#990000">&gt;=</font> <font color="#FF0000">'A'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>c <font color="#990000">&lt;=</font> <font color="#FF0000">'F'</font><font color="#990000">)</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+    helpPrinted <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">dumpIBCMFile</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// find last command to not print</font></i>
-    <font color="#009900">int</font> end<font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> end <font color="#990000">=</font> <font color="#993399">4095</font><font color="#990000">;</font> end <font color="#990000">&gt;=</font> <font color="#993399">0</font><font color="#990000">;</font> end<font color="#990000">--</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> mem<font color="#990000">[</font>end<font color="#990000">]</font> <font color="#990000">!=</font> <font color="#993399">0</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;=</font> end<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"%.4x</font><font color="#CC33CC">\t</font><font color="#FF0000">pc = %.4x</font><font color="#CC33CC">\t</font><font color="#FF0000">%s</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> mem<font color="#990000">[</font>i<font color="#990000">],</font> i<font color="#990000">,</font>
-                <b><font color="#000000">decodeIBCMInstruction</font></b><font color="#990000">(</font>mem<font color="#990000">[</font>i<font color="#990000">]));</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> name <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" [option] ..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Options:"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-comp &lt;inputfile&gt;]</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Signals the program to compile the IBCM file speicfied by &lt;inputfile&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-sim &lt;inputfile&gt;]</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Signals the program to simulate the IBCM program specified by &lt;inputfile&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-o &lt;outfile&gt;]</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Specify the name of the outfile produced by compiling &lt;inputfile&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t\t\t\t</span><span style="color:#FF0000">The defaut value for &lt;outfile&gt; is </span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">ibcm.bin.</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-verbose]</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Prints useful debugging information while compiling and emulating"</span> <span style="color:#990000">&lt;&lt;</span> endl
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t\t\t\t</span><span style="color:#FF0000">he specified IBCM program."</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" Specify twice for more output."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-dump &lt;inputfile&gt;]</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Outputs a binary IBCM file in text format."</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" Also specify -verbose for decompilation."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-print]</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Prints a listing of the program before and after the simulation."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-maxticks &lt;n&gt;]</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Set the maximum number of ticks."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-stats]</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Prints stats of the executed program, including the number of ticks."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">[-help]</span><span style="color:#CC33CC">\t\t\t</span><span style="color:#FF0000">Prints this help message."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
+<span style="color:#009900">void</span> <b><span style="color:#000000">checkEndian</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">int</span> firsttime <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>firsttime<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">union</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#009900">char</span> charword<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">];</span>
+            <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> intword<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> check<span style="color:#990000">;</span>
+        check<span style="color:#990000">.</span>charword<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        check<span style="color:#990000">.</span>charword<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">2</span><span style="color:#990000">;</span>
+        check<span style="color:#990000">.</span>charword<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
+        check<span style="color:#990000">.</span>charword<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">4</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#ifdef</span></b> IS_BIG_ENDIAN
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>check<span style="color:#990000">.</span>intword <span style="color:#990000">!=</span> <span style="color:#993399">0x01020304</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>  <i><span style="color:#9A1900">/* big */</span></i>
+            cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"ERROR: Host machine is not Big Endian.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">Exiting."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">205</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#ifdef</span></b> IS_LITTLE_ENDIAN
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>check<span style="color:#990000">.</span>intword <span style="color:#990000">!=</span> <span style="color:#993399">0x04030201</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>  <i><span style="color:#9A1900">/* little */</span></i>
+            cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"ERROR: Host machine is not Little Endian.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">Exiting."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">206</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#error</span></b> ERROR<span style="color:#990000">:</span> must define <span style="color:#008080">either</span> IS_LITTLE_ENDIAN <span style="color:#008080">or</span> IS_BIG_ENDIAN
+<b><span style="color:#000080">#endif</span></b> <i><span style="color:#9A1900">// IS_LITTLE_ENDIAN</span></i>
+<b><span style="color:#000080">#endif</span></b> <i><span style="color:#9A1900">// IS_BIG_ENDIAN</span></i>
+        firsttime <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> <b><font color="#000000">compileCode</font></b> <font color="#990000">(</font><font color="#008080">string</font> infilename<font color="#990000">,</font> <font color="#008080">string</font> outfilename<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> line<font color="#990000">;</font>
-    <font color="#009900">int</font> linenum <font color="#990000">=</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">,</font> outputlines <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// open input file</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">infile</font></b><font color="#990000">(</font>infilename<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>infile<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error: unable to open input file."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">200</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// open output file</font></i>
-    <font color="#008080">ofstream</font> <b><font color="#000000">outfile</font></b><font color="#990000">(</font>outfilename<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>outfile<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error: unable to open output file."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">201</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read input file, write to output file</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(!</font>infile<font color="#990000">.</font><b><font color="#000000">eof</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-        linenum<font color="#990000">++;</font>
-        <b><font color="#000000">getline</font></b> <font color="#990000">(</font>infile<font color="#990000">,</font>line<font color="#990000">);</font>
-        <i><font color="#9A1900">// skip blank lines</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> line<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">continue</font></b><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'/'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'/'</font><font color="#990000">)</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">continue</font></b><font color="#990000">;</font>
-        <i><font color="#9A1900">// sanity check</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">ishexdigit</font></b><font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">])</font> <font color="#990000">||</font> <font color="#990000">!</font><b><font color="#000000">ishexdigit</font></b><font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">])</font> <font color="#990000">||</font>
-                <font color="#990000">!</font><b><font color="#000000">ishexdigit</font></b><font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">])</font> <font color="#990000">||</font> <font color="#990000">!</font><b><font color="#000000">ishexdigit</font></b><font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">])</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error on line "</font> <font color="#990000">&lt;&lt;</font> linenum <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": invalid hex digits"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        line<font color="#990000">[</font><font color="#993399">4</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-        <font color="#009900">int</font> hex<font color="#990000">;</font>
-        <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>line<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">(),</font> <font color="#FF0000">"%x"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>hex<font color="#990000">);</font>
-<b><font color="#000080">#ifdef</font></b> IS_LITTLE_ENDIAN
-        <font color="#009900">char</font> g <font color="#990000">=</font> hex <font color="#990000">%</font> <font color="#993399">256</font><font color="#990000">;</font>
-        outfile<font color="#990000">.</font><b><font color="#000000">write</font></b><font color="#990000">(&amp;</font>g<font color="#990000">,</font><font color="#993399">1</font><font color="#990000">);</font>
-        g <font color="#990000">=</font> hex <font color="#990000">/</font> <font color="#993399">256</font><font color="#990000">;</font>
-        outfile<font color="#990000">.</font><b><font color="#000000">write</font></b><font color="#990000">(&amp;</font>g<font color="#990000">,</font><font color="#993399">1</font><font color="#990000">);</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#error</font></b> Not yet working <font color="#008080">for</font> non<font color="#990000">-</font>little<font color="#990000">-</font>endian machines
-<b><font color="#000080">#endif</font></b>
-        <i><font color="#9A1900">//cout &lt;&lt; line[0] &lt;&lt; line[1] &lt;&lt; line[2] &lt;&lt; line[3] &lt;&lt; endl;</font></i>
-        outputlines<font color="#990000">++;</font>
-    <font color="#FF0000">}</font>
-    infile<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// fill remaining space with 0's</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(;</font> outputlines <font color="#990000">&lt;</font> <font color="#993399">4096</font><font color="#990000">;</font> outputlines<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#009900">char</font> x <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-        <i><font color="#9A1900">//cout &lt;&lt; "0000" &lt;&lt; endl;</font></i>
-        outfile<font color="#990000">.</font><b><font color="#000000">write</font></b> <font color="#990000">(&amp;</font>x<font color="#990000">,</font><font color="#993399">1</font><font color="#990000">);</font>
-        outfile<font color="#990000">.</font><b><font color="#000000">write</font></b> <font color="#990000">(&amp;</font>x<font color="#990000">,</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    outfile<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">ishexdigit</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> c<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>c<span style="color:#990000">)</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>c <span style="color:#990000">&gt;=</span> <span style="color:#FF0000">'a'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>c <span style="color:#990000">&lt;=</span> <span style="color:#FF0000">'f'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>c <span style="color:#990000">&gt;=</span> <span style="color:#FF0000">'A'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>c <span style="color:#990000">&lt;=</span> <span style="color:#FF0000">'F'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> <b><font color="#000000">readBinaryIBCMFile</font></b> <font color="#990000">(</font><font color="#008080">string</font> infilename<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> cmdnum <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// open input file</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">infile</font></b><font color="#990000">(</font>infilename<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>infile<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error: unable to open input file."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">202</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// load up file into array</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">4096</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        mem<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#009900">char</font> buf<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">];</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(!</font>infile<font color="#990000">.</font><b><font color="#000000">eof</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-        infile<font color="#990000">.</font><b><font color="#000000">read</font></b><font color="#990000">(</font>buf<font color="#990000">,</font><font color="#993399">2</font><font color="#990000">);</font>
-<b><font color="#000080">#ifdef</font></b> IS_LITTLE_ENDIAN
-        mem<font color="#990000">[</font>cmdnum<font color="#990000">]</font> <font color="#990000">=</font> <font color="#990000">(</font>buf<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&amp;</font> <font color="#993399">0x000000ff</font><font color="#990000">)</font> <font color="#990000">*</font> <font color="#993399">256</font> <font color="#990000">+</font> <font color="#990000">(</font>buf<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&amp;</font> <font color="#993399">0x000000ff</font><font color="#990000">);</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#error</font></b> Not yet working <font color="#008080">for</font> non<font color="#990000">-</font>little<font color="#990000">-</font>endian machines
-<b><font color="#000080">#endif</font></b>
-        cmdnum<font color="#990000">++;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">//for ( int i = 0; i &lt; 4096; i++ ) printf ("%.4x\n", mem[i] &amp; 0x0000ffff);</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">dumpIBCMFile</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// find last command to not print</span></i>
+    <span style="color:#009900">int</span> end<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> end <span style="color:#990000">=</span> <span style="color:#993399">4095</span><span style="color:#990000">;</span> end <span style="color:#990000">&gt;=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> end<span style="color:#990000">--</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> mem<span style="color:#990000">[</span>end<span style="color:#990000">]</span> <span style="color:#990000">!=</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;=</span> end<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"%.4x</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">pc = %.4x</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">%s</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> mem<span style="color:#990000">[</span>i<span style="color:#990000">],</span> i<span style="color:#990000">,</span>
+                <b><span style="color:#000000">decodeIBCMInstruction</span></b><span style="color:#990000">(</span>mem<span style="color:#990000">[</span>i<span style="color:#990000">]));</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
 
 
+<span style="color:#009900">void</span> <b><span style="color:#000000">compileCode</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> infilename<span style="color:#990000">,</span> <span style="color:#008080">string</span> outfilename<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> line<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> linenum <span style="color:#990000">=</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">,</span> outputlines <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// open input file</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">infile</span></b><span style="color:#990000">(</span>infilename<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>infile<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error: unable to open input file."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">200</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// open output file</span></i>
+    <span style="color:#008080">ofstream</span> <b><span style="color:#000000">outfile</span></b><span style="color:#990000">(</span>outfilename<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>outfile<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error: unable to open output file."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">201</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read input file, write to output file</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(!</span>infile<span style="color:#990000">.</span><b><span style="color:#000000">eof</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+        linenum<span style="color:#990000">++;</span>
+        <b><span style="color:#000000">getline</span></b> <span style="color:#990000">(</span>infile<span style="color:#990000">,</span>line<span style="color:#990000">);</span>
+        <i><span style="color:#9A1900">// skip blank lines</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> line<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'/'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'/'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// sanity check</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">ishexdigit</span></b><span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">])</span> <span style="color:#990000">||</span> <span style="color:#990000">!</span><b><span style="color:#000000">ishexdigit</span></b><span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">])</span> <span style="color:#990000">||</span>
+                <span style="color:#990000">!</span><b><span style="color:#000000">ishexdigit</span></b><span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">])</span> <span style="color:#990000">||</span> <span style="color:#990000">!</span><b><span style="color:#000000">ishexdigit</span></b><span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">])</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error on line "</span> <span style="color:#990000">&lt;&lt;</span> linenum <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": invalid hex digits"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        line<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <span style="color:#009900">int</span> hex<span style="color:#990000">;</span>
+        <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>line<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">(),</span> <span style="color:#FF0000">"%x"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>hex<span style="color:#990000">);</span>
+<b><span style="color:#000080">#ifdef</span></b> IS_LITTLE_ENDIAN
+        <span style="color:#009900">char</span> g <span style="color:#990000">=</span> hex <span style="color:#990000">%</span> <span style="color:#993399">256</span><span style="color:#990000">;</span>
+        outfile<span style="color:#990000">.</span><b><span style="color:#000000">write</span></b><span style="color:#990000">(&amp;</span>g<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+        g <span style="color:#990000">=</span> hex <span style="color:#990000">/</span> <span style="color:#993399">256</span><span style="color:#990000">;</span>
+        outfile<span style="color:#990000">.</span><b><span style="color:#000000">write</span></b><span style="color:#990000">(&amp;</span>g<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#error</span></b> Not yet working <span style="color:#008080">for</span> non<span style="color:#990000">-</span>little<span style="color:#990000">-</span>endian machines
+<b><span style="color:#000080">#endif</span></b>
+        <i><span style="color:#9A1900">//cout &lt;&lt; line[0] &lt;&lt; line[1] &lt;&lt; line[2] &lt;&lt; line[3] &lt;&lt; endl;</span></i>
+        outputlines<span style="color:#990000">++;</span>
+    <span style="color:#FF0000">}</span>
+    infile<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// fill remaining space with 0's</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(;</span> outputlines <span style="color:#990000">&lt;</span> <span style="color:#993399">4096</span><span style="color:#990000">;</span> outputlines<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">char</span> x <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">//cout &lt;&lt; "0000" &lt;&lt; endl;</span></i>
+        outfile<span style="color:#990000">.</span><b><span style="color:#000000">write</span></b> <span style="color:#990000">(&amp;</span>x<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+        outfile<span style="color:#990000">.</span><b><span style="color:#000000">write</span></b> <span style="color:#990000">(&amp;</span>x<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    outfile<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
 
-<b><font color="#0000FF">union</font></b> ibcm_instruction <font color="#FF0000">{</font>
-    <font color="#009900">unsigned</font> <font color="#009900">short</font> buf<font color="#990000">;</font>
-<b><font color="#000080">#ifdef</font></b> IS_BIG_ENDIAN <i><font color="#9A1900">//The IBCM is big endian</font></i>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">char</font> high<font color="#990000">,</font> low<font color="#990000">;</font>
-    <font color="#FF0000">}</font> bytes<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">,</font> unused<font color="#990000">:</font><font color="#993399">12</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> halt<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">,</font> ioopt<font color="#990000">:</font><font color="#993399">2</font><font color="#990000">,</font> unused<font color="#990000">:</font><font color="#993399">10</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> io<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">,</font> shiftop<font color="#990000">:</font><font color="#993399">2</font><font color="#990000">,</font> unused<font color="#990000">:</font><font color="#993399">5</font><font color="#990000">,</font> shiftcount<font color="#990000">:</font><font color="#993399">5</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> shifts<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">,</font> address<font color="#990000">:</font><font color="#993399">12</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> others<font color="#990000">;</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#ifdef</font></b> IS_LITTLE_ENDIAN <i><font color="#9A1900">//The IBCM is little endian</font></i>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">char</font> low<font color="#990000">,</font> high<font color="#990000">;</font>
-    <font color="#FF0000">}</font> bytes<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> unused<font color="#990000">:</font><font color="#993399">12</font><font color="#990000">,</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> halt<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> unused<font color="#990000">:</font><font color="#993399">10</font><font color="#990000">,</font> ioopt<font color="#990000">:</font><font color="#993399">2</font><font color="#990000">,</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> io<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> shiftcount<font color="#990000">:</font><font color="#993399">5</font><font color="#990000">,</font> unused<font color="#990000">:</font><font color="#993399">5</font><font color="#990000">,</font> shiftop<font color="#990000">:</font><font color="#993399">2</font><font color="#990000">,</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> shifts<font color="#990000">;</font>
-    <b><font color="#0000FF">struct</font></b> <font color="#FF0000">{</font>
-        <font color="#009900">unsigned</font> <font color="#009900">int</font> address<font color="#990000">:</font><font color="#993399">12</font><font color="#990000">,</font> op<font color="#990000">:</font><font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> others<font color="#990000">;</font>
-<b><font color="#000080">#else</font></b>
-<b><font color="#000080">#error</font></b> Must <font color="#008080">define</font> BIG_ENDIAN <font color="#008080">or</font> LITTLE_ENDIAN
-<b><font color="#000080">#endif</font></b> <i><font color="#9A1900">// LITTLE_ENDIAN</font></i>
-<b><font color="#000080">#endif</font></b> <i><font color="#9A1900">// BIG_ENDIAN</font></i>
-<font color="#FF0000">}</font> ir<font color="#990000">,</font> ir2<font color="#990000">;</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">readBinaryIBCMFile</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> infilename<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> cmdnum <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// open input file</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">infile</span></b><span style="color:#990000">(</span>infilename<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>infile<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error: unable to open input file."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">202</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// load up file into array</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">4096</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        mem<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#009900">char</span> buf<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(!</span>infile<span style="color:#990000">.</span><b><span style="color:#000000">eof</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+        infile<span style="color:#990000">.</span><b><span style="color:#000000">read</span></b><span style="color:#990000">(</span>buf<span style="color:#990000">,</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+<b><span style="color:#000080">#ifdef</span></b> IS_LITTLE_ENDIAN
+        mem<span style="color:#990000">[</span>cmdnum<span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#990000">(</span>buf<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&amp;</span> <span style="color:#993399">0x000000ff</span><span style="color:#990000">)</span> <span style="color:#990000">*</span> <span style="color:#993399">256</span> <span style="color:#990000">+</span> <span style="color:#990000">(</span>buf<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&amp;</span> <span style="color:#993399">0x000000ff</span><span style="color:#990000">);</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#error</span></b> Not yet working <span style="color:#008080">for</span> non<span style="color:#990000">-</span>little<span style="color:#990000">-</span>endian machines
+<b><span style="color:#000080">#endif</span></b>
+        cmdnum<span style="color:#990000">++;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">//for ( int i = 0; i &lt; 4096; i++ ) printf ("%.4x\n", mem[i] &amp; 0x0000ffff);</span></i>
+<span style="color:#FF0000">}</span>
 
 
-<font color="#009900">char</font><font color="#990000">*</font> <b><font color="#000000">decodeIBCMInstruction</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">short</font> inst<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">static</font></b> <font color="#008080">string</font> instnames<font color="#990000">[]</font> <font color="#990000">=</font> <font color="#FF0000">{</font><font color="#FF0000">"halt"</font><font color="#990000">,</font> <font color="#FF0000">"I/O"</font><font color="#990000">,</font> <font color="#FF0000">"shifts"</font><font color="#990000">,</font> <font color="#FF0000">"load"</font><font color="#990000">,</font> <font color="#FF0000">"store"</font><font color="#990000">,</font> <font color="#FF0000">"add"</font><font color="#990000">,</font> <font color="#FF0000">"sub"</font><font color="#990000">,</font> <font color="#FF0000">"and"</font><font color="#990000">,</font>
-                                 <font color="#FF0000">"or"</font><font color="#990000">,</font> <font color="#FF0000">"xor"</font><font color="#990000">,</font> <font color="#FF0000">"not"</font><font color="#990000">,</font> <font color="#FF0000">"nop"</font><font color="#990000">,</font> <font color="#FF0000">"jmp"</font><font color="#990000">,</font> <font color="#FF0000">"jmpe"</font><font color="#990000">,</font> <font color="#FF0000">"jmpl"</font><font color="#990000">,</font> <font color="#FF0000">"brl"</font>
-                                <font color="#FF0000">}</font><font color="#990000">;</font>
-    <b><font color="#0000FF">static</font></b> <font color="#009900">char</font> buf<font color="#990000">[</font><font color="#993399">256</font><font color="#990000">],</font> buf2<font color="#990000">[</font><font color="#993399">8</font><font color="#990000">];</font>
-    ir2<font color="#990000">.</font>buf <font color="#990000">=</font> inst<font color="#990000">;</font>
-    <font color="#009900">int</font> op <font color="#990000">=</font> ir2<font color="#990000">.</font>others<font color="#990000">.</font>op<font color="#990000">;</font>
-    buf<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>op <font color="#990000">&lt;=</font> <font color="#993399">2</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>op <font color="#990000">==</font> <font color="#993399">10</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>op <font color="#990000">==</font> <font color="#993399">11</font><font color="#990000">)</font> <font color="#990000">)</font> <i><font color="#9A1900">// halt, not, nop, I/O, and shift</font></i>
-        <b><font color="#000000">strcpy</font></b> <font color="#990000">(</font>buf<font color="#990000">,</font> instnames<font color="#990000">[</font>op<font color="#990000">].</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> op <font color="#990000">&gt;=</font> <font color="#993399">3</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">strcpy</font></b> <font color="#990000">(</font>buf<font color="#990000">,</font> instnames<font color="#990000">[</font>ir2<font color="#990000">.</font>others<font color="#990000">.</font>op<font color="#990000">].</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-        <b><font color="#000000">strcat</font></b> <font color="#990000">(</font>buf<font color="#990000">,</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">);</font>
-        <b><font color="#000000">sprintf</font></b> <font color="#990000">(</font>buf2<font color="#990000">,</font> <font color="#FF0000">"%.3x"</font><font color="#990000">,</font> ir2<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">);</font>
-        <b><font color="#000000">strcat</font></b> <font color="#990000">(</font>buf<font color="#990000">,</font> buf2<font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> buf<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+
+<b><span style="color:#0000FF">union</span></b> ibcm_instruction <span style="color:#FF0000">{</span>
+    <span style="color:#008080">uint16_t</span> buf<span style="color:#990000">;</span>
+<b><span style="color:#000080">#ifdef</span></b> IS_BIG_ENDIAN <i><span style="color:#9A1900">//The IBCM is big endian</span></i>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">char</span> high<span style="color:#990000">,</span> low<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> bytes<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">,</span> unused<span style="color:#990000">:</span><span style="color:#993399">12</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> halt<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">,</span> ioopt<span style="color:#990000">:</span><span style="color:#993399">2</span><span style="color:#990000">,</span> unused<span style="color:#990000">:</span><span style="color:#993399">10</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> io<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">,</span> shiftop<span style="color:#990000">:</span><span style="color:#993399">2</span><span style="color:#990000">,</span> unused<span style="color:#990000">:</span><span style="color:#993399">5</span><span style="color:#990000">,</span> shiftcount<span style="color:#990000">:</span><span style="color:#993399">5</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> shifts<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">,</span> address<span style="color:#990000">:</span><span style="color:#993399">12</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> others<span style="color:#990000">;</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#ifdef</span></b> IS_LITTLE_ENDIAN <i><span style="color:#9A1900">//The IBCM is little endian</span></i>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">char</span> low<span style="color:#990000">,</span> high<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> bytes<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> unused<span style="color:#990000">:</span><span style="color:#993399">12</span><span style="color:#990000">,</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> halt<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> unused<span style="color:#990000">:</span><span style="color:#993399">10</span><span style="color:#990000">,</span> ioopt<span style="color:#990000">:</span><span style="color:#993399">2</span><span style="color:#990000">,</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> io<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> shiftcount<span style="color:#990000">:</span><span style="color:#993399">5</span><span style="color:#990000">,</span> unused<span style="color:#990000">:</span><span style="color:#993399">5</span><span style="color:#990000">,</span> shiftop<span style="color:#990000">:</span><span style="color:#993399">2</span><span style="color:#990000">,</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> shifts<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">struct</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> address<span style="color:#990000">:</span><span style="color:#993399">12</span><span style="color:#990000">,</span> op<span style="color:#990000">:</span><span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> others<span style="color:#990000">;</span>
+<b><span style="color:#000080">#else</span></b>
+<b><span style="color:#000080">#error</span></b> Must <span style="color:#008080">define</span> BIG_ENDIAN <span style="color:#008080">or</span> LITTLE_ENDIAN
+<b><span style="color:#000080">#endif</span></b> <i><span style="color:#9A1900">// LITTLE_ENDIAN</span></i>
+<b><span style="color:#000080">#endif</span></b> <i><span style="color:#9A1900">// BIG_ENDIAN</span></i>
+<span style="color:#FF0000">}</span> ir<span style="color:#990000">,</span> ir2<span style="color:#990000">;</span>
 
 
-<font color="#009900">void</font> <b><font color="#000000">simulateIBCM</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> acc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">,</font> pc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">,</font> incpc<font color="#990000">;</font>
-    <font color="#008080">string</font> buf<font color="#990000">;</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-        incpc <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        ir<font color="#990000">.</font>buf <font color="#990000">=</font> mem<font color="#990000">[</font>pc<font color="#990000">];</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">2</font> <font color="#990000">)</font>
-            <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">pc = %.3x: ir = %.4x, ibcm = '%s'</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>buf<font color="#990000">,</font> <b><font color="#000000">decodeIBCMInstruction</font></b><font color="#990000">(</font>ir<font color="#990000">.</font>buf<font color="#990000">));</font>
-        numinst<font color="#990000">++;</font>
-        <b><font color="#0000FF">switch</font></b> <font color="#990000">(</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>op<font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">0</font><font color="#990000">:</font> <i><font color="#9A1900">// halt</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: halt</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">1</font><font color="#990000">:</font> <i><font color="#9A1900">// I/O</font></i>
-                <b><font color="#0000FF">switch</font></b> <font color="#990000">(</font> ir<font color="#990000">.</font>io<font color="#990000">.</font>ioopt <font color="#990000">)</font> <font color="#FF0000">{</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">0</font><font color="#990000">:</font> <i><font color="#9A1900">// read hex</font></i>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: I/O: read hex</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Enter hex input: "</font><font color="#990000">);</font>
-                        <b><font color="#000000">fflush</font></b> <font color="#990000">(</font>stdout<font color="#990000">);</font>
-                        cin <font color="#990000">&gt;&gt;</font> buf<font color="#990000">;</font>
-                        <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>buf<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">(),</font> <font color="#FF0000">"%x"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>acc<font color="#990000">);</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">1</font><font color="#990000">:</font> <i><font color="#9A1900">// read ascii</font></i>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: I/O: read ascii</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Enter ascii input: "</font><font color="#990000">);</font>
-                        <b><font color="#000000">fflush</font></b> <font color="#990000">(</font>stdout<font color="#990000">);</font>
-                        cin <font color="#990000">&gt;&gt;</font> buf<font color="#990000">;</font>
-                        acc <font color="#990000">=</font> buf<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">];</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">2</font><font color="#990000">:</font> <i><font color="#9A1900">// write hex</font></i>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: I/O: write hex</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Hex output: "</font><font color="#990000">);</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"%.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> acc<font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">3</font><font color="#990000">:</font> <i><font color="#9A1900">// write ascii</font></i>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: I/O: write ascii</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Ascii output: "</font><font color="#990000">);</font>
-                        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"%c</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> acc <font color="#990000">&amp;</font> <font color="#993399">0xff</font><font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">2</font><font color="#990000">:</font> <i><font color="#9A1900">// shifts</font></i>
-                <b><font color="#0000FF">switch</font></b> <font color="#990000">(</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftop <font color="#990000">)</font> <font color="#FF0000">{</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">0</font><font color="#990000">:</font> <i><font color="#9A1900">// shift left</font></i>
-                        acc <font color="#990000">=</font> <font color="#990000">(</font>acc <font color="#990000">&lt;&lt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">)</font> <font color="#990000">&amp;</font> <font color="#993399">0xffff</font><font color="#990000">;</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: shift left by %d; result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftop<font color="#990000">,</font> acc<font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">1</font><font color="#990000">:</font> <i><font color="#9A1900">// shift right</font></i>
-                        acc <font color="#990000">=</font> <font color="#990000">(</font>acc <font color="#990000">&gt;&gt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">)</font> <font color="#990000">&amp;</font> <font color="#990000">(</font><font color="#993399">0xffff</font> <font color="#990000">&gt;&gt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">);</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: shift right by %d; result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftop<font color="#990000">,</font> acc<font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">2</font><font color="#990000">:</font> <i><font color="#9A1900">// rotate left</font></i>
-                        acc <font color="#990000">=</font> <font color="#990000">((</font>acc <font color="#990000">&lt;&lt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">)</font> <font color="#990000">&amp;</font> <font color="#993399">0xffff</font><font color="#990000">)</font> <font color="#990000">|</font>
-                              <font color="#990000">((</font>acc <font color="#990000">&gt;&gt;</font> <font color="#990000">(</font><font color="#993399">16</font><font color="#990000">-</font>ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">))</font> <font color="#990000">&amp;</font> <font color="#990000">(</font><font color="#993399">0xffff</font> <font color="#990000">&gt;&gt;</font> <font color="#990000">(</font><font color="#993399">16</font><font color="#990000">-</font>ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">)));</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: rotate left by %d; result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftop<font color="#990000">,</font> acc<font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                    <b><font color="#0000FF">case</font></b> <font color="#993399">3</font><font color="#990000">:</font> <i><font color="#9A1900">// rotate right</font></i>
-                        acc <font color="#990000">=</font> <font color="#990000">((</font>acc <font color="#990000">&gt;&gt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">)</font> <font color="#990000">&amp;</font> <font color="#990000">(</font><font color="#993399">0xffff</font> <font color="#990000">&gt;&gt;</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">))</font> <font color="#990000">|</font>
-                              <font color="#990000">((</font>acc <font color="#990000">&lt;&lt;</font> <font color="#990000">(</font><font color="#993399">16</font><font color="#990000">-</font>ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftcount<font color="#990000">))</font> <font color="#990000">&amp;</font> <font color="#993399">0xffff</font><font color="#990000">);</font>
-                        acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: rotate right by %d; result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>shifts<font color="#990000">.</font>shiftop<font color="#990000">,</font> acc<font color="#990000">);</font>
-                        <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">3</font><font color="#990000">:</font> <i><font color="#9A1900">// load</font></i>
-                acc <font color="#990000">=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: load result (@ %.3x) is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">4</font><font color="#990000">:</font> <i><font color="#9A1900">// store</font></i>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">]</font> <font color="#990000">=</font> acc<font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: store result (@ %.3x) is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">,</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">]);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">5</font><font color="#990000">:</font> <i><font color="#9A1900">// add</font></i>
-                acc <font color="#990000">+=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: add result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">6</font><font color="#990000">:</font> <i><font color="#9A1900">// sub</font></i>
-                acc <font color="#990000">-=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: sub result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">7</font><font color="#990000">:</font> <i><font color="#9A1900">// and</font></i>
-                acc <font color="#990000">&amp;=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: and result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">8</font><font color="#990000">:</font> <i><font color="#9A1900">// or</font></i>
-                acc <font color="#990000">|=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: or result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">9</font><font color="#990000">:</font> <i><font color="#9A1900">// xor</font></i>
-                acc <font color="#990000">^=</font> mem<font color="#990000">[</font>ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">];</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: xor result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">10</font><font color="#990000">:</font> <i><font color="#9A1900">// not</font></i>
-                acc <font color="#990000">=</font> <font color="#990000">~</font>acc<font color="#990000">;</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: not result is %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">11</font><font color="#990000">:</font> <i><font color="#9A1900">// nop</font></i>
-                <i><font color="#9A1900">// do nothing</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x:  nop</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">12</font><font color="#990000">:</font> <i><font color="#9A1900">// jmp</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: jmp to %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">);</font>
-                pc <font color="#990000">=</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">;</font>
-                incpc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">13</font><font color="#990000">:</font> <i><font color="#9A1900">// jmpe</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: jmpe to %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">);</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>acc <font color="#990000">&amp;</font> <font color="#993399">0x0000ffff</font><font color="#990000">)</font> <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-                    pc <font color="#990000">=</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">;</font>
-                    incpc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">14</font><font color="#990000">:</font> <i><font color="#9A1900">// jmpl</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: jmpl to %.3x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">);</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>acc <font color="#990000">&amp;</font> <font color="#993399">0x00008000</font><font color="#990000">)</font> <font color="#990000">!=</font> <font color="#993399">0</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-                    pc <font color="#990000">=</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">;</font>
-                    incpc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">15</font><font color="#990000">:</font> <i><font color="#9A1900">// brl</font></i>
-                acc <font color="#990000">=</font> pc<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">;</font>
-                acc <font color="#990000">&amp;=</font> <font color="#993399">0x0000ffff</font><font color="#990000">;</font>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> verbose <font color="#990000">&gt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"pc = %.3x: brl from %.3x to %.4x</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> pc<font color="#990000">,</font> acc<font color="#990000">,</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">);</font>
-                pc <font color="#990000">=</font> ir<font color="#990000">.</font>others<font color="#990000">.</font>address<font color="#990000">;</font>
-                incpc <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> incpc <font color="#990000">)</font>
-            pc<font color="#990000">++;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> maxticks <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>numinst <font color="#990000">&gt;=</font> maxticks<font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Simulation reached the maximum number of "</font> <font color="#990000">&lt;&lt;</font> maxticks <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" instructions to execute."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Simulation reached the maximum number of "</font> <font color="#990000">&lt;&lt;</font> maxticks <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" instructions to execute."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">char</span><span style="color:#990000">*</span> <b><span style="color:#000000">decodeIBCMInstruction</span></b><span style="color:#990000">(</span><span style="color:#008080">uint16_t</span> inst<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#008080">string</span> instnames<span style="color:#990000">[]</span> <span style="color:#990000">=</span> <span style="color:#FF0000">{</span><span style="color:#FF0000">"halt"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"I/O"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"shifts"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"load"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"store"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"add"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"sub"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"and"</span><span style="color:#990000">,</span>
+                                 <span style="color:#FF0000">"or"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"xor"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"not"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"nop"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"jmp"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"jmpe"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"jmpl"</span><span style="color:#990000">,</span> <span style="color:#FF0000">"brl"</span>
+                                <span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">char</span> buf<span style="color:#990000">[</span><span style="color:#993399">256</span><span style="color:#990000">],</span> buf2<span style="color:#990000">[</span><span style="color:#993399">8</span><span style="color:#990000">];</span>
+    ir2<span style="color:#990000">.</span>buf <span style="color:#990000">=</span> inst<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> op <span style="color:#990000">=</span> ir2<span style="color:#990000">.</span>others<span style="color:#990000">.</span>op<span style="color:#990000">;</span>
+    buf<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>op <span style="color:#990000">&lt;=</span> <span style="color:#993399">2</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>op <span style="color:#990000">==</span> <span style="color:#993399">10</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>op <span style="color:#990000">==</span> <span style="color:#993399">11</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// halt, not, nop, I/O, and shift</span></i>
+        <b><span style="color:#000000">strcpy</span></b> <span style="color:#990000">(</span>buf<span style="color:#990000">,</span> instnames<span style="color:#990000">[</span>op<span style="color:#990000">].</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> op <span style="color:#990000">&gt;=</span> <span style="color:#993399">3</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">strcpy</span></b> <span style="color:#990000">(</span>buf<span style="color:#990000">,</span> instnames<span style="color:#990000">[</span>ir2<span style="color:#990000">.</span>others<span style="color:#990000">.</span>op<span style="color:#990000">].</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+        <b><span style="color:#000000">strcat</span></b> <span style="color:#990000">(</span>buf<span style="color:#990000">,</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+        <b><span style="color:#000000">sprintf</span></b> <span style="color:#990000">(</span>buf2<span style="color:#990000">,</span> <span style="color:#FF0000">"%.3x"</span><span style="color:#990000">,</span> ir2<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">);</span>
+        <b><span style="color:#000000">strcat</span></b> <span style="color:#990000">(</span>buf<span style="color:#990000">,</span> buf2<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> buf<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+
+
+<span style="color:#009900">void</span> <b><span style="color:#000000">simulateIBCM</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> acc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">,</span> pc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">,</span> incpc<span style="color:#990000">;</span>
+    <span style="color:#008080">string</span> buf<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+        incpc <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        ir<span style="color:#990000">.</span>buf <span style="color:#990000">=</span> mem<span style="color:#990000">[</span>pc<span style="color:#990000">];</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span>
+            <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">pc = %.3x: ir = %.4x, ibcm = '%s'</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>buf<span style="color:#990000">,</span> <b><span style="color:#000000">decodeIBCMInstruction</span></b><span style="color:#990000">(</span>ir<span style="color:#990000">.</span>buf<span style="color:#990000">));</span>
+        numinst<span style="color:#990000">++;</span>
+        <b><span style="color:#0000FF">switch</span></b> <span style="color:#990000">(</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>op<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">0</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// halt</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: halt</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">1</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// I/O</span></i>
+                <b><span style="color:#0000FF">switch</span></b> <span style="color:#990000">(</span> ir<span style="color:#990000">.</span>io<span style="color:#990000">.</span>ioopt <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">0</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// read hex</span></i>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: I/O: read hex</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Enter hex input: "</span><span style="color:#990000">);</span>
+                        <b><span style="color:#000000">fflush</span></b> <span style="color:#990000">(</span>stdout<span style="color:#990000">);</span>
+                        cin <span style="color:#990000">&gt;&gt;</span> buf<span style="color:#990000">;</span>
+                        <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>buf<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">(),</span> <span style="color:#FF0000">"%x"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>acc<span style="color:#990000">);</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">1</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// read ascii</span></i>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: I/O: read ascii</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Enter ascii input: "</span><span style="color:#990000">);</span>
+                        <b><span style="color:#000000">fflush</span></b> <span style="color:#990000">(</span>stdout<span style="color:#990000">);</span>
+                        cin <span style="color:#990000">&gt;&gt;</span> buf<span style="color:#990000">;</span>
+                        acc <span style="color:#990000">=</span> buf<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">];</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">2</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// write hex</span></i>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: I/O: write hex</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Hex output: "</span><span style="color:#990000">);</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"%.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">3</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// write ascii</span></i>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: I/O: write ascii</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Ascii output: "</span><span style="color:#990000">);</span>
+                        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"%c</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> acc <span style="color:#990000">&amp;</span> <span style="color:#993399">0xff</span><span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">2</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// shifts</span></i>
+                <b><span style="color:#0000FF">switch</span></b> <span style="color:#990000">(</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftop <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">0</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// shift left</span></i>
+                        acc <span style="color:#990000">=</span> <span style="color:#990000">(</span>acc <span style="color:#990000">&lt;&lt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">)</span> <span style="color:#990000">&amp;</span> <span style="color:#993399">0xffff</span><span style="color:#990000">;</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: shift left by %d; result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftop<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">1</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// shift right</span></i>
+                        acc <span style="color:#990000">=</span> <span style="color:#990000">(</span>acc <span style="color:#990000">&gt;&gt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">)</span> <span style="color:#990000">&amp;</span> <span style="color:#990000">(</span><span style="color:#993399">0xffff</span> <span style="color:#990000">&gt;&gt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">);</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: shift right by %d; result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftop<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">2</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// rotate left</span></i>
+                        acc <span style="color:#990000">=</span> <span style="color:#990000">((</span>acc <span style="color:#990000">&lt;&lt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">)</span> <span style="color:#990000">&amp;</span> <span style="color:#993399">0xffff</span><span style="color:#990000">)</span> <span style="color:#990000">|</span>
+                              <span style="color:#990000">((</span>acc <span style="color:#990000">&gt;&gt;</span> <span style="color:#990000">(</span><span style="color:#993399">16</span><span style="color:#990000">-</span>ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">))</span> <span style="color:#990000">&amp;</span> <span style="color:#990000">(</span><span style="color:#993399">0xffff</span> <span style="color:#990000">&gt;&gt;</span> <span style="color:#990000">(</span><span style="color:#993399">16</span><span style="color:#990000">-</span>ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">)));</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: rotate left by %d; result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftop<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">3</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// rotate right</span></i>
+                        acc <span style="color:#990000">=</span> <span style="color:#990000">((</span>acc <span style="color:#990000">&gt;&gt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">)</span> <span style="color:#990000">&amp;</span> <span style="color:#990000">(</span><span style="color:#993399">0xffff</span> <span style="color:#990000">&gt;&gt;</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">))</span> <span style="color:#990000">|</span>
+                              <span style="color:#990000">((</span>acc <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">(</span><span style="color:#993399">16</span><span style="color:#990000">-</span>ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftcount<span style="color:#990000">))</span> <span style="color:#990000">&amp;</span> <span style="color:#993399">0xffff</span><span style="color:#990000">);</span>
+                        acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: rotate right by %d; result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>shifts<span style="color:#990000">.</span>shiftop<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                        <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">3</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// load</span></i>
+                acc <span style="color:#990000">=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: load result (@ %.3x) is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">4</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// store</span></i>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">]</span> <span style="color:#990000">=</span> acc<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: store result (@ %.3x) is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">,</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">]);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">5</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// add</span></i>
+                acc <span style="color:#990000">+=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: add result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">6</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// sub</span></i>
+                acc <span style="color:#990000">-=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: sub result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">7</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// and</span></i>
+                acc <span style="color:#990000">&amp;=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: and result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">8</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// or</span></i>
+                acc <span style="color:#990000">|=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: or result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">9</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// xor</span></i>
+                acc <span style="color:#990000">^=</span> mem<span style="color:#990000">[</span>ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">];</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: xor result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">10</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// not</span></i>
+                acc <span style="color:#990000">=</span> <span style="color:#990000">~</span>acc<span style="color:#990000">;</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: not result is %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">11</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// nop</span></i>
+                <i><span style="color:#9A1900">// do nothing</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x:  nop</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">12</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// jmp</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: jmp to %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">);</span>
+                pc <span style="color:#990000">=</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">;</span>
+                incpc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">13</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// jmpe</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: jmpe to %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>acc <span style="color:#990000">&amp;</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">)</span> <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    pc <span style="color:#990000">=</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">;</span>
+                    incpc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">14</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// jmpl</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: jmpl to %.3x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>acc <span style="color:#990000">&amp;</span> <span style="color:#993399">0x00008000</span><span style="color:#990000">)</span> <span style="color:#990000">!=</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    pc <span style="color:#990000">=</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">;</span>
+                    incpc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">15</span><span style="color:#990000">:</span> <i><span style="color:#9A1900">// brl</span></i>
+                acc <span style="color:#990000">=</span> pc<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+                acc <span style="color:#990000">&amp;=</span> <span style="color:#993399">0x0000ffff</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> verbose <span style="color:#990000">&gt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"pc = %.3x: brl from %.3x to %.4x</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> pc<span style="color:#990000">,</span> acc<span style="color:#990000">,</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">);</span>
+                pc <span style="color:#990000">=</span> ir<span style="color:#990000">.</span>others<span style="color:#990000">.</span>address<span style="color:#990000">;</span>
+                incpc <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> incpc <span style="color:#990000">)</span>
+            pc<span style="color:#990000">++;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> maxticks <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>numinst <span style="color:#990000">&gt;=</span> maxticks<span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Simulation reached the maximum number of "</span> <span style="color:#990000">&lt;&lt;</span> maxticks <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" instructions to execute."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Simulation reached the maximum number of "</span> <span style="color:#990000">&lt;&lt;</span> maxticks <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" instructions to execute."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab01/lifecycle.cpp.html
+++ b/labs/lab01/lifecycle.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/lifecycle.cpp.html
+++ b/labs/lab01/lifecycle.cpp.html
@@ -1,140 +1,140 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>lifecycle.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// ---------------------------------------------------  class definition</font></i>
-<b><font color="#0000FF">class</font></b> <font color="#008080">MyObject</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#0000FF">static</font></b> <font color="#009900">int</font> numObjs<font color="#990000">;</font>
-    <b><font color="#000000">MyObject</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>n <font color="#990000">=</font> <font color="#FF0000">"--default--"</font><font color="#990000">);</font>      <i><font color="#9A1900">// default constructor</font></i>
-    <b><font color="#000000">MyObject</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> MyObject<font color="#990000">&amp;</font> rhs<font color="#990000">);</font>                <i><font color="#9A1900">// copy constructor</font></i>
-    <font color="#990000">~</font><b><font color="#000000">MyObject</font></b><font color="#990000">();</font>                                  <i><font color="#9A1900">// destructor</font></i>
-    <font color="#008080">string</font> <b><font color="#000000">getName</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">return</font></b> name<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#009900">void</font> <b><font color="#000000">setName</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#008080">string</font> newName<font color="#990000">)</font> <font color="#FF0000">{</font>
-        name <font color="#990000">=</font> newName<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">friend</font></b> ostream<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font>ostream<font color="#990000">&amp;</font> output<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> MyObject<font color="#990000">&amp;</font> obj<font color="#990000">);</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">string</font> name<font color="#990000">;</font>
-    <font color="#009900">int</font> id<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// ---------------------------------------------------  class definition</span></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">MyObject</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">int</span> numObjs<span style="color:#990000">;</span>
+    <b><span style="color:#000000">MyObject</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>n <span style="color:#990000">=</span> <span style="color:#FF0000">"--default--"</span><span style="color:#990000">);</span>      <i><span style="color:#9A1900">// default constructor</span></i>
+    <b><span style="color:#000000">MyObject</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> MyObject<span style="color:#990000">&amp;</span> rhs<span style="color:#990000">);</span>                <i><span style="color:#9A1900">// copy constructor</span></i>
+    <span style="color:#990000">~</span><b><span style="color:#000000">MyObject</span></b><span style="color:#990000">();</span>                                  <i><span style="color:#9A1900">// destructor</span></i>
+    <span style="color:#008080">string</span> <b><span style="color:#000000">getName</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">return</span></b> name<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">setName</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#008080">string</span> newName<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        name <span style="color:#990000">=</span> newName<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">friend</span></b> ostream<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span>ostream<span style="color:#990000">&amp;</span> output<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> MyObject<span style="color:#990000">&amp;</span> obj<span style="color:#990000">);</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">string</span> name<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> id<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// ------------------------------------------------  default constructor</font></i>
-MyObject<font color="#990000">::</font><b><font color="#000000">MyObject</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>n<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">name</font></b><font color="#990000">(</font>n<font color="#990000">)</font> <font color="#FF0000">{</font>
-    id <font color="#990000">=</font> <font color="#990000">++</font>numObjs<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"MyObject Default constructor: "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// ------------------------------------------------  default constructor</span></i>
+MyObject<span style="color:#990000">::</span><b><span style="color:#000000">MyObject</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>n<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">name</span></b><span style="color:#990000">(</span>n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    id <span style="color:#990000">=</span> <span style="color:#990000">++</span>numObjs<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"MyObject Default constructor: "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// ---------------------------------------------------  copy constructor</font></i>
-MyObject<font color="#990000">::</font><b><font color="#000000">MyObject</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> MyObject<font color="#990000">&amp;</font> rhs<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">name</font></b><font color="#990000">(</font>rhs<font color="#990000">.</font>name<font color="#990000">)</font> <font color="#FF0000">{</font>
-    id <font color="#990000">=</font> <font color="#990000">++</font>numObjs<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"MyObject Copy constructor:    "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// ---------------------------------------------------  copy constructor</span></i>
+MyObject<span style="color:#990000">::</span><b><span style="color:#000000">MyObject</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> MyObject<span style="color:#990000">&amp;</span> rhs<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">name</span></b><span style="color:#990000">(</span>rhs<span style="color:#990000">.</span>name<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    id <span style="color:#990000">=</span> <span style="color:#990000">++</span>numObjs<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"MyObject Copy constructor:    "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// --------------------------------------------------------  destructor</font></i>
-MyObject<font color="#990000">::~</font><b><font color="#000000">MyObject</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"MyObject Destructor:          "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// --------------------------------------------------------  destructor</span></i>
+MyObject<span style="color:#990000">::~</span><b><span style="color:#000000">MyObject</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"MyObject Destructor:          "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// ----------------------------------------------------------  print out</font></i>
-ostream<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font>ostream<font color="#990000">&amp;</font> output<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> MyObject<font color="#990000">&amp;</font> obj<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// output in format:  ("object name",id)</font></i>
-    <b><font color="#0000FF">return</font></b> output <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"(</font><font color="#CC33CC">\"</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> obj<font color="#990000">.</font>name <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\"</font><font color="#FF0000">,"</font> <font color="#990000">&lt;&lt;</font> obj<font color="#990000">.</font>id <font color="#990000">&lt;&lt;</font> <font color="#FF0000">")"</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// ----------------------------------------------------------  print out</span></i>
+ostream<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span>ostream<span style="color:#990000">&amp;</span> output<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> MyObject<span style="color:#990000">&amp;</span> obj<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// output in format:  ("object name",id)</span></i>
+    <b><span style="color:#0000FF">return</span></b> output <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"(</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> obj<span style="color:#990000">.</span>name <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">,"</span> <span style="color:#990000">&lt;&lt;</span> obj<span style="color:#990000">.</span>id <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">")"</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//---------------------------------------------------- static variables</font></i>
-<font color="#009900">int</font> MyObject<font color="#990000">::</font>numObjs <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>  <i><font color="#9A1900">// static member for all objects in class</font></i>
-<b><font color="#0000FF">static</font></b> <font color="#008080">MyObject</font> <b><font color="#000000">staticObj</font></b><font color="#990000">(</font><font color="#FF0000">"I'm static, outside of main"</font><font color="#990000">);</font>
+<i><span style="color:#9A1900">//---------------------------------------------------- static variables</span></i>
+<span style="color:#009900">int</span> MyObject<span style="color:#990000">::</span>numObjs <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>  <i><span style="color:#9A1900">// static member for all objects in class</span></i>
+<b><span style="color:#0000FF">static</span></b> <span style="color:#008080">MyObject</span> <b><span style="color:#000000">staticObj</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"I'm static, outside of main"</span><span style="color:#990000">);</span>
 
-<i><font color="#9A1900">//---------------------------------------------------------- prototypes</font></i>
-<font color="#008080">MyObject</font> <b><font color="#000000">getMaxMyObj</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o2<font color="#990000">);</font>
-<font color="#009900">int</font> <b><font color="#000000">cmpMyObj</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o2<font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">swapMyObj</font></b><font color="#990000">(</font>MyObject<font color="#990000">&amp;</font> o1<font color="#990000">,</font> MyObject<font color="#990000">&amp;</font> o2<font color="#990000">);</font>
+<i><span style="color:#9A1900">//---------------------------------------------------------- prototypes</span></i>
+<span style="color:#008080">MyObject</span> <b><span style="color:#000000">getMaxMyObj</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o2<span style="color:#990000">);</span>
+<span style="color:#009900">int</span> <b><span style="color:#000000">cmpMyObj</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o2<span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">swapMyObj</span></b><span style="color:#990000">(</span>MyObject<span style="color:#990000">&amp;</span> o1<span style="color:#990000">,</span> MyObject<span style="color:#990000">&amp;</span> o2<span style="color:#990000">);</span>
 
-<i><font color="#9A1900">//--------------------------------------------------------------- main</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--PART 1: Start of main--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--Defining o1, o2(Bob)--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">MyObject</font> o1<font color="#990000">,</font> <b><font color="#000000">o2</font></b><font color="#990000">(</font><font color="#FF0000">"Bob"</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--Defining o3(o2)--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">MyObject</font> <b><font color="#000000">o3</font></b><font color="#990000">(</font>o2<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--Defining array of 3 objects--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">MyObject</font> array<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">];</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">--PART 2: call function using call-by-value,"</font>
-         <font color="#FF0000">" return int--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">cmpMyObj</font></b><font color="#990000">(</font>o1<font color="#990000">,</font> o3<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--call function using call-by-value, return MyObject--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">getMaxMyObj</font></b><font color="#990000">(</font>o1<font color="#990000">,</font> o3<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">--PART 3:  o1: "</font> <font color="#990000">&lt;&lt;</font> o1 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  --entering new block, define new o1(Sally)--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <font color="#008080">MyObject</font> <b><font color="#000000">o1</font></b><font color="#990000">(</font><font color="#FF0000">"Sally"</font><font color="#990000">);</font>
-        o1<font color="#990000">.</font><b><font color="#000000">setName</font></b><font color="#990000">(</font><font color="#FF0000">"Sally"</font><font color="#990000">);</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  o1: "</font> <font color="#990000">&lt;&lt;</font> o1 <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">o2: "</font> <font color="#990000">&lt;&lt;</font> o2 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  --call swap function using call-by-reference--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">swapMyObj</font></b><font color="#990000">(</font>o1<font color="#990000">,</font> o2<font color="#990000">);</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  --were their values swapped?--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  o1: "</font> <font color="#990000">&lt;&lt;</font> o1 <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">o2: "</font> <font color="#990000">&lt;&lt;</font> o2 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  --leaving new block--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"o1: "</font> <font color="#990000">&lt;&lt;</font> o1 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">--PART 4: Define reference var.: { MyObject&amp; oref=o1; } --"</font>
-         <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">{</font>
-        MyObject<font color="#990000">&amp;</font> oref<font color="#990000">=</font>o1<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"-- was anything constructed/destructed?--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">--PART 5: new and delete--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--use new to create one object, then array of 2 objects--"</font>
-         <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">MyObject</font> <font color="#990000">*</font>op1 <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> MyObject<font color="#990000">,</font> <font color="#990000">*</font>op2 <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> MyObject<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">];</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--use delete to remove that one object--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> op1<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--use delete [] to remove that array of 2 objects --"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> <font color="#990000">[]</font> op2<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">--LAST PART:  End of main--"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//--------------------------------------------------------------- main</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--PART 1: Start of main--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--Defining o1, o2(Bob)--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">MyObject</span> o1<span style="color:#990000">,</span> <b><span style="color:#000000">o2</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Bob"</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--Defining o3(o2)--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">MyObject</span> <b><span style="color:#000000">o3</span></b><span style="color:#990000">(</span>o2<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--Defining array of 3 objects--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">MyObject</span> array<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">];</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">--PART 2: call function using call-by-value,"</span>
+         <span style="color:#FF0000">" return int--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">cmpMyObj</span></b><span style="color:#990000">(</span>o1<span style="color:#990000">,</span> o3<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--call function using call-by-value, return MyObject--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">getMaxMyObj</span></b><span style="color:#990000">(</span>o1<span style="color:#990000">,</span> o3<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">--PART 3:  o1: "</span> <span style="color:#990000">&lt;&lt;</span> o1 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  --entering new block, define new o1(Sally)--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <span style="color:#008080">MyObject</span> <b><span style="color:#000000">o1</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Sally"</span><span style="color:#990000">);</span>
+        o1<span style="color:#990000">.</span><b><span style="color:#000000">setName</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Sally"</span><span style="color:#990000">);</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  o1: "</span> <span style="color:#990000">&lt;&lt;</span> o1 <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">o2: "</span> <span style="color:#990000">&lt;&lt;</span> o2 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  --call swap function using call-by-reference--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">swapMyObj</span></b><span style="color:#990000">(</span>o1<span style="color:#990000">,</span> o2<span style="color:#990000">);</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  --were their values swapped?--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  o1: "</span> <span style="color:#990000">&lt;&lt;</span> o1 <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">o2: "</span> <span style="color:#990000">&lt;&lt;</span> o2 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  --leaving new block--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"o1: "</span> <span style="color:#990000">&lt;&lt;</span> o1 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">--PART 4: Define reference var.: { MyObject&amp; oref=o1; } --"</span>
+         <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">{</span>
+        MyObject<span style="color:#990000">&amp;</span> oref<span style="color:#990000">=</span>o1<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"-- was anything constructed/destructed?--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">--PART 5: new and delete--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--use new to create one object, then array of 2 objects--"</span>
+         <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">MyObject</span> <span style="color:#990000">*</span>op1 <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> MyObject<span style="color:#990000">,</span> <span style="color:#990000">*</span>op2 <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> MyObject<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">];</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--use delete to remove that one object--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> op1<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--use delete [] to remove that array of 2 objects --"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> <span style="color:#990000">[]</span> op2<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">--LAST PART:  End of main--"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//---------------------------------------------------------- cmpMyObj</font></i>
-<font color="#009900">int</font> <b><font color="#000000">cmpMyObj</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> name1 <font color="#990000">=</font> o1<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">(),</font> name2 <font color="#990000">=</font> o2<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> name1 <font color="#990000">==</font> name2 <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> name1 <font color="#990000">&lt;</font> name2 <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//---------------------------------------------------------- cmpMyObj</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">cmpMyObj</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> name1 <span style="color:#990000">=</span> o1<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">(),</span> name2 <span style="color:#990000">=</span> o2<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> name1 <span style="color:#990000">==</span> name2 <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> name1 <span style="color:#990000">&lt;</span> name2 <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//---------------------------------------------------------- getMaxMyObj</font></i>
-<font color="#008080">MyObject</font> <b><font color="#000000">getMaxMyObj</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#008080">MyObject</font> o2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> name1 <font color="#990000">=</font> o1<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">(),</font> name2 <font color="#990000">=</font> o2<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> name1 <font color="#990000">&gt;=</font> name2 <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> o1<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        <b><font color="#0000FF">return</font></b> o2<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//---------------------------------------------------------- getMaxMyObj</span></i>
+<span style="color:#008080">MyObject</span> <b><span style="color:#000000">getMaxMyObj</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">MyObject</span> o2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> name1 <span style="color:#990000">=</span> o1<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">(),</span> name2 <span style="color:#990000">=</span> o2<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> name1 <span style="color:#990000">&gt;=</span> name2 <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> o1<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        <b><span style="color:#0000FF">return</span></b> o2<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//---------------------------------------------------------- swapMyObj</font></i>
-<font color="#009900">void</font> <b><font color="#000000">swapMyObj</font></b><font color="#990000">(</font>MyObject<font color="#990000">&amp;</font> o1<font color="#990000">,</font> MyObject<font color="#990000">&amp;</font> o2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">MyObject</font> <b><font color="#000000">tmp</font></b><font color="#990000">(</font>o1<font color="#990000">);</font>
-    o1<font color="#990000">.</font><b><font color="#000000">setName</font></b><font color="#990000">(</font>o2<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">());</font>
-    o2<font color="#990000">.</font><b><font color="#000000">setName</font></b><font color="#990000">(</font>tmp<font color="#990000">.</font><b><font color="#000000">getName</font></b><font color="#990000">());</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">//---------------------------------------------------------- swapMyObj</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">swapMyObj</span></b><span style="color:#990000">(</span>MyObject<span style="color:#990000">&amp;</span> o1<span style="color:#990000">,</span> MyObject<span style="color:#990000">&amp;</span> o2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">MyObject</span> <b><span style="color:#000000">tmp</span></b><span style="color:#990000">(</span>o1<span style="color:#990000">);</span>
+    o1<span style="color:#990000">.</span><b><span style="color:#000000">setName</span></b><span style="color:#990000">(</span>o2<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">());</span>
+    o2<span style="color:#990000">.</span><b><span style="color:#000000">setName</span></b><span style="color:#990000">(</span>tmp<span style="color:#990000">.</span><b><span style="color:#000000">getName</span></b><span style="color:#990000">());</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab01/list.cpp.html
+++ b/labs/lab01/list.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/list.cpp.html
+++ b/labs/lab01/list.cpp.html
@@ -1,227 +1,227 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>list.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This file contains the main code to test the List class</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// Copyright (c) 1994, 2014 by Aaron Bloomfield</font></i>
-<i><font color="#9A1900">// Released under a CC BY-SA license</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// Revision history</font></i>
-<i><font color="#9A1900">// 05-07-94: Main code written</font></i>
-<i><font color="#9A1900">// 07-12-95: Bug updates</font></i>
-<i><font color="#9A1900">// 01-13-14: Modified to fit modern C++ compilers; reformatted</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This file contains the main code to test the List class</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// Copyright (c) 1994, 2014 by Aaron Bloomfield</span></i>
+<i><span style="color:#9A1900">// Released under a CC BY-SA license</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// Revision history</span></i>
+<i><span style="color:#9A1900">// 05-07-94: Main code written</span></i>
+<i><span style="color:#9A1900">// 07-12-95: Bug updates</span></i>
+<i><span style="color:#9A1900">// 01-13-14: Modified to fit modern C++ compilers; reformatted</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"list.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"list.h"</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"main(): started.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <font color="#008080">List&lt;int&gt;</font> <font color="#990000">*</font>l <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List<font color="#990000">&lt;</font><font color="#009900">int</font><font color="#990000">&gt;();</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>n<font color="#990000">,</font> i<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"main(): started.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <span style="color:#008080">List&lt;int&gt;</span> <span style="color:#990000">*</span>l <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List<span style="color:#990000">&lt;</span><span style="color:#009900">int</span><span style="color:#990000">&gt;();</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>n<span style="color:#990000">,</span> i<span style="color:#990000">;</span>
 
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    i <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">size</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size(): returned "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    i <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">element</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"element(): '"</font> <font color="#990000">&lt;&lt;</font> <font color="#993399">2</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' returned: "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b> <font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b> <font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    i <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">element</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"element(): '"</font> <font color="#990000">&lt;&lt;</font> <font color="#993399">2</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' returned: "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    i <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">element</font></b><font color="#990000">(</font><font color="#993399">4</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"element(): '"</font> <font color="#990000">&lt;&lt;</font> <font color="#993399">4</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' returned: "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    i <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size(): returned "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    i <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">element</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"element(): '"</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#993399">2</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' returned: "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b> <span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b> <span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    i <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">element</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"element(): '"</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#993399">2</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' returned: "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    i <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">element</span></b><span style="color:#990000">(</span><span style="color:#993399">4</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"element(): '"</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#993399">4</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' returned: "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b> <font color="#990000">(</font><font color="#993399">4</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b> <font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b> <span style="color:#990000">(</span><span style="color:#993399">4</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b> <span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    i <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">size</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"head(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">tail</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned NULL.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"tail(): returned "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size(): returned "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    i <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"head(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">tail</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned NULL.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"tail(): returned "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size(): returned "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">4</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push_head</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): list is empty, pop(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    n <font color="#990000">=</font> l<font color="#990000">-&gt;</font><b><font color="#000000">pop_head</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n <font color="#990000">==</font> NULL <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop_head(): list is empty, pop_head(): returning NULL</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"pop_head(): returning "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>n <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">clear</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"clear() called.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">4</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push_head</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): list is empty, pop(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    n <span style="color:#990000">=</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop_head</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop_head(): list is empty, pop_head(): returning NULL</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"pop_head(): returning "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>n <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">clear</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"clear() called.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"empty() called, returned "</font> <font color="#990000">&lt;&lt;</font> l<font color="#990000">-&gt;</font><b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">4</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><font color="#993399">6</font><font color="#990000">);</font>
-    l<font color="#990000">-&gt;</font><b><font color="#000000">display</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">delete</font></b> l<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"empty() called, returned "</span> <span style="color:#990000">&lt;&lt;</span> l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">4</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#993399">6</span><span style="color:#990000">);</span>
+    l<span style="color:#990000">-&gt;</span><b><span style="color:#000000">display</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">delete</span></b> l<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"main(): Goodbye.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"main(): Goodbye.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab01/list.h.html
+++ b/labs/lab01/list.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/list.h.html
+++ b/labs/lab01/list.h.html
@@ -1,279 +1,279 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>list.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* This file contains the List class, a singly linked unordered</font></i>
-<i><font color="#9A1900"> * templated list class.  struct List_Link is the data structure for</font></i>
-<i><font color="#9A1900"> * the list links.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Copyright (c) 1994, 2014 by Aaron Bloomfield</font></i>
-<i><font color="#9A1900"> * Released under a CC BY-SA license</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Revision history</font></i>
-<i><font color="#9A1900"> * 05-01-94: Main code written</font></i>
-<i><font color="#9A1900"> * 07-12-95: Bug updates</font></i>
-<i><font color="#9A1900"> * 01-13-14: Modified to fit modern C++ compilers; reformatted</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The tail of the list, in this implementation, is where the elements</font></i>
-<i><font color="#9A1900"> * are pushed (added) to and popped (removed) from.  For example:</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * head &lt;-- element &lt;-- element &lt;-- element &lt;-- element &lt;-- tail</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Methods:</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * List()                 Constructor, initilized an empty list</font></i>
-<i><font color="#9A1900"> * ~List()                Destructor, deletes the entire list</font></i>
-<i><font color="#9A1900"> * void push(T item);     Adds an item to the tail of the list</font></i>
-<i><font color="#9A1900"> * T* pop();              Removes an item from the tail of the list</font></i>
-<i><font color="#9A1900"> * int size();            Returns the size (length) of the list</font></i>
-<i><font color="#9A1900"> * void display();        Displays the list</font></i>
-<i><font color="#9A1900"> * int empty();           Returns 1 if the list is empty, 0 otherwise</font></i>
-<i><font color="#9A1900"> * void clear();          Clears (removes all elements from) the list</font></i>
-<i><font color="#9A1900"> * T* push_head();        Adds an item to the head of the list</font></i>
-<i><font color="#9A1900"> * T* tail();             Returns the tail data</font></i>
-<i><font color="#9A1900"> * T* head();             Returns the head data</font></i>
-<i><font color="#9A1900"> * int element (T item);  Returns 1 if T is in the list, 0 otherwise</font></i>
-<i><font color="#9A1900"> * pop_head (T item);     Removes an item from the head of the list</font></i>
-<i><font color="#9A1900"> * int remove (T item)    Removes item, returns 1 if sucessful, else 0</font></i>
-<i><font color="#9A1900"> * T* getptr (T item)     Returns the pointer to the parameter or NULL</font></i>
-<i><font color="#9A1900"> * void save(FILE *fp)    Saves the list- calls the objects methods</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The List class requires &lt;iostream&gt; to be included, as it uses</font></i>
-<i><font color="#9A1900"> * cout's in the display method.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * In order to use the List class, the data type T must either be a</font></i>
-<i><font color="#9A1900"> * standard type, or be a class with the '==' operator overloaded.  To</font></i>
-<i><font color="#9A1900"> * use the display method, the data type must also have the '&lt;&lt;'</font></i>
-<i><font color="#9A1900"> * operator overloaded.  Examples follow, using a Complex class with</font></i>
-<i><font color="#9A1900"> * two attributes, real and imag (both ints).  The operator overloads</font></i>
-<i><font color="#9A1900"> * need to be functions outside the class declaration, and the</font></i>
-<i><font color="#9A1900"> * attributes used need to be public.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *      class Complex {</font></i>
-<i><font color="#9A1900"> *        public:</font></i>
-<i><font color="#9A1900"> *          int real, imag;</font></i>
-<i><font color="#9A1900"> *          Complex () { real = imag = 0; }</font></i>
-<i><font color="#9A1900"> *          Complex (int r, int i) { real = r; imag = i; }</font></i>
-<i><font color="#9A1900"> *          ~Complex () { }</font></i>
-<i><font color="#9A1900"> *          void set (int r, int i) { real = r; imag = i; }</font></i>
-<i><font color="#9A1900"> *      };</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *      int operator == (Complex c1, Complex c2) {</font></i>
-<i><font color="#9A1900"> *        return ( (c1.real == c2.real) &amp;&amp; (c1.imag == c2.imag) );</font></i>
-<i><font color="#9A1900"> *      }</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *      int operator != (Complex c1, Complex c2) {</font></i>
-<i><font color="#9A1900"> *        return ( (c1.real != c2.real) || (c1.imag != c2.imag) );</font></i>
-<i><font color="#9A1900"> *      }</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> *      ostream&amp; operator &lt;&lt; (ostream&amp; out, Complex c) {</font></i>
-<i><font color="#9A1900"> *        return (out &lt;&lt; c.real &lt;&lt; " + " &lt;&lt; c.imag &lt;&lt; "i");</font></i>
-<i><font color="#9A1900"> *      }</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* This file contains the List class, a singly linked unordered</span></i>
+<i><span style="color:#9A1900"> * templated list class.  struct List_Link is the data structure for</span></i>
+<i><span style="color:#9A1900"> * the list links.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Copyright (c) 1994, 2014 by Aaron Bloomfield</span></i>
+<i><span style="color:#9A1900"> * Released under a CC BY-SA license</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Revision history</span></i>
+<i><span style="color:#9A1900"> * 05-01-94: Main code written</span></i>
+<i><span style="color:#9A1900"> * 07-12-95: Bug updates</span></i>
+<i><span style="color:#9A1900"> * 01-13-14: Modified to fit modern C++ compilers; reformatted</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The tail of the list, in this implementation, is where the elements</span></i>
+<i><span style="color:#9A1900"> * are pushed (added) to and popped (removed) from.  For example:</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * head &lt;-- element &lt;-- element &lt;-- element &lt;-- element &lt;-- tail</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Methods:</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * List()                 Constructor, initilized an empty list</span></i>
+<i><span style="color:#9A1900"> * ~List()                Destructor, deletes the entire list</span></i>
+<i><span style="color:#9A1900"> * void push(T item);     Adds an item to the tail of the list</span></i>
+<i><span style="color:#9A1900"> * T* pop();              Removes an item from the tail of the list</span></i>
+<i><span style="color:#9A1900"> * int size();            Returns the size (length) of the list</span></i>
+<i><span style="color:#9A1900"> * void display();        Displays the list</span></i>
+<i><span style="color:#9A1900"> * int empty();           Returns 1 if the list is empty, 0 otherwise</span></i>
+<i><span style="color:#9A1900"> * void clear();          Clears (removes all elements from) the list</span></i>
+<i><span style="color:#9A1900"> * T* push_head();        Adds an item to the head of the list</span></i>
+<i><span style="color:#9A1900"> * T* tail();             Returns the tail data</span></i>
+<i><span style="color:#9A1900"> * T* head();             Returns the head data</span></i>
+<i><span style="color:#9A1900"> * int element (T item);  Returns 1 if T is in the list, 0 otherwise</span></i>
+<i><span style="color:#9A1900"> * pop_head (T item);     Removes an item from the head of the list</span></i>
+<i><span style="color:#9A1900"> * int remove (T item)    Removes item, returns 1 if sucessful, else 0</span></i>
+<i><span style="color:#9A1900"> * T* getptr (T item)     Returns the pointer to the parameter or NULL</span></i>
+<i><span style="color:#9A1900"> * void save(FILE *fp)    Saves the list- calls the objects methods</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The List class requires &lt;iostream&gt; to be included, as it uses</span></i>
+<i><span style="color:#9A1900"> * cout's in the display method.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * In order to use the List class, the data type T must either be a</span></i>
+<i><span style="color:#9A1900"> * standard type, or be a class with the '==' operator overloaded.  To</span></i>
+<i><span style="color:#9A1900"> * use the display method, the data type must also have the '&lt;&lt;'</span></i>
+<i><span style="color:#9A1900"> * operator overloaded.  Examples follow, using a Complex class with</span></i>
+<i><span style="color:#9A1900"> * two attributes, real and imag (both ints).  The operator overloads</span></i>
+<i><span style="color:#9A1900"> * need to be functions outside the class declaration, and the</span></i>
+<i><span style="color:#9A1900"> * attributes used need to be public.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *      class Complex {</span></i>
+<i><span style="color:#9A1900"> *        public:</span></i>
+<i><span style="color:#9A1900"> *          int real, imag;</span></i>
+<i><span style="color:#9A1900"> *          Complex () { real = imag = 0; }</span></i>
+<i><span style="color:#9A1900"> *          Complex (int r, int i) { real = r; imag = i; }</span></i>
+<i><span style="color:#9A1900"> *          ~Complex () { }</span></i>
+<i><span style="color:#9A1900"> *          void set (int r, int i) { real = r; imag = i; }</span></i>
+<i><span style="color:#9A1900"> *      };</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *      int operator == (Complex c1, Complex c2) {</span></i>
+<i><span style="color:#9A1900"> *        return ( (c1.real == c2.real) &amp;&amp; (c1.imag == c2.imag) );</span></i>
+<i><span style="color:#9A1900"> *      }</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *      int operator != (Complex c1, Complex c2) {</span></i>
+<i><span style="color:#9A1900"> *        return ( (c1.real != c2.real) || (c1.imag != c2.imag) );</span></i>
+<i><span style="color:#9A1900"> *      }</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> *      ostream&amp; operator &lt;&lt; (ostream&amp; out, Complex c) {</span></i>
+<i><span style="color:#9A1900"> *        return (out &lt;&lt; c.real &lt;&lt; " + " &lt;&lt; c.imag &lt;&lt; "i");</span></i>
+<i><span style="color:#9A1900"> *      }</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-
-
-<b><font color="#0000FF">template</font></b> <font color="#990000">&lt;</font><b><font color="#0000FF">class</font></b> <font color="#008080">T</font><font color="#990000">&gt;</font>
-<b><font color="#0000FF">struct</font></b> <font color="#008080">List_Link</font> <font color="#FF0000">{</font>
-    <font color="#008080">T</font> <font color="#990000">*</font>data<font color="#990000">;</font>
-    <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>next<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
 
-<b><font color="#0000FF">template</font></b> <font color="#990000">&lt;</font><b><font color="#0000FF">class</font></b> <font color="#008080">T</font><font color="#990000">&gt;</font>
-<b><font color="#0000FF">class</font></b> <font color="#008080">List</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">Fsm</font><font color="#990000">;</font>
-    <i><font color="#9A1900">/*  head &lt;-- element &lt;-- element &lt;-- element &lt;-- element &lt;-- tail       */</font></i>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>_head<font color="#990000">,</font> <font color="#990000">*</font>_tail<font color="#990000">;</font>
+<b><span style="color:#0000FF">template</span></b> <span style="color:#990000">&lt;</span><b><span style="color:#0000FF">class</span></b> <span style="color:#008080">T</span><span style="color:#990000">&gt;</span>
+<b><span style="color:#0000FF">struct</span></b> <span style="color:#008080">List_Link</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">T</span> <span style="color:#990000">*</span>data<span style="color:#990000">;</span>
+    <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>next<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">List</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        _head <font color="#990000">=</font> _tail <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <i><font color="#9A1900">// cout &lt;&lt; "List Constructor called.\n"; }</font></i>
 
-    <font color="#990000">~</font><b><font color="#000000">List</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">clear</font></b><font color="#990000">();</font>
-    <font color="#FF0000">}</font>
+<b><span style="color:#0000FF">template</span></b> <span style="color:#990000">&lt;</span><b><span style="color:#0000FF">class</span></b> <span style="color:#008080">T</span><span style="color:#990000">&gt;</span>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">List</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Fsm</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">/*  head &lt;-- element &lt;-- element &lt;-- element &lt;-- element &lt;-- tail       */</span></i>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>_head<span style="color:#990000">,</span> <span style="color:#990000">*</span>_tail<span style="color:#990000">;</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">push</font></b><font color="#990000">(</font><font color="#008080">T</font> item<font color="#990000">)</font> <font color="#FF0000">{</font>
-<i><font color="#9A1900">//    cout &lt;&lt; "push(): called with element: " &lt;&lt; item &lt;&lt; endl;</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-            _head <font color="#990000">=</font> _tail <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List_Link<font color="#990000">&lt;</font>T<font color="#990000">&gt;;</font>
-            _head<font color="#990000">-&gt;</font>next <font color="#990000">=</font> NULL<font color="#990000">;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            temp <font color="#990000">=</font> _tail<font color="#990000">;</font>
-            _tail <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List_Link<font color="#990000">&lt;</font>T<font color="#990000">&gt;;</font>
-            _tail<font color="#990000">-&gt;</font>next <font color="#990000">=</font> temp<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        _tail<font color="#990000">-&gt;</font>data <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> T<font color="#990000">;</font>
-        <font color="#990000">*</font>_tail<font color="#990000">-&gt;</font>data <font color="#990000">=</font> item<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">List</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        _head <span style="color:#990000">=</span> _tail <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// cout &lt;&lt; "List Constructor called.\n"; }</span></i>
 
-    T<font color="#990000">*</font> <b><font color="#000000">pop</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            <font color="#008080">T</font> <font color="#990000">*</font>ret<font color="#990000">;</font>
-            temp <font color="#990000">=</font> _tail<font color="#990000">;</font>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> _tail <font color="#990000">)</font>
-                _tail <font color="#990000">=</font> _head <font color="#990000">=</font> NULL<font color="#990000">;</font>
-            <b><font color="#0000FF">else</font></b>
-                _tail <font color="#990000">=</font> _tail<font color="#990000">-&gt;</font>next<font color="#990000">;</font>
-            ret <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>data<font color="#990000">;</font>
-            <b><font color="#0000FF">delete</font></b> temp<font color="#990000">;</font>
-            <b><font color="#0000FF">return</font></b> ret<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#990000">~</span><b><span style="color:#000000">List</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">clear</span></b><span style="color:#990000">();</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">int</font> <b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _tail <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#009900">int</font> s <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp <font color="#990000">!=</font> NULL<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font>
-                <font color="#990000">++</font>s<font color="#990000">;</font>
-            <b><font color="#0000FF">return</font></b> s<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">push</span></b><span style="color:#990000">(</span><span style="color:#008080">T</span> item<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+<i><span style="color:#9A1900">//    cout &lt;&lt; "push(): called with element: " &lt;&lt; item &lt;&lt; endl;</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            _head <span style="color:#990000">=</span> _tail <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List_Link<span style="color:#990000">&lt;</span>T<span style="color:#990000">&gt;;</span>
+            _head<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span>
+            _tail <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List_Link<span style="color:#990000">&lt;</span>T<span style="color:#990000">&gt;;</span>
+            _tail<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        _tail<span style="color:#990000">-&gt;</span>data <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> T<span style="color:#990000">;</span>
+        <span style="color:#990000">*</span>_tail<span style="color:#990000">-&gt;</span>data <span style="color:#990000">=</span> item<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">save</font></b><font color="#990000">(</font><font color="#008080">FILE</font> <font color="#990000">*</font>fp<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{}</font>
-        <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp <font color="#990000">!=</font> NULL<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font>
-                temp<font color="#990000">-&gt;</font>data<font color="#990000">-&gt;</font><b><font color="#000000">save</font></b><font color="#990000">(</font>fp<font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    T<span style="color:#990000">*</span> <b><span style="color:#000000">pop</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            <span style="color:#008080">T</span> <span style="color:#990000">*</span>ret<span style="color:#990000">;</span>
+            temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> _tail <span style="color:#990000">)</span>
+                _tail <span style="color:#990000">=</span> _head <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">else</span></b>
+                _tail <span style="color:#990000">=</span> _tail<span style="color:#990000">-&gt;</span>next<span style="color:#990000">;</span>
+            ret <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>data<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">delete</span></b> temp<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">return</span></b> ret<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">display</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"List is empty.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-<i><font color="#9A1900">//      cout &lt;&lt; "display(): List is printed reverse: List is not empty.\n\t";</font></i>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp <font color="#990000">!=</font> NULL<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>temp<font color="#990000">-&gt;</font>data <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-            cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _tail <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#009900">int</span> s <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp <span style="color:#990000">!=</span> NULL<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span>
+                <span style="color:#990000">++</span>s<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">return</span></b> s<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">int</font> <b><font color="#000000">empty</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">return</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">);</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">save</span></b><span style="color:#990000">(</span><span style="color:#008080">FILE</span> <span style="color:#990000">*</span>fp<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{}</span>
+        <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp <span style="color:#990000">!=</span> NULL<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span>
+                temp<span style="color:#990000">-&gt;</span>data<span style="color:#990000">-&gt;</span><b><span style="color:#000000">save</span></b><span style="color:#990000">(</span>fp<span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    T<font color="#990000">*</font> <b><font color="#000000">tail</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _tail <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            <b><font color="#0000FF">return</font></b> _tail<font color="#990000">-&gt;</font>data<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">display</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"List is empty.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+<i><span style="color:#9A1900">//      cout &lt;&lt; "display(): List is printed reverse: List is not empty.\n\t";</span></i>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp <span style="color:#990000">!=</span> NULL<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">-&gt;</span>data <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+            cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    T<font color="#990000">*</font> <b><font color="#000000">head</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            <b><font color="#0000FF">return</font></b> _head<font color="#990000">-&gt;</font>data<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">empty</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">int</font> <b><font color="#000000">element</font></b> <font color="#990000">(</font><font color="#008080">T</font> item<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _tail <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp <font color="#990000">!=</font> NULL<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">*</font>temp<font color="#990000">-&gt;</font>data <font color="#990000">==</font> item <font color="#990000">)</font>
-                <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    T<span style="color:#990000">*</span> <b><span style="color:#000000">tail</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _tail <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            <b><span style="color:#0000FF">return</span></b> _tail<span style="color:#990000">-&gt;</span>data<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    T<font color="#990000">*</font> <b><font color="#000000">getptr</font></b> <font color="#990000">(</font><font color="#008080">T</font> item<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _tail <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp <font color="#990000">!=</font> NULL<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">*</font>temp<font color="#990000">-&gt;</font>data <font color="#990000">==</font> item <font color="#990000">)</font>
-                <b><font color="#0000FF">return</font></b> temp<font color="#990000">-&gt;</font>data<font color="#990000">;</font>
-        <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    T<span style="color:#990000">*</span> <b><span style="color:#000000">head</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            <b><span style="color:#0000FF">return</span></b> _head<span style="color:#990000">-&gt;</span>data<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">clear</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font><b><font color="#000000">pop</font></b><font color="#990000">()</font> <font color="#990000">!=</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font> <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">element</span></b> <span style="color:#990000">(</span><span style="color:#008080">T</span> item<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _tail <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp <span style="color:#990000">!=</span> NULL<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">*</span>temp<span style="color:#990000">-&gt;</span>data <span style="color:#990000">==</span> item <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">push_head</font></b> <font color="#990000">(</font><font color="#008080">T</font> item<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-            _head <font color="#990000">=</font> _tail <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List_Link<font color="#990000">&lt;</font>T<font color="#990000">&gt;;</font>
-            _head<font color="#990000">-&gt;</font>next <font color="#990000">=</font> NULL<font color="#990000">;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            temp <font color="#990000">=</font> _head<font color="#990000">;</font>
-            _head <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List_Link<font color="#990000">&lt;</font>T<font color="#990000">&gt;;</font>
-            temp<font color="#990000">-&gt;</font>next <font color="#990000">=</font> _head<font color="#990000">;</font>
-            _head<font color="#990000">-&gt;</font>next <font color="#990000">=</font> NULL<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        _head<font color="#990000">-&gt;</font>data <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> T<font color="#990000">;</font>
-        <font color="#990000">*</font>_head<font color="#990000">-&gt;</font>data <font color="#990000">=</font> item<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    T<span style="color:#990000">*</span> <b><span style="color:#000000">getptr</span></b> <span style="color:#990000">(</span><span style="color:#008080">T</span> item<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _tail <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp <span style="color:#990000">!=</span> NULL<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">*</span>temp<span style="color:#990000">-&gt;</span>data <span style="color:#990000">==</span> item <span style="color:#990000">)</span>
+                <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">-&gt;</span>data<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    T<font color="#990000">*</font> <b><font color="#000000">pop_head</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> NULL <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-            <font color="#008080">T</font> <font color="#990000">*</font>ret<font color="#990000">;</font>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">!=</font> _head<font color="#990000">;</font> temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font> <font color="#FF0000">{</font> <font color="#FF0000">}</font>
-            ret <font color="#990000">=</font> _head<font color="#990000">-&gt;</font>data<font color="#990000">;</font>
-            _head <font color="#990000">=</font> temp<font color="#990000">;</font>
-            temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next<font color="#990000">;</font>
-            <b><font color="#0000FF">delete</font></b> temp<font color="#990000">;</font>
-            _head<font color="#990000">-&gt;</font>next <font color="#990000">=</font> NULL<font color="#990000">;</font>
-            <b><font color="#0000FF">return</font></b> ret<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">clear</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span><b><span style="color:#000000">pop</span></b><span style="color:#990000">()</span> <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">int</font> <b><font color="#000000">remove</font></b> <font color="#990000">(</font><font color="#008080">T</font> item<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font><b><font color="#000000">element</font></b><font color="#990000">(</font>item<font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"remove(): element '"</font> <font color="#990000">&lt;&lt;</font> item <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' exists.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> _head <font color="#990000">==</font> _tail <font color="#990000">)</font> <font color="#FF0000">{</font>
-                <b><font color="#0000FF">delete</font></b> _head<font color="#990000">;</font>
-                _head <font color="#990000">=</font> _tail <font color="#990000">=</font> NULL<font color="#990000">;</font>
-            <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">*</font>_tail<font color="#990000">-&gt;</font>data <font color="#990000">==</font> item <font color="#990000">)</font> <font color="#FF0000">{</font>
-                <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">;</font>
-                temp <font color="#990000">=</font> _tail<font color="#990000">;</font>
-                _tail <font color="#990000">=</font> _tail<font color="#990000">-&gt;</font>next<font color="#990000">;</font>
-                <b><font color="#0000FF">delete</font></b> temp<font color="#990000">;</font>
-            <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                <font color="#008080">List_Link&lt;T&gt;</font> <font color="#990000">*</font>temp<font color="#990000">,</font> <font color="#990000">*</font>temp2<font color="#990000">;</font>
-                <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> temp <font color="#990000">=</font> _tail<font color="#990000">;</font>
-                        <font color="#990000">*</font>temp<font color="#990000">-&gt;</font>next<font color="#990000">-&gt;</font>data <font color="#990000">!=</font> item<font color="#990000">;</font>
-                        temp <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next <font color="#990000">)</font> <font color="#FF0000">{</font> <font color="#FF0000">}</font>
-                temp2 <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next<font color="#990000">;</font>
-                temp<font color="#990000">-&gt;</font>next <font color="#990000">=</font> temp<font color="#990000">-&gt;</font>next<font color="#990000">-&gt;</font>next<font color="#990000">;</font>
-                <b><font color="#0000FF">delete</font></b> temp2<font color="#990000">;</font>
-            <font color="#FF0000">}</font>
-            <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"remove(): element '"</font> <font color="#990000">&lt;&lt;</font> item <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' does not exist.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-            <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">push_head</span></b> <span style="color:#990000">(</span><span style="color:#008080">T</span> item<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            _head <span style="color:#990000">=</span> _tail <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List_Link<span style="color:#990000">&lt;</span>T<span style="color:#990000">&gt;;</span>
+            _head<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            temp <span style="color:#990000">=</span> _head<span style="color:#990000">;</span>
+            _head <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List_Link<span style="color:#990000">&lt;</span>T<span style="color:#990000">&gt;;</span>
+            temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> _head<span style="color:#990000">;</span>
+            _head<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        _head<span style="color:#990000">-&gt;</span>data <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> T<span style="color:#990000">;</span>
+        <span style="color:#990000">*</span>_head<span style="color:#990000">-&gt;</span>data <span style="color:#990000">=</span> item<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-<font color="#FF0000">}</font><font color="#990000">;</font>
-</tt></pre>
+    T<span style="color:#990000">*</span> <b><span style="color:#000000">pop_head</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+            <span style="color:#008080">T</span> <span style="color:#990000">*</span>ret<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">!=</span> _head<span style="color:#990000">;</span> temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">}</span>
+            ret <span style="color:#990000">=</span> _head<span style="color:#990000">-&gt;</span>data<span style="color:#990000">;</span>
+            _head <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+            temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">delete</span></b> temp<span style="color:#990000">;</span>
+            _head<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">return</span></b> ret<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+
+    <span style="color:#009900">int</span> <b><span style="color:#000000">remove</span></b> <span style="color:#990000">(</span><span style="color:#008080">T</span> item<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span><b><span style="color:#000000">element</span></b><span style="color:#990000">(</span>item<span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"remove(): element '"</span> <span style="color:#990000">&lt;&lt;</span> item <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' exists.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> _head <span style="color:#990000">==</span> _tail <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                <b><span style="color:#0000FF">delete</span></b> _head<span style="color:#990000">;</span>
+                _head <span style="color:#990000">=</span> _tail <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">*</span>_tail<span style="color:#990000">-&gt;</span>data <span style="color:#990000">==</span> item <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">;</span>
+                temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span>
+                _tail <span style="color:#990000">=</span> _tail<span style="color:#990000">-&gt;</span>next<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">delete</span></b> temp<span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                <span style="color:#008080">List_Link&lt;T&gt;</span> <span style="color:#990000">*</span>temp<span style="color:#990000">,</span> <span style="color:#990000">*</span>temp2<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> temp <span style="color:#990000">=</span> _tail<span style="color:#990000">;</span>
+                        <span style="color:#990000">*</span>temp<span style="color:#990000">-&gt;</span>next<span style="color:#990000">-&gt;</span>data <span style="color:#990000">!=</span> item<span style="color:#990000">;</span>
+                        temp <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">}</span>
+                temp2 <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next<span style="color:#990000">;</span>
+                temp<span style="color:#990000">-&gt;</span>next <span style="color:#990000">=</span> temp<span style="color:#990000">-&gt;</span>next<span style="color:#990000">-&gt;</span>next<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">delete</span></b> temp2<span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span>
+            <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"remove(): element '"</span> <span style="color:#990000">&lt;&lt;</span> item <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' does not exist.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+</pre>
 </body>
 </html>

--- a/labs/lab01/svtest.cpp.html
+++ b/labs/lab01/svtest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/svtest.cpp.html
+++ b/labs/lab01/svtest.cpp.html
@@ -1,55 +1,55 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>svtest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
 
-<i><font color="#9A1900">// svutil is a library to support string-vectors, i.e. vector&lt;string&gt;</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"svutil.h"</font>
+<i><span style="color:#9A1900">// svutil is a library to support string-vectors, i.e. vector&lt;string&gt;</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"svutil.h"</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Exercise the svutil library by defining some vector&lt;string&gt; objects and</font></i>
-<i><font color="#9A1900">// calling operations on them.</font></i>
+<i><span style="color:#9A1900">// Exercise the svutil library by defining some vector&lt;string&gt; objects and</span></i>
+<i><span style="color:#9A1900">// calling operations on them.</span></i>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">vector&lt;string&gt;</font> cs216Section1<font color="#990000">,</font> cs216Section2<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">vector&lt;string&gt;</span> cs216Section1<span style="color:#990000">,</span> cs216Section2<span style="color:#990000">;</span>
 
-    cs216Section1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"Alex"</font><font color="#990000">);</font>
-    cs216Section1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"Jodi"</font><font color="#990000">);</font>
-    cs216Section1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"Kit"</font><font color="#990000">);</font>
+    cs216Section1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Alex"</span><span style="color:#990000">);</span>
+    cs216Section1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Jodi"</span><span style="color:#990000">);</span>
+    cs216Section1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"Kit"</span><span style="color:#990000">);</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Section contains: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">svOutput</font></b><font color="#990000">(</font>cs216Section1<font color="#990000">);</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Section contains: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">svOutput</span></b><span style="color:#990000">(</span>cs216Section1<span style="color:#990000">);</span>
 
-    <font color="#008080">string</font> name<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter student name: "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> name<font color="#990000">;</font>
+    <span style="color:#008080">string</span> name<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter student name: "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> name<span style="color:#990000">;</span>
 
-    <font color="#009900">int</font> posn <font color="#990000">=</font> <b><font color="#000000">svFind</font></b><font color="#990000">(</font>cs216Section1<font color="#990000">,</font> name<font color="#990000">);</font>
+    <span style="color:#009900">int</span> posn <span style="color:#990000">=</span> <b><span style="color:#000000">svFind</span></b><span style="color:#990000">(</span>cs216Section1<span style="color:#990000">,</span> name<span style="color:#990000">);</span>
 
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> posn <font color="#990000">==</font> <font color="#990000">-</font><font color="#993399">1</font> <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Student not found in section."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Found student at index "</font> <font color="#990000">&lt;&lt;</font> posn <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <b><font color="#000000">svDeleteAt</font></b><font color="#990000">(</font>cs216Section1<font color="#990000">,</font> posn<font color="#990000">)</font> <font color="#990000">)</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Deleted student from section!"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> posn <span style="color:#990000">==</span> <span style="color:#990000">-</span><span style="color:#993399">1</span> <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Student not found in section."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Found student at index "</span> <span style="color:#990000">&lt;&lt;</span> posn <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <b><span style="color:#000000">svDeleteAt</span></b><span style="color:#990000">(</span>cs216Section1<span style="color:#990000">,</span> posn<span style="color:#990000">)</span> <span style="color:#990000">)</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Deleted student from section!"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Final section contents are:"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">svOutput</font></b><font color="#990000">(</font>cs216Section1<font color="#990000">);</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Final section contents are:"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">svOutput</span></b><span style="color:#990000">(</span>cs216Section1<span style="color:#990000">);</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
 
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab01/svutil.cpp.html
+++ b/labs/lab01/svutil.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/svutil.cpp.html
+++ b/labs/lab01/svutil.cpp.html
@@ -1,63 +1,63 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>svutil.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// utility functions for vectors of strings</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// utility functions for vectors of strings</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"svutil.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"svutil.h"</span>
 
-<i><font color="#9A1900">// prints the strings in the vector</font></i>
-<font color="#009900">void</font> <b><font color="#000000">svOutput</font></b> <font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect <font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> i<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> vect<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> <font color="#990000">++</font>i<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> vect<font color="#990000">.</font><b><font color="#000000">at</font></b><font color="#990000">(</font>i<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// prints the strings in the vector</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">svOutput</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> i<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">at</span></b><span style="color:#990000">(</span>i<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
 
-<i><font color="#9A1900">// finds a string in a vector and returns its index</font></i>
-<font color="#009900">int</font> <b><font color="#000000">svFind</font></b> <font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#008080">string</font> s<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> i<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> vect<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> <font color="#990000">++</font>i<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> vect<font color="#990000">.</font><b><font color="#000000">at</font></b><font color="#990000">(</font>i<font color="#990000">)</font> <font color="#990000">==</font> s <font color="#990000">)</font> <b><font color="#0000FF">return</font></b> i<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// finds a string in a vector and returns its index</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">svFind</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#008080">string</span> s<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> i<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">at</span></b><span style="color:#990000">(</span>i<span style="color:#990000">)</span> <span style="color:#990000">==</span> s <span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b> i<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// removes an element from the vector at index idx</font></i>
-<i><font color="#9A1900">// returns true if remove successful, otherwise false</font></i>
-<font color="#009900">bool</font> <b><font color="#000000">svDeleteAt</font></b> <font color="#990000">(</font> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#009900">int</font> idx <font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> lastIndex <font color="#990000">=</font> vect<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()-</font><font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> idx <font color="#990000">&lt;</font> <font color="#993399">0</font> <font color="#990000">||</font> idx <font color="#990000">&gt;</font> lastIndex <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> idx <font color="#990000">==</font> lastIndex <font color="#990000">)</font>
-        vect<font color="#990000">.</font><b><font color="#000000">pop_back</font></b><font color="#990000">();</font>
-    <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        <font color="#008080">string</font> temp <font color="#990000">=</font> vect<font color="#990000">.</font><b><font color="#000000">at</font></b><font color="#990000">(</font>lastIndex<font color="#990000">);</font>
-        vect<font color="#990000">.</font><b><font color="#000000">pop_back</font></b><font color="#990000">();</font>
-        vect<font color="#990000">.</font><b><font color="#000000">at</font></b><font color="#990000">(</font>idx<font color="#990000">)</font> <font color="#990000">=</font> temp<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// removes an element from the vector at index idx</span></i>
+<i><span style="color:#9A1900">// returns true if remove successful, otherwise false</span></i>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">svDeleteAt</span></b> <span style="color:#990000">(</span> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#009900">int</span> idx <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> lastIndex <span style="color:#990000">=</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> idx <span style="color:#990000">&lt;</span> <span style="color:#993399">0</span> <span style="color:#990000">||</span> idx <span style="color:#990000">&gt;</span> lastIndex <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> idx <span style="color:#990000">==</span> lastIndex <span style="color:#990000">)</span>
+        vect<span style="color:#990000">.</span><b><span style="color:#000000">pop_back</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">string</span> temp <span style="color:#990000">=</span> vect<span style="color:#990000">.</span><b><span style="color:#000000">at</span></b><span style="color:#990000">(</span>lastIndex<span style="color:#990000">);</span>
+        vect<span style="color:#990000">.</span><b><span style="color:#000000">pop_back</span></b><span style="color:#990000">();</span>
+        vect<span style="color:#990000">.</span><b><span style="color:#000000">at</span></b><span style="color:#990000">(</span>idx<span style="color:#990000">)</span> <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// sorts a vector of string in ascending order</font></i>
-<font color="#009900">void</font> <b><font color="#000000">svSort</font></b> <font color="#990000">(</font> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect <font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// not implemented yet</font></i>
-    <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// sorts a vector of string in ascending order</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">svSort</span></b> <span style="color:#990000">(</span> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// not implemented yet</span></i>
+    <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// return the index of the largest string in range index start to end</font></i>
-<font color="#009900">int</font> <b><font color="#000000">svFindMax</font></b><font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#009900">int</font> start<font color="#990000">,</font> <font color="#009900">int</font> end <font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// not implemented yet</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// return the index of the largest string in range index start to end</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">svFindMax</span></b><span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#009900">int</span> start<span style="color:#990000">,</span> <span style="color:#009900">int</span> end <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// not implemented yet</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-</tt></pre>
+</pre>
 </body>
 </html>

--- a/labs/lab01/svutil.h.html
+++ b/labs/lab01/svutil.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab01/svutil.h.html
+++ b/labs/lab01/svutil.h.html
@@ -1,42 +1,42 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>svutil.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// utility functions for vectors of string</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// utility functions for vectors of string</span></i>
 
-<b><font color="#000080">#ifndef</font></b> SVUTIL_H
-<b><font color="#000080">#define</font></b> SVUTIL_H
+<b><span style="color:#000080">#ifndef</span></b> SVUTIL_H
+<b><span style="color:#000080">#define</span></b> SVUTIL_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;vector&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;vector&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// prints the strings in the vector</font></i>
-<font color="#009900">void</font> <b><font color="#000000">svOutput</font></b> <font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect <font color="#990000">);</font>
+<i><span style="color:#9A1900">// prints the strings in the vector</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">svOutput</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect <span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// finds a string in a vector and returns its index</font></i>
-<font color="#009900">int</font> <b><font color="#000000">svFind</font></b> <font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#008080">string</font> s<font color="#990000">);</font>
+<i><span style="color:#9A1900">// finds a string in a vector and returns its index</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">svFind</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#008080">string</span> s<span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// removes an element from the vector at index idx</font></i>
-<i><font color="#9A1900">// returns true if remove successful, otherwise false</font></i>
-<font color="#009900">bool</font> <b><font color="#000000">svDeleteAt</font></b> <font color="#990000">(</font> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#009900">int</font> idx <font color="#990000">);</font>
+<i><span style="color:#9A1900">// removes an element from the vector at index idx</span></i>
+<i><span style="color:#9A1900">// returns true if remove successful, otherwise false</span></i>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">svDeleteAt</span></b> <span style="color:#990000">(</span> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#009900">int</span> idx <span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// sorts a vector of string in ascending order</font></i>
-<font color="#009900">void</font> <b><font color="#000000">svSort</font></b> <font color="#990000">(</font> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect <font color="#990000">);</font>
+<i><span style="color:#9A1900">// sorts a vector of string in ascending order</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">svSort</span></b> <span style="color:#990000">(</span> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect <span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// return the index of the largest string in range index start to end</font></i>
-<font color="#009900">int</font> <b><font color="#000000">svFindMax</font></b><font color="#990000">(</font> <b><font color="#0000FF">const</font></b> <font color="#008080">vector&lt;string&gt;</font> <font color="#990000">&amp;</font>vect<font color="#990000">,</font> <font color="#009900">int</font> start<font color="#990000">,</font> <font color="#009900">int</font> end <font color="#990000">);</font>
+<i><span style="color:#9A1900">// return the index of the largest string in range index start to end</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">svFindMax</span></b><span style="color:#990000">(</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#008080">vector&lt;string&gt;</span> <span style="color:#990000">&amp;</span>vect<span style="color:#990000">,</span> <span style="color:#009900">int</span> start<span style="color:#990000">,</span> <span style="color:#009900">int</span> end <span style="color:#990000">);</span>
 
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab02/List.h.html
+++ b/labs/lab02/List.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab02/List.h.html
+++ b/labs/lab02/List.h.html
@@ -48,9 +48,9 @@ http://www.gnu.org/software/src-highlite">
     <span style="color:#009900">void</span> <b><span style="color:#000000">insertBefore</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#008080">ListItr</span> position<span style="color:#990000">);</span>
     <i><span style="color:#9A1900">//Inserts x before current iterator position p</span></i>
     <span style="color:#009900">void</span> <b><span style="color:#000000">insertAtTail</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Insert x at tail of list</span></i>
-    <span style="color:#009900">void</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>		<i><span style="color:#9A1900">//Removes the first occurrence of x</span></i>
     <span style="color:#008080">ListItr</span> <b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>		<i><span style="color:#9A1900">//Returns an iterator that points to</span></i>
     <i><span style="color:#9A1900">// the first occurrence of x, else return a iterator to the dummy tail node</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>		<i><span style="color:#9A1900">//Removes the first occurrence of x</span></i>
 
     <span style="color:#009900">int</span> <b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">//Returns the number of elements in the list</span></i>
 

--- a/labs/lab02/List.h.html
+++ b/labs/lab02/List.h.html
@@ -1,71 +1,71 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>List.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900"> * Filename: List.h</font></i>
-<i><font color="#9A1900"> * Description: List class definition</font></i>
-<i><font color="#9A1900"> * 	also includes the prototype for non-member function print()</font></i>
-<i><font color="#9A1900"> */</font></i>
-<b><font color="#000080">#ifndef</font></b> LIST_H
-<b><font color="#000080">#define</font></b> LIST_H
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900"> * Filename: List.h</span></i>
+<i><span style="color:#9A1900"> * Description: List class definition</span></i>
+<i><span style="color:#9A1900"> * 	also includes the prototype for non-member function print()</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<b><span style="color:#000080">#ifndef</span></b> LIST_H
+<b><span style="color:#000080">#define</span></b> LIST_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"ListNode.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"ListItr.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"ListNode.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"ListItr.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// When reading in ListItr.h first, it starts reading in this file</font></i>
-<i><font color="#9A1900">// before declaring that ListItr is a class.  This file then include</font></i>
-<i><font color="#9A1900">// ListItr.h, but beacuse of the #ifndef LISTITR_H statement, the code</font></i>
-<i><font color="#9A1900">// in that file is not read.  Thus, in this case, this List.h file</font></i>
-<i><font color="#9A1900">// will be read in, and will not know that ListItr is a class, which</font></i>
-<i><font color="#9A1900">// will cause compilation problems later on in this file.  Got it?</font></i>
-<i><font color="#9A1900">// Isn't C++ fun???</font></i>
-<b><font color="#0000FF">class</font></b> <font color="#008080">ListItr</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// When reading in ListItr.h first, it starts reading in this file</span></i>
+<i><span style="color:#9A1900">// before declaring that ListItr is a class.  This file then include</span></i>
+<i><span style="color:#9A1900">// ListItr.h, but beacuse of the #ifndef LISTITR_H statement, the code</span></i>
+<i><span style="color:#9A1900">// in that file is not read.  Thus, in this case, this List.h file</span></i>
+<i><span style="color:#9A1900">// will be read in, and will not know that ListItr is a class, which</span></i>
+<i><span style="color:#9A1900">// will cause compilation problems later on in this file.  Got it?</span></i>
+<i><span style="color:#9A1900">// Isn't C++ fun???</span></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ListItr</span><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">List</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">List</font></b><font color="#990000">();</font>				<i><font color="#9A1900">//Constructor</font></i>
-    <b><font color="#000000">List</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> List<font color="#990000">&amp;</font> source<font color="#990000">);</font>	<i><font color="#9A1900">//Copy Constructor</font></i>
-    <font color="#990000">~</font><b><font color="#000000">List</font></b><font color="#990000">();</font>			<i><font color="#9A1900">//Destructor</font></i>
-    List<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">=(</font><b><font color="#0000FF">const</font></b> List<font color="#990000">&amp;</font> source<font color="#990000">);</font>	<i><font color="#9A1900">//Equals Operator</font></i>
-    <font color="#009900">bool</font> <b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>		<i><font color="#9A1900">//Returns true if empty; else false</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>	<i><font color="#9A1900">//Removes all items except blank head and tail</font></i>
-    <font color="#008080">ListItr</font> <b><font color="#000000">first</font></b><font color="#990000">();</font> 		<i><font color="#9A1900">//Returns an iterator that points to</font></i>
-    <i><font color="#9A1900">//the ListNode in the first position</font></i>
-    <font color="#008080">ListItr</font> <b><font color="#000000">last</font></b><font color="#990000">();</font>			<i><font color="#9A1900">//Returns an iterator that points to</font></i>
-    <i><font color="#9A1900">//the ListNode in the last position</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">insertAfter</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#008080">ListItr</font> position<font color="#990000">);</font>
-    <i><font color="#9A1900">//Inserts x after current iterator position p</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">insertBefore</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#008080">ListItr</font> position<font color="#990000">);</font>
-    <i><font color="#9A1900">//Inserts x before current iterator position p</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">insertAtTail</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>	<i><font color="#9A1900">//Insert x at tail of list</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>		<i><font color="#9A1900">//Removes the first occurrence of x</font></i>
-    <font color="#008080">ListItr</font> <b><font color="#000000">find</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>		<i><font color="#9A1900">//Returns an iterator that points to</font></i>
-    <i><font color="#9A1900">// the first occurrence of x, else return a iterator to the dummy tail node</font></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">List</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">List</span></b><span style="color:#990000">();</span>				<i><span style="color:#9A1900">//Constructor</span></i>
+    <b><span style="color:#000000">List</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> List<span style="color:#990000">&amp;</span> source<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Copy Constructor</span></i>
+    <span style="color:#990000">~</span><b><span style="color:#000000">List</span></b><span style="color:#990000">();</span>			<i><span style="color:#9A1900">//Destructor</span></i>
+    List<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">=(</span><b><span style="color:#0000FF">const</span></b> List<span style="color:#990000">&amp;</span> source<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Equals Operator</span></i>
+    <span style="color:#009900">bool</span> <b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>		<i><span style="color:#9A1900">//Returns true if empty; else false</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>	<i><span style="color:#9A1900">//Removes all items except blank head and tail</span></i>
+    <span style="color:#008080">ListItr</span> <b><span style="color:#000000">first</span></b><span style="color:#990000">();</span> 		<i><span style="color:#9A1900">//Returns an iterator that points to</span></i>
+    <i><span style="color:#9A1900">//the ListNode in the first position</span></i>
+    <span style="color:#008080">ListItr</span> <b><span style="color:#000000">last</span></b><span style="color:#990000">();</span>			<i><span style="color:#9A1900">//Returns an iterator that points to</span></i>
+    <i><span style="color:#9A1900">//the ListNode in the last position</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">insertAfter</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#008080">ListItr</span> position<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">//Inserts x after current iterator position p</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">insertBefore</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#008080">ListItr</span> position<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">//Inserts x before current iterator position p</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">insertAtTail</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Insert x at tail of list</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>		<i><span style="color:#9A1900">//Removes the first occurrence of x</span></i>
+    <span style="color:#008080">ListItr</span> <b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>		<i><span style="color:#9A1900">//Returns an iterator that points to</span></i>
+    <i><span style="color:#9A1900">// the first occurrence of x, else return a iterator to the dummy tail node</span></i>
 
-    <font color="#009900">int</font> <b><font color="#000000">size</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font> <i><font color="#9A1900">//Returns the number of elements in the list</font></i>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">//Returns the number of elements in the list</span></i>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">ListNode</font> <font color="#990000">*</font>head<font color="#990000">,</font> <font color="#990000">*</font>tail<font color="#990000">;</font>	<i><font color="#9A1900">//indicates beginning and end of the list</font></i>
-    <font color="#009900">int</font> count<font color="#990000">;</font>			<i><font color="#9A1900">//#of elements in list</font></i>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">ListItr</font><font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">ListNode</span> <span style="color:#990000">*</span>head<span style="color:#990000">,</span> <span style="color:#990000">*</span>tail<span style="color:#990000">;</span>	<i><span style="color:#9A1900">//indicates beginning and end of the list</span></i>
+    <span style="color:#009900">int</span> count<span style="color:#990000">;</span>			<i><span style="color:#9A1900">//#of elements in list</span></i>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ListItr</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// printList: non-member function prototype</font></i>
-<font color="#009900">void</font> <b><font color="#000000">printList</font></b><font color="#990000">(</font>List<font color="#990000">&amp;</font> source<font color="#990000">,</font> <font color="#009900">bool</font> direction<font color="#990000">);</font>
-<i><font color="#9A1900">//prints list forwards when direction is true</font></i>
-<i><font color="#9A1900">//or backwards when direction is false</font></i>
-<b><font color="#000080">#endif</font></b>
-<i><font color="#9A1900">/* end of List.h */</font></i>
-</tt></pre>
+<i><span style="color:#9A1900">// printList: non-member function prototype</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printList</span></b><span style="color:#990000">(</span>List<span style="color:#990000">&amp;</span> source<span style="color:#990000">,</span> <span style="color:#009900">bool</span> direction<span style="color:#990000">);</span>
+<i><span style="color:#9A1900">//prints list forwards when direction is true</span></i>
+<i><span style="color:#9A1900">//or backwards when direction is false</span></i>
+<b><span style="color:#000080">#endif</span></b>
+<i><span style="color:#9A1900">/* end of List.h */</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab02/ListItr.h.html
+++ b/labs/lab02/ListItr.h.html
@@ -1,47 +1,47 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>ListItr.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900"> * Filename: ListItr.h</font></i>
-<i><font color="#9A1900"> * Description: ListItr class definition</font></i>
-<i><font color="#9A1900"> */</font></i>
-<b><font color="#000080">#ifndef</font></b> LISTITR_H
-<b><font color="#000080">#define</font></b> LISTITR_H
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900"> * Filename: ListItr.h</span></i>
+<i><span style="color:#9A1900"> * Description: ListItr class definition</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<b><span style="color:#000080">#ifndef</span></b> LISTITR_H
+<b><span style="color:#000080">#define</span></b> LISTITR_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"ListNode.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"List.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"ListNode.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"List.h"</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">ListItr</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">ListItr</font></b><font color="#990000">();</font>			<i><font color="#9A1900">//Constructor</font></i>
-    <b><font color="#000000">ListItr</font></b><font color="#990000">(</font>ListNode<font color="#990000">*</font> theNode<font color="#990000">);</font>	<i><font color="#9A1900">// One parameter constructor</font></i>
-    <font color="#009900">bool</font> <b><font color="#000000">isPastEnd</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>	<i><font color="#9A1900">//Returns true if past end position</font></i>
-    <i><font color="#9A1900">// in list, else false</font></i>
-    <font color="#009900">bool</font> <b><font color="#000000">isPastBeginning</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font><i><font color="#9A1900">//Returns true if past first position</font></i>
-    <i><font color="#9A1900">// in list, else false</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">moveForward</font></b><font color="#990000">();</font>	<i><font color="#9A1900">//Advances current to next position in list</font></i>
-    <i><font color="#9A1900">//(unless already past end of list)</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">moveBackward</font></b><font color="#990000">();</font>	<i><font color="#9A1900">//Moves current back to previous position</font></i>
-    <i><font color="#9A1900">// in list (unless already past beginning of</font></i>
-    <i><font color="#9A1900">// list)</font></i>
-    <font color="#009900">int</font> <b><font color="#000000">retrieve</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>	<i><font color="#9A1900">//Returns item in current position</font></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ListItr</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">ListItr</span></b><span style="color:#990000">();</span>			<i><span style="color:#9A1900">//Constructor</span></i>
+    <b><span style="color:#000000">ListItr</span></b><span style="color:#990000">(</span>ListNode<span style="color:#990000">*</span> theNode<span style="color:#990000">);</span>	<i><span style="color:#9A1900">// One parameter constructor</span></i>
+    <span style="color:#009900">bool</span> <b><span style="color:#000000">isPastEnd</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>	<i><span style="color:#9A1900">//Returns true if past end position</span></i>
+    <i><span style="color:#9A1900">// in list, else false</span></i>
+    <span style="color:#009900">bool</span> <b><span style="color:#000000">isPastBeginning</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span><i><span style="color:#9A1900">//Returns true if past first position</span></i>
+    <i><span style="color:#9A1900">// in list, else false</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">moveForward</span></b><span style="color:#990000">();</span>	<i><span style="color:#9A1900">//Advances current to next position in list</span></i>
+    <i><span style="color:#9A1900">//(unless already past end of list)</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">moveBackward</span></b><span style="color:#990000">();</span>	<i><span style="color:#9A1900">//Moves current back to previous position</span></i>
+    <i><span style="color:#9A1900">// in list (unless already past beginning of</span></i>
+    <i><span style="color:#9A1900">// list)</span></i>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">retrieve</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>	<i><span style="color:#9A1900">//Returns item in current position</span></i>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    ListNode<font color="#990000">*</font> current<font color="#990000">;</font>		<i><font color="#9A1900">//holds the position in the list</font></i>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">List</font><font color="#990000">;</font>	<i><font color="#9A1900">// List class needs access to “current”</font></i>
-    <i><font color="#9A1900">// ListNode's private data members</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    ListNode<span style="color:#990000">*</span> current<span style="color:#990000">;</span>		<i><span style="color:#9A1900">//holds the position in the list</span></i>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">List</span><span style="color:#990000">;</span>	<i><span style="color:#9A1900">// List class needs access to “current”</span></i>
+    <i><span style="color:#9A1900">// ListNode's private data members</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-<i><font color="#9A1900">/* end of ListItr.h */</font></i>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+<i><span style="color:#9A1900">/* end of ListItr.h */</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab02/ListItr.h.html
+++ b/labs/lab02/ListItr.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab02/ListNode.h.html
+++ b/labs/lab02/ListNode.h.html
@@ -1,48 +1,48 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>ListNode.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900"> * Filename: ListNode.h</font></i>
-<i><font color="#9A1900"> * Description: ListNode class definition</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900"> * Filename: ListNode.h</span></i>
+<i><span style="color:#9A1900"> * Description: ListNode class definition</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#ifndef</font></b> LISTNODE_H
-<b><font color="#000080">#define</font></b> LISTNODE_H
+<b><span style="color:#000080">#ifndef</span></b> LISTNODE_H
+<b><span style="color:#000080">#define</span></b> LISTNODE_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
 
-<i><font color="#9A1900">// next line needed because NULL is part of std namespace</font></i>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<i><span style="color:#9A1900">// next line needed because NULL is part of std namespace</span></i>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">ListNode</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">ListNode</font></b><font color="#990000">();</font>                 <i><font color="#9A1900">// Constructor</font></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ListNode</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">ListNode</span></b><span style="color:#990000">();</span>                 <i><span style="color:#9A1900">// Constructor</span></i>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> value<font color="#990000">;</font>
-    <font color="#008080">ListNode</font> <font color="#990000">*</font>next<font color="#990000">,</font> <font color="#990000">*</font>previous<font color="#990000">;</font>	<i><font color="#9A1900">// for doubly linked lists</font></i>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> value<span style="color:#990000">;</span>
+    <span style="color:#008080">ListNode</span> <span style="color:#990000">*</span>next<span style="color:#990000">,</span> <span style="color:#990000">*</span>previous<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// for doubly linked lists</span></i>
 
-    <i><font color="#9A1900">// List needs to be able to access/change ListNode's next and</font></i>
-    <i><font color="#9A1900">// previous pointers</font></i>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">List</font><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// List needs to be able to access/change ListNode's next and</span></i>
+    <i><span style="color:#9A1900">// previous pointers</span></i>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">List</span><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// ListItr needs to access/change ListNode as well</font></i>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">ListItr</font><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// ListItr needs to access/change ListNode as well</span></i>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ListItr</span><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// Not writing a destructor is fine in this case since there is no</font></i>
-    <i><font color="#9A1900">// dynamically allocated memory in this class.  No constructor is</font></i>
-    <i><font color="#9A1900">// necessary, as an object will be set up by the List class.</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// Not writing a destructor is fine in this case since there is no</span></i>
+    <i><span style="color:#9A1900">// dynamically allocated memory in this class.  No constructor is</span></i>
+    <i><span style="color:#9A1900">// necessary, as an object will be set up by the List class.</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab02/ListNode.h.html
+++ b/labs/lab02/ListNode.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab02/ListTest.cpp.html
+++ b/labs/lab02/ListTest.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,445 +8,445 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>ListTest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">//	Modified: 8/30/2006: mc2zk</font></i>
-<i><font color="#9A1900">//  CS216 Lab 1 - Test Harness</font></i>
-<i><font color="#9A1900">//   by Michael Crane</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">//  Integrate this test harness with your List implementation to</font></i>
-<i><font color="#9A1900">//  thoroughly test your design.  I have only used functions that were</font></i>
-<i><font color="#9A1900">//  explicitly defined in the specification, with one exception:</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">//  I have assumed a global print function whose prototype is</font></i>
-<i><font color="#9A1900">//      void printList(List l, bool forward);</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">//  If the 'forward' parameter is true,</font></i>
-<i><font color="#9A1900">//      the list is printed in forward order</font></i>
-<i><font color="#9A1900">//  if the 'forward' parameter is false,</font></i>
-<i><font color="#9A1900">//      the list is printed in reverse order</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">//	Modified: 8/30/2006: mc2zk</span></i>
+<i><span style="color:#9A1900">//  CS216 Lab 1 - Test Harness</span></i>
+<i><span style="color:#9A1900">//   by Michael Crane</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">//  Integrate this test harness with your List implementation to</span></i>
+<i><span style="color:#9A1900">//  thoroughly test your design.  I have only used functions that were</span></i>
+<i><span style="color:#9A1900">//  explicitly defined in the specification, with one exception:</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">//  I have assumed a global print function whose prototype is</span></i>
+<i><span style="color:#9A1900">//      void printList(List l, bool forward);</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">//  If the 'forward' parameter is true,</span></i>
+<i><span style="color:#9A1900">//      the list is printed in forward order</span></i>
+<i><span style="color:#9A1900">//  if the 'forward' parameter is false,</span></i>
+<i><span style="color:#9A1900">//      the list is printed in reverse order</span></i>
 
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;ctype.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;ctype.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">//Make sure your own files for the List and ListItr</font></i>
-<i><font color="#9A1900">//classes are included here.  These are the names I used.</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"List.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"ListItr.h"</font>
+<i><span style="color:#9A1900">//Make sure your own files for the List and ListItr</span></i>
+<i><span style="color:#9A1900">//classes are included here.  These are the names I used.</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"List.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"ListItr.h"</span>
 
 
-<font color="#009900">int</font>      <b><font color="#000000">menu</font></b> <font color="#990000">(</font><font color="#008080">string</font> option<font color="#990000">[],</font> <font color="#009900">int</font> n_opt<font color="#990000">);</font>
+<span style="color:#009900">int</span>      <b><span style="color:#000000">menu</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> option<span style="color:#990000">[],</span> <span style="color:#009900">int</span> n_opt<span style="color:#990000">);</span>
 
-<i><font color="#9A1900">//set up menu options</font></i>
-<font color="#008080">string</font>   option<font color="#990000">[]</font> <font color="#990000">=</font>   <font color="#FF0000">{</font> <font color="#FF0000">"Quit"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"New List"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Show List elements"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Set ListItr with first()"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Set ListItr with find()"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Set ListItr with last()"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Move ListItr forward"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Move ListItr backward"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Retrieve element at ListItr"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Insert element before"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Insert element after"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Insert element at tail"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Remove element"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Cardinality (size)"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Copy list w/copy constructor"</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Copy list with operator="</font><font color="#990000">,</font>
-                        <font color="#FF0000">"Make list empty"</font><font color="#990000">,</font>
-                      <font color="#FF0000">}</font><font color="#990000">;</font>
-<font color="#009900">int</font>      <b><font color="#0000FF">const</font></b> n_choice <font color="#990000">=</font> <font color="#993399">17</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">//set up menu options</span></i>
+<span style="color:#008080">string</span>   option<span style="color:#990000">[]</span> <span style="color:#990000">=</span>   <span style="color:#FF0000">{</span> <span style="color:#FF0000">"Quit"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"New List"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Show List elements"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Set ListItr with first()"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Set ListItr with find()"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Set ListItr with last()"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Move ListItr forward"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Move ListItr backward"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Retrieve element at ListItr"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Insert element before"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Insert element after"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Insert element at tail"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Remove element"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Cardinality (size)"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Copy list w/copy constructor"</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Copy list with operator="</span><span style="color:#990000">,</span>
+                        <span style="color:#FF0000">"Make list empty"</span><span style="color:#990000">,</span>
+                      <span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<span style="color:#009900">int</span>      <b><span style="color:#0000FF">const</span></b> n_choice <span style="color:#990000">=</span> <span style="color:#993399">17</span><span style="color:#990000">;</span>
 
-<font color="#009900">int</font>   <b><font color="#000000">main</font></b> <font color="#990000">()</font>
-<i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900">**  This main driver program interactively exercises a</font></i>
-<i><font color="#9A1900">**   list package.</font></i>
-<i><font color="#9A1900">**  It assumes a linked list implementation, and its real</font></i>
-<i><font color="#9A1900">**   purpose is to exercise the underlying list manipulation</font></i>
-<i><font color="#9A1900">**   procedures.</font></i>
-<i><font color="#9A1900">**  It uses a menu to accept commands from the terminal,</font></i>
-<i><font color="#9A1900">**   then performs the indicated command.</font></i>
-<i><font color="#9A1900">*/</font></i>
-<font color="#FF0000">{</font>
-    <font color="#009900">int</font>      command<font color="#990000">;</font>
-    <font color="#008080">string</font>   response<font color="#990000">;</font>
-    <font color="#008080">List</font>     <font color="#990000">*</font>list <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <font color="#008080">ListItr</font>  <font color="#990000">*</font>itr <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <i><font color="#9A1900">// Initialize this run</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"--------------------------------------------------</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">This test harness operates with one List</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">object and one ListItr object.</font><font color="#CC33CC">\n\n</font><font color="#FF0000">"</font>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Use the menu options to manipulate these</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">objects.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
+<span style="color:#009900">int</span>   <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span>
+<i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900">**  This main driver program interactively exercises a</span></i>
+<i><span style="color:#9A1900">**   list package.</span></i>
+<i><span style="color:#9A1900">**  It assumes a linked list implementation, and its real</span></i>
+<i><span style="color:#9A1900">**   purpose is to exercise the underlying list manipulation</span></i>
+<i><span style="color:#9A1900">**   procedures.</span></i>
+<i><span style="color:#9A1900">**  It uses a menu to accept commands from the terminal,</span></i>
+<i><span style="color:#9A1900">**   then performs the indicated command.</span></i>
+<i><span style="color:#9A1900">*/</span></i>
+<span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span>      command<span style="color:#990000">;</span>
+    <span style="color:#008080">string</span>   response<span style="color:#990000">;</span>
+    <span style="color:#008080">List</span>     <span style="color:#990000">*</span>list <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <span style="color:#008080">ListItr</span>  <span style="color:#990000">*</span>itr <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// Initialize this run</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"--------------------------------------------------</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">This test harness operates with one List</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">object and one ListItr object.</span><span style="color:#CC33CC">\n\n</span><span style="color:#FF0000">"</span>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Use the menu options to manipulate these</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">objects.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        command <font color="#990000">=</font> <b><font color="#000000">menu</font></b><font color="#990000">(</font>option<font color="#990000">,</font> n_choice<font color="#990000">);</font>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        command <span style="color:#990000">=</span> <b><span style="color:#000000">menu</span></b><span style="color:#990000">(</span>option<span style="color:#990000">,</span> n_choice<span style="color:#990000">);</span>
 
-        <b><font color="#0000FF">switch</font></b> <font color="#990000">(</font>command<font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">1</font><font color="#990000">:</font>                        <i><font color="#9A1900">// Quit</font></i>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Do you really want to quit? (y/n) &gt; "</font><font color="#990000">;</font>
-                cin  <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+        <b><span style="color:#0000FF">switch</span></b> <span style="color:#990000">(</span>command<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">1</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// Quit</span></i>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Do you really want to quit? (y/n) &gt; "</span><span style="color:#990000">;</span>
+                cin  <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'y'</font> <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'Y'</font><font color="#990000">)</font> <font color="#FF0000">{</font>                 <i><font color="#9A1900">// Normal Exit</font></i>
-                    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">!=</font> NULL<font color="#990000">)</font> <b><font color="#0000FF">delete</font></b> list<font color="#990000">;</font>
-                    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr <font color="#990000">!=</font> NULL<font color="#990000">)</font> <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-                    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'y'</span> <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'Y'</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>                 <i><span style="color:#9A1900">// Normal Exit</span></i>
+                    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">!=</span> NULL<span style="color:#990000">)</span> <b><span style="color:#0000FF">delete</span></b> list<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr <span style="color:#990000">!=</span> NULL<span style="color:#990000">)</span> <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">2</font><font color="#990000">:</font>                        <i><font color="#9A1900">// New list</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">!=</font> NULL<font color="#990000">)</font>
-		  <b><font color="#0000FF">delete</font></b> list<font color="#990000">;</font>
-                list <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> List<font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">2</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// New list</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">!=</span> NULL<span style="color:#990000">)</span>
+		  <b><span style="color:#0000FF">delete</span></b> list<span style="color:#990000">;</span>
+                list <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> List<span style="color:#990000">;</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">You have created an empty list</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Do you want to initialize it with elements? (y/n) &gt; "</font><font color="#990000">;</font>
-                cin  <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">You have created an empty list</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Do you want to initialize it with elements? (y/n) &gt; "</span><span style="color:#990000">;</span>
+                cin  <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">!=</font> <font color="#FF0000">'y'</font> <font color="#990000">&amp;&amp;</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">!=</font> <font color="#FF0000">'Y'</font><font color="#990000">)</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <i><font color="#9A1900">// accept elements</font></i>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Enter elements one by one as integers.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t\t</font><font color="#FF0000">Any non-numeric character, e.g. #, "</font><font color="#990000">;</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"will terminate input</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">!=</span> <span style="color:#FF0000">'y'</span> <span style="color:#990000">&amp;&amp;</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">!=</span> <span style="color:#FF0000">'Y'</span><span style="color:#990000">)</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <i><span style="color:#9A1900">// accept elements</span></i>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Enter elements one by one as integers.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t\t</span><span style="color:#FF0000">Any non-numeric character, e.g. #, "</span><span style="color:#990000">;</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"will terminate input</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter first element: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter first element: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">while</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-                    list<font color="#990000">-&gt;</font><b><font color="#000000">insertAtTail</font></b><font color="#990000">(</font>element<font color="#990000">);</font>
+                <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+                    list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">insertAtTail</span></b><span style="color:#990000">(</span>element<span style="color:#990000">);</span>
 
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter next element: "</font><font color="#990000">;</font>
-                    cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter next element: "</span><span style="color:#990000">;</span>
+                    cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">3</font><font color="#990000">:</font>                      <i><font color="#9A1900">// show elements</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Print the list forwards or backwards? (f/b) &gt; "</font><font color="#990000">;</font>
-                cin  <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">3</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// show elements</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Print the list forwards or backwards? (f/b) &gt; "</span><span style="color:#990000">;</span>
+                cin  <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'b'</font> <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'B'</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in reverse order:"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order:"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'b'</span> <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'B'</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in reverse order:"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order:"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">4</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test first()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Setting the ListItr to the first element..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font>
-		  <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-                itr <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">ListItr</font></b><font color="#990000">((</font>list<font color="#990000">-&gt;</font><b><font color="#000000">first</font></b><font color="#990000">()));</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">4</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test first()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Setting the ListItr to the first element..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span>
+		  <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+                itr <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">ListItr</span></b><span style="color:#990000">((</span>list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">first</span></b><span style="color:#990000">()));</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">5</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test find()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter element to find: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">5</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test find()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter element to find: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-		    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font>
-		      <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-                    itr <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">ListItr</font></b><font color="#990000">((</font>list<font color="#990000">-&gt;</font><b><font color="#000000">find</font></b><font color="#990000">(</font>element<font color="#990000">)));</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Setting the ListItr to find("</font>
-                         <font color="#990000">&lt;&lt;</font> element <font color="#990000">&lt;&lt;</font> <font color="#FF0000">")..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Please enter an integer."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+		    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span>
+		      <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+                    itr <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">ListItr</span></b><span style="color:#990000">((</span>list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">find</span></b><span style="color:#990000">(</span>element<span style="color:#990000">)));</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Setting the ListItr to find("</span>
+                         <span style="color:#990000">&lt;&lt;</span> element <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">")..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Please enter an integer."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">6</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test last()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Setting the ListItr to the last element..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font>
-		  <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-                itr <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">ListItr</font></b><font color="#990000">((</font>list<font color="#990000">-&gt;</font><b><font color="#000000">last</font></b><font color="#990000">()));</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">6</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test last()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Setting the ListItr to the last element..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span>
+		  <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+                itr <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">ListItr</span></b><span style="color:#990000">((</span>list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">last</span></b><span style="color:#990000">()));</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">7</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test moveForwards()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a ListItr first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Moving the ListItr forwards..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                itr<font color="#990000">-&gt;</font><b><font color="#000000">moveForward</font></b><font color="#990000">();</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">7</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test moveForwards()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a ListItr first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Moving the ListItr forwards..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                itr<span style="color:#990000">-&gt;</span><b><span style="color:#000000">moveForward</span></b><span style="color:#990000">();</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">8</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test move_backwards()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a ListItr first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Moving the ListItr backwards..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                itr<font color="#990000">-&gt;</font><b><font color="#000000">moveBackward</font></b><font color="#990000">();</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">8</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test move_backwards()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a ListItr first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Moving the ListItr backwards..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                itr<span style="color:#990000">-&gt;</span><b><span style="color:#000000">moveBackward</span></b><span style="color:#990000">();</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">9</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test retrieve()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a ListItr first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">9</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test retrieve()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a ListItr first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr<font color="#990000">-&gt;</font><b><font color="#000000">isPastBeginning</font></b><font color="#990000">())</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">The ListItr is past the beginning."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>itr<font color="#990000">-&gt;</font><b><font color="#000000">isPastEnd</font></b><font color="#990000">())</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">The ListItr is past the end."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#0000FF">else</font></b>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Element retrieved: "</font> <font color="#990000">&lt;&lt;</font> itr<font color="#990000">-&gt;</font><b><font color="#000000">retrieve</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr<span style="color:#990000">-&gt;</span><b><span style="color:#000000">isPastBeginning</span></b><span style="color:#990000">())</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">The ListItr is past the beginning."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>itr<span style="color:#990000">-&gt;</span><b><span style="color:#000000">isPastEnd</span></b><span style="color:#990000">())</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">The ListItr is past the end."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">else</span></b>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Element retrieved: "</span> <span style="color:#990000">&lt;&lt;</span> itr<span style="color:#990000">-&gt;</span><b><span style="color:#000000">retrieve</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">10</font><font color="#990000">:</font>                        <i><font color="#9A1900">// Insert element before</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL <font color="#990000">||</font> itr <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List and ListItr first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">10</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// Insert element before</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL <span style="color:#990000">||</span> itr <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List and ListItr first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter element to insert: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter element to insert: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-                    list<font color="#990000">-&gt;</font><b><font color="#000000">insertBefore</font></b><font color="#990000">(</font>element<font color="#990000">,</font> <font color="#990000">*</font>itr<font color="#990000">);</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Inserting "</font> <font color="#990000">&lt;&lt;</font> element
-                         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" before the current ListItr"</font> <font color="#990000">&lt;&lt;</font>endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Please enter an integer."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+                    list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">insertBefore</span></b><span style="color:#990000">(</span>element<span style="color:#990000">,</span> <span style="color:#990000">*</span>itr<span style="color:#990000">);</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Inserting "</span> <span style="color:#990000">&lt;&lt;</span> element
+                         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" before the current ListItr"</span> <span style="color:#990000">&lt;&lt;</span>endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Please enter an integer."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">11</font><font color="#990000">:</font>                        <i><font color="#9A1900">// Insert element after</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL <font color="#990000">||</font> itr <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List and ListItr first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">11</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// Insert element after</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL <span style="color:#990000">||</span> itr <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List and ListItr first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter element to insert: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter element to insert: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-                    list<font color="#990000">-&gt;</font><b><font color="#000000">insertAfter</font></b><font color="#990000">(</font>element<font color="#990000">,</font> <font color="#990000">*</font>itr<font color="#990000">);</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Inserting "</font> <font color="#990000">&lt;&lt;</font> element
-                         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" after the current ListItr"</font> <font color="#990000">&lt;&lt;</font>endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Please enter an integer."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+                    list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">insertAfter</span></b><span style="color:#990000">(</span>element<span style="color:#990000">,</span> <span style="color:#990000">*</span>itr<span style="color:#990000">);</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Inserting "</span> <span style="color:#990000">&lt;&lt;</span> element
+                         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" after the current ListItr"</span> <span style="color:#990000">&lt;&lt;</span>endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Please enter an integer."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">12</font><font color="#990000">:</font>                        <i><font color="#9A1900">// Insert element at tail</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">12</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// Insert element at tail</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter element to insert: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter element to insert: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-                    list<font color="#990000">-&gt;</font><b><font color="#000000">insertAtTail</font></b><font color="#990000">(</font>element<font color="#990000">);</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Inserting "</font> <font color="#990000">&lt;&lt;</font> element
-                         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" at the tail of the list"</font> <font color="#990000">&lt;&lt;</font>endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Please enter an integer."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+                    list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">insertAtTail</span></b><span style="color:#990000">(</span>element<span style="color:#990000">);</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Inserting "</span> <span style="color:#990000">&lt;&lt;</span> element
+                         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" at the tail of the list"</span> <span style="color:#990000">&lt;&lt;</span>endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Please enter an integer."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">13</font><font color="#990000">:</font>                        <i><font color="#9A1900">// Remove element</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">13</span><span style="color:#990000">:</span>                        <i><span style="color:#9A1900">// Remove element</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Enter element to remove: "</font><font color="#990000">;</font>
-                cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Enter element to remove: "</span><span style="color:#990000">;</span>
+                cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
 
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-                    <font color="#009900">int</font> element <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>response<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-                    list<font color="#990000">-&gt;</font><b><font color="#000000">remove</font></b><font color="#990000">(</font>element<font color="#990000">);</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Removing "</font> <font color="#990000">&lt;&lt;</font> element
-                         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" from list"</font> <font color="#990000">&lt;&lt;</font>endl<font color="#990000">;</font>
-                <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Please enter an integer."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+                    <span style="color:#009900">int</span> element <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>response<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+                    list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>element<span style="color:#990000">);</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Removing "</span> <span style="color:#990000">&lt;&lt;</span> element
+                         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" from list"</span> <span style="color:#990000">&lt;&lt;</span>endl<span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Please enter an integer."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The elements in forward order: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The elements in forward order: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">14</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test size()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">14</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test size()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Size of list: "</font> <font color="#990000">&lt;&lt;</font> list<font color="#990000">-&gt;</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Size of list: "</span> <span style="color:#990000">&lt;&lt;</span> list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">15</font><font color="#990000">:</font> <font color="#FF0000">{</font>                    <i><font color="#9A1900">// test copy constructor</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                List<font color="#990000">*</font> old_list<font color="#990000">=</font>list<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> list <font color="#990000">!=</font> NULL <font color="#990000">)</font>
-		  <b><font color="#0000FF">delete</font></b> list<font color="#990000">;</font>
-                list<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">List</font></b><font color="#990000">(*</font>old_list<font color="#990000">);</font>
-                old_list<font color="#990000">-&gt;</font><b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">15</span><span style="color:#990000">:</span> <span style="color:#FF0000">{</span>                    <i><span style="color:#9A1900">// test copy constructor</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                List<span style="color:#990000">*</span> old_list<span style="color:#990000">=</span>list<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> list <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span>
+		  <b><span style="color:#0000FF">delete</span></b> list<span style="color:#990000">;</span>
+                list<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">List</span></b><span style="color:#990000">(*</span>old_list<span style="color:#990000">);</span>
+                old_list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The new list is (forward ): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The new list is (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list was made empty (forward ): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>old_list<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list was made empty (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>old_list<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list should be destroyed now."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                <b><font color="#0000FF">delete</font></b> old_list<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-		  <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-		  itr <font color="#990000">=</font> NULL<font color="#990000">;</font>
-		<font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <font color="#FF0000">}</font>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">16</font><font color="#990000">:</font> <font color="#FF0000">{</font>                    <i><font color="#9A1900">// test equals operator</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
-                List<font color="#990000">*</font> old_list<font color="#990000">=</font>list<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> list <font color="#990000">!=</font> NULL <font color="#990000">)</font>
-		  <b><font color="#0000FF">delete</font></b> list<font color="#990000">;</font>
-                list<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">List</font></b><font color="#990000">();</font>
-                <font color="#990000">*</font>list<font color="#990000">=*</font>old_list<font color="#990000">;</font>
-                old_list<font color="#990000">-&gt;</font><b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The new list is (forward ): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The new list is (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list was made empty (forward ): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>old_list<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list was made empty (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>old_list<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list should be destroyed now."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                <b><span style="color:#0000FF">delete</span></b> old_list<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+		  <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+		  itr <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+		<span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">16</span><span style="color:#990000">:</span> <span style="color:#FF0000">{</span>                    <i><span style="color:#9A1900">// test equals operator</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
+                List<span style="color:#990000">*</span> old_list<span style="color:#990000">=</span>list<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> list <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span>
+		  <b><span style="color:#0000FF">delete</span></b> list<span style="color:#990000">;</span>
+                list<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">List</span></b><span style="color:#990000">();</span>
+                <span style="color:#990000">*</span>list<span style="color:#990000">=*</span>old_list<span style="color:#990000">;</span>
+                old_list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The new list is (forward ): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The new list is (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list was made empty (forward ): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>old_list<font color="#990000">,</font><b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list was made empty (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>old_list<font color="#990000">,</font><b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The old list should be destroyed now."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>                
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The new list is (forward ): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The new list is (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list was made empty (forward ): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>old_list<span style="color:#990000">,</span><b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list was made empty (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>old_list<span style="color:#990000">,</span><b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The old list should be destroyed now."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>                
 
-                <b><font color="#0000FF">delete</font></b> old_list<font color="#990000">;</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-		  <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-		  itr <font color="#990000">=</font> NULL<font color="#990000">;</font>
-		<font color="#FF0000">}</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-            <font color="#FF0000">}</font>
+                <b><span style="color:#0000FF">delete</span></b> old_list<span style="color:#990000">;</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+		  <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+		  itr <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+		<span style="color:#FF0000">}</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span>
 
-            <b><font color="#0000FF">case</font></b> <font color="#993399">17</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test makeEmpty()</font></i>
-                <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-                    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-                <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">17</span><span style="color:#990000">:</span>                      <i><span style="color:#9A1900">// test makeEmpty()</span></i>
+                <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>list <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Create a List first."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                    <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+                <span style="color:#FF0000">}</span>
 
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The list is (forward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The list is (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-                list<font color="#990000">-&gt;</font><b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>
-		<b><font color="#0000FF">if</font></b> <font color="#990000">(</font> itr <font color="#990000">!=</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-		  <b><font color="#0000FF">delete</font></b> itr<font color="#990000">;</font>
-		  itr <font color="#990000">=</font> NULL<font color="#990000">;</font>
-		<font color="#FF0000">}</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The list was made empty (forward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">true</font></b><font color="#990000">);</font>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The list was made empty (backward): "</font><font color="#990000">;</font>
-                <b><font color="#000000">printList</font></b><font color="#990000">(*</font>list<font color="#990000">,</font><b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-        <font color="#FF0000">}</font>               <i><font color="#9A1900">// end of switch (command)</font></i>
-    <font color="#FF0000">}</font>            <i><font color="#9A1900">// end of while (1)</font></i>
-<font color="#FF0000">}</font>     <i><font color="#9A1900">// end of main()</font></i>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The list is (forward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The list is (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+                list<span style="color:#990000">-&gt;</span><b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>
+		<b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> itr <span style="color:#990000">!=</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+		  <b><span style="color:#0000FF">delete</span></b> itr<span style="color:#990000">;</span>
+		  itr <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+		<span style="color:#FF0000">}</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The list was made empty (forward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The list was made empty (backward): "</span><span style="color:#990000">;</span>
+                <b><span style="color:#000000">printList</span></b><span style="color:#990000">(*</span>list<span style="color:#990000">,</span><b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>               <i><span style="color:#9A1900">// end of switch (command)</span></i>
+    <span style="color:#FF0000">}</span>            <i><span style="color:#9A1900">// end of while (1)</span></i>
+<span style="color:#FF0000">}</span>     <i><span style="color:#9A1900">// end of main()</span></i>
 
-<font color="#009900">int</font>   <b><font color="#000000">menu</font></b> <font color="#990000">(</font><font color="#008080">string</font> option<font color="#990000">[],</font> <font color="#009900">int</font> n_opt<font color="#990000">)</font>
-<i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900">**  This simple routine takes an array of 'n_opt' options</font></i>
-<i><font color="#9A1900">**  (pointers to strings, describing the 'option')</font></i>
-<i><font color="#9A1900">**  displays these options on the screen,</font></i>
-<i><font color="#9A1900">**  and requests a choice on the part of the user</font></i>
-<i><font color="#9A1900">**  It returns the integer number (position in the list)</font></i>
-<i><font color="#9A1900">**  of the chosen option.</font></i>
-<i><font color="#9A1900">**</font></i>
-<i><font color="#9A1900">**  NOTE, all input and output uses 'stdin' and 'stdout'</font></i>
-<i><font color="#9A1900">*/</font></i>
-<font color="#FF0000">{</font>
-    <font color="#009900">int</font>      choice<font color="#990000">,</font> i<font color="#990000">;</font>
-    <font color="#008080">string</font>   input<font color="#990000">;</font>
+<span style="color:#009900">int</span>   <b><span style="color:#000000">menu</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> option<span style="color:#990000">[],</span> <span style="color:#009900">int</span> n_opt<span style="color:#990000">)</span>
+<i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900">**  This simple routine takes an array of 'n_opt' options</span></i>
+<i><span style="color:#9A1900">**  (pointers to strings, describing the 'option')</span></i>
+<i><span style="color:#9A1900">**  displays these options on the screen,</span></i>
+<i><span style="color:#9A1900">**  and requests a choice on the part of the user</span></i>
+<i><span style="color:#9A1900">**  It returns the integer number (position in the list)</span></i>
+<i><span style="color:#9A1900">**  of the chosen option.</span></i>
+<i><span style="color:#9A1900">**</span></i>
+<i><span style="color:#9A1900">**  NOTE, all input and output uses 'stdin' and 'stdout'</span></i>
+<i><span style="color:#9A1900">*/</span></i>
+<span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span>      choice<span style="color:#990000">,</span> i<span style="color:#990000">;</span>
+    <span style="color:#008080">string</span>   input<span style="color:#990000">;</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"     - - - - - -  MENU - - - - - -</font><font color="#CC33CC">\n\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"     - - - - - -  MENU - - - - - -</span><span style="color:#CC33CC">\n\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font>i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> n_opt<font color="#990000">;</font> <font color="#990000">++</font>i<font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">(</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" - "</font> <font color="#990000">&lt;&lt;</font> option<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span>i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> n_opt<span style="color:#990000">;</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">(</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" - "</span> <span style="color:#990000">&lt;&lt;</span> option<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"     - - - - - - - - - - - - - - -</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"     - - - - - - - - - - - - - - -</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font>input<font color="#990000">.</font><b><font color="#000000">empty</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"     Enter number of choice &gt; "</font><font color="#990000">;</font>
-        cin <font color="#990000">&gt;&gt;</font> input<font color="#990000">;</font>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span>input<span style="color:#990000">.</span><b><span style="color:#000000">empty</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"     Enter number of choice &gt; "</span><span style="color:#990000">;</span>
+        cin <span style="color:#990000">&gt;&gt;</span> input<span style="color:#990000">;</span>
 
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>input<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]))</font> <font color="#FF0000">{</font>
-            choice <font color="#990000">=</font> <b><font color="#000000">atoi</font></b><font color="#990000">(</font>input<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>input<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]))</span> <span style="color:#FF0000">{</span>
+            choice <span style="color:#990000">=</span> <b><span style="color:#000000">atoi</span></b><span style="color:#990000">(</span>input<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
 
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>choice <font color="#990000">&lt;=</font> n_opt <font color="#990000">&amp;&amp;</font> choice <font color="#990000">&gt;</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-                <b><font color="#0000FF">return</font></b> choice<font color="#990000">;</font>
-            <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>          <i><font color="#9A1900">/* choice out of range */</font></i>
-                cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Your response MUST be between 1 and "</font>
-                     <font color="#990000">&lt;&lt;</font> n_opt <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-                input <font color="#990000">=</font> <font color="#FF0000">""</font><font color="#990000">;</font>
-            <font color="#FF0000">}</font>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>                <i><font color="#9A1900">/* Non-numeric input, ignore */</font></i>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Your response MUST be a number!</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-            input <font color="#990000">=</font> <font color="#FF0000">""</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>choice <span style="color:#990000">&lt;=</span> n_opt <span style="color:#990000">&amp;&amp;</span> choice <span style="color:#990000">&gt;</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+                <b><span style="color:#0000FF">return</span></b> choice<span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>          <i><span style="color:#9A1900">/* choice out of range */</span></i>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Your response MUST be between 1 and "</span>
+                     <span style="color:#990000">&lt;&lt;</span> n_opt <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+                input <span style="color:#990000">=</span> <span style="color:#FF0000">""</span><span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>                <i><span style="color:#9A1900">/* Non-numeric input, ignore */</span></i>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">Your response MUST be a number!</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+            input <span style="color:#990000">=</span> <span style="color:#FF0000">""</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>          <i><font color="#9A1900">// end of menu()</font></i>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>          <i><span style="color:#9A1900">// end of menu()</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab02/ListTest.cpp.html
+++ b/labs/lab02/ListTest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/avl-worksheet/Makefile.html
+++ b/labs/lab05/avl-worksheet/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/avl-worksheet/Makefile.html
+++ b/labs/lab05/avl-worksheet/Makefile.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">graphs:</span>
+	@echo Making all graphs into .svg files<span style="color:#990000">...</span>
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpdf "$$1".dot -o "$$1".pdf"}'</span> <span style="color:#990000">|</span> bash
+	pdflatex avl-worksheet.tex
+
+<span style="color:#990000">clean:</span>
+	/bin/rm -f <span style="color:#990000">*~</span> <span style="color:#990000">*</span>.log <span style="color:#990000">*</span>.aux
+</pre>
+</body>
+</html>

--- a/labs/lab05/code/inlab/BSTPathTest.cpp.html
+++ b/labs/lab05/code/inlab/BSTPathTest.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,27 +8,27 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>BSTPathTest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"BinarySearchTree.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"BinarySearchTree.h"</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <font color="#008080">BinarySearchTree</font> bst<font color="#990000">;</font>
-  <b><font color="#0000FF">while</font></b> <font color="#990000">(</font>cin<font color="#990000">.</font><b><font color="#000000">good</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> instr<font color="#990000">,</font> word<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> instr<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> word<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"I"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      bst<font color="#990000">.</font><b><font color="#000000">insert</font></b><font color="#990000">(</font>word<font color="#990000">);</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"R"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      bst<font color="#990000">.</font><b><font color="#000000">remove</font></b><font color="#990000">(</font>word<font color="#990000">);</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"L"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"BST path: "</font> <font color="#990000">&lt;&lt;</font> bst<font color="#990000">.</font><b><font color="#000000">pathTo</font></b><font color="#990000">(</font>word<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-  <font color="#FF0000">}</font>
-  cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"BST numNodes: "</font> <font color="#990000">&lt;&lt;</font> bst<font color="#990000">.</font><b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font></tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <span style="color:#008080">BinarySearchTree</span> bst<span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span>cin<span style="color:#990000">.</span><b><span style="color:#000000">good</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> instr<span style="color:#990000">,</span> word<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> instr<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> word<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"I"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      bst<span style="color:#990000">.</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span>word<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"R"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      bst<span style="color:#990000">.</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>word<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"L"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"BST path: "</span> <span style="color:#990000">&lt;&lt;</span> bst<span style="color:#990000">.</span><b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span>word<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+  <span style="color:#FF0000">}</span>
+  cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"BST numNodes: "</span> <span style="color:#990000">&lt;&lt;</span> bst<span style="color:#990000">.</span><b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/inlab/BSTPathTest.cpp.html
+++ b/labs/lab05/code/inlab/BSTPathTest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/inlab/BinaryNode.cpp.html
+++ b/labs/lab05/code/inlab/BinaryNode.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,22 +8,22 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>BinaryNode.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"BinaryNode.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"BinaryNode.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-BinaryNode<font color="#990000">::</font><b><font color="#000000">BinaryNode</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  value <font color="#990000">=</font> <font color="#FF0000">"?"</font><font color="#990000">;</font>
-  left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-  right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+BinaryNode<span style="color:#990000">::</span><b><span style="color:#000000">BinaryNode</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  value <span style="color:#990000">=</span> <span style="color:#FF0000">"?"</span><span style="color:#990000">;</span>
+  left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+  right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-BinaryNode<font color="#990000">::~</font><b><font color="#000000">BinaryNode</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">delete</font></b> left<font color="#990000">;</font>
-  <b><font color="#0000FF">delete</font></b> right<font color="#990000">;</font>
-  left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-  right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font></tt></pre>
+BinaryNode<span style="color:#990000">::~</span><b><span style="color:#000000">BinaryNode</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">delete</span></b> left<span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">delete</span></b> right<span style="color:#990000">;</span>
+  left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+  right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/inlab/BinaryNode.cpp.html
+++ b/labs/lab05/code/inlab/BinaryNode.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/inlab/BinaryNode.h.html
+++ b/labs/lab05/code/inlab/BinaryNode.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/inlab/BinaryNode.h.html
+++ b/labs/lab05/code/inlab/BinaryNode.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,23 +8,23 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>BinaryNode.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> BINARYNODE_H
-<b><font color="#000080">#define</font></b> BINARYNODE_H
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> BINARYNODE_H
+<b><span style="color:#000080">#define</span></b> BINARYNODE_H
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">BinaryNode</font> <font color="#FF0000">{</font>
-  <b><font color="#000000">BinaryNode</font></b><font color="#990000">();</font>
-  <font color="#990000">~</font><b><font color="#000000">BinaryNode</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">BinaryNode</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#000000">BinaryNode</span></b><span style="color:#990000">();</span>
+  <span style="color:#990000">~</span><b><span style="color:#000000">BinaryNode</span></b><span style="color:#990000">();</span>
 
-  <font color="#008080">string</font> value<font color="#990000">;</font>
-  BinaryNode<font color="#990000">*</font> left<font color="#990000">;</font>
-  BinaryNode<font color="#990000">*</font> right<font color="#990000">;</font>
+  <span style="color:#008080">string</span> value<span style="color:#990000">;</span>
+  BinaryNode<span style="color:#990000">*</span> left<span style="color:#990000">;</span>
+  BinaryNode<span style="color:#990000">*</span> right<span style="color:#990000">;</span>
 
-  <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">BinarySearchTree</font><font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">BinarySearchTree</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b></tt></pre>
+<b><span style="color:#000080">#endif</span></b></pre>
 </body>
 </html>

--- a/labs/lab05/code/inlab/BinarySearchTree.cpp.html
+++ b/labs/lab05/code/inlab/BinarySearchTree.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,130 +8,130 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>BinarySearchTree.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"BinarySearchTree.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"BinaryNode.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"BinarySearchTree.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"BinaryNode.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-BinarySearchTree<font color="#990000">::</font><b><font color="#000000">BinarySearchTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font> root <font color="#990000">=</font> NULL<font color="#990000">;</font> <font color="#FF0000">}</font>
+BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">BinarySearchTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span> root <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span> <span style="color:#FF0000">}</span>
 
-BinarySearchTree<font color="#990000">::~</font><b><font color="#000000">BinarySearchTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">delete</font></b> root<font color="#990000">;</font>
-  root <font color="#990000">=</font> NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+BinarySearchTree<span style="color:#990000">::~</span><b><span style="color:#000000">BinarySearchTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">delete</span></b> root<span style="color:#990000">;</span>
+  root <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// insert finds a position for x in the tree and places it there.</font></i>
-<font color="#009900">void</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// insert finds a position for x in the tree and places it there.</span></i>
+<span style="color:#009900">void</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// remove finds x's position in the tree and removes it.</font></i>
-<font color="#009900">void</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font> root <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>root<font color="#990000">,</font> x<font color="#990000">);</font> <font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// remove finds x's position in the tree and removes it.</span></i>
+<span style="color:#009900">void</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span> root <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>root<span style="color:#990000">,</span> x<span style="color:#990000">);</span> <span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// pathTo finds x in the tree and returns a string representing the path it</font></i>
-<i><font color="#9A1900">// took to get there.</font></i>
-<font color="#008080">string</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">pathTo</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// pathTo finds x in the tree and returns a string representing the path it</span></i>
+<i><span style="color:#9A1900">// took to get there.</span></i>
+<span style="color:#008080">string</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// find determines whether or not x exists in the tree.</font></i>
-<font color="#009900">bool</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">find</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// find determines whether or not x exists in the tree.</span></i>
+<span style="color:#009900">bool</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// numNodes returns the total number of nodes in the tree.</font></i>
-<font color="#009900">int</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// numNodes returns the total number of nodes in the tree.</span></i>
+<span style="color:#009900">int</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// private helper for remove to allow recursion over different nodes. returns</font></i>
-<i><font color="#9A1900">// a BinaryNode* that is assigned to the original node.</font></i>
-BinaryNode<font color="#990000">*</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">remove</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*&amp;</font> n<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <i><font color="#9A1900">// first look for x</font></i>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">==</font> n<font color="#990000">-&gt;</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// found</font></i>
-    <i><font color="#9A1900">// no children</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL <font color="#990000">&amp;&amp;</font> n<font color="#990000">-&gt;</font>right <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// single child</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      BinaryNode<font color="#990000">*</font> temp <font color="#990000">=</font> n<font color="#990000">-&gt;</font>right<font color="#990000">;</font>
-      n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>right <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      BinaryNode<font color="#990000">*</font> temp <font color="#990000">=</font> n<font color="#990000">-&gt;</font>left<font color="#990000">;</font>
-      n<font color="#990000">-&gt;</font>left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// two children</font></i>
-    <font color="#008080">string</font> sr <font color="#990000">=</font> <b><font color="#000000">min</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">);</font>
-    n<font color="#990000">-&gt;</font>value <font color="#990000">=</font> sr<font color="#990000">;</font>
-    n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">,</font> sr<font color="#990000">);</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">&lt;</font> n<font color="#990000">-&gt;</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    n<font color="#990000">-&gt;</font>left <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>left<font color="#990000">,</font> x<font color="#990000">);</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-    n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">,</font> x<font color="#990000">);</font>
-  <font color="#FF0000">}</font>
-  <b><font color="#0000FF">return</font></b> n<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// private helper for remove to allow recursion over different nodes. returns</span></i>
+<i><span style="color:#9A1900">// a BinaryNode* that is assigned to the original node.</span></i>
+BinaryNode<span style="color:#990000">*</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <i><span style="color:#9A1900">// first look for x</span></i>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">==</span> n<span style="color:#990000">-&gt;</span>value<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// found</span></i>
+    <i><span style="color:#9A1900">// no children</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL <span style="color:#990000">&amp;&amp;</span> n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// single child</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      BinaryNode<span style="color:#990000">*</span> temp <span style="color:#990000">=</span> n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">;</span>
+      n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      BinaryNode<span style="color:#990000">*</span> temp <span style="color:#990000">=</span> n<span style="color:#990000">-&gt;</span>left<span style="color:#990000">;</span>
+      n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// two children</span></i>
+    <span style="color:#008080">string</span> sr <span style="color:#990000">=</span> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">);</span>
+    n<span style="color:#990000">-&gt;</span>value <span style="color:#990000">=</span> sr<span style="color:#990000">;</span>
+    n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> sr<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">&lt;</span> n<span style="color:#990000">-&gt;</span>value<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left<span style="color:#990000">,</span> x<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+    n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> x<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span>
+  <b><span style="color:#0000FF">return</span></b> n<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// min finds the string with the smallest value in a subtree.</font></i>
-<font color="#008080">string</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">min</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// go to bottom-left node</font></i>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>node<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> node<font color="#990000">-&gt;</font>value<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <b><font color="#0000FF">return</font></b> <b><font color="#000000">min</font></b><font color="#990000">(</font>node<font color="#990000">-&gt;</font>left<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// min finds the string with the smallest value in a subtree.</span></i>
+<span style="color:#008080">string</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// go to bottom-left node</span></i>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>node<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> node<span style="color:#990000">-&gt;</span>value<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>node<span style="color:#990000">-&gt;</span>left<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Helper function to print branches of the binary tree</font></i>
-<font color="#009900">void</font> <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>Trunk<font color="#990000">*</font> p<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>p <font color="#990000">==</font> nullptr<font color="#990000">)</font> <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
-  <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>p<font color="#990000">-&gt;</font>prev<font color="#990000">);</font>
-  cout <font color="#990000">&lt;&lt;</font> p<font color="#990000">-&gt;</font>str<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Helper function to print branches of the binary tree</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>Trunk<span style="color:#990000">*</span> p<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>p <span style="color:#990000">==</span> nullptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
+  <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>p<span style="color:#990000">-&gt;</span>prev<span style="color:#990000">);</span>
+  cout <span style="color:#990000">&lt;&lt;</span> p<span style="color:#990000">-&gt;</span>str<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Recursive function to print binary tree</font></i>
-<i><font color="#9A1900">// It uses inorder traversal</font></i>
-<font color="#009900">void</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">printTree</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*</font> root<font color="#990000">,</font> Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#009900">bool</font> isLeft<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>root <font color="#990000">==</font> NULL<font color="#990000">)</font> <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
+<i><span style="color:#9A1900">// Recursive function to print binary tree</span></i>
+<i><span style="color:#9A1900">// It uses inorder traversal</span></i>
+<span style="color:#009900">void</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*</span> root<span style="color:#990000">,</span> Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#009900">bool</span> isRight<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>root <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
 
-  <font color="#008080">string</font> prev_str <font color="#990000">=</font> <font color="#FF0000">"    "</font><font color="#990000">;</font>
-  Trunk<font color="#990000">*</font> trunk <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">Trunk</font></b><font color="#990000">(</font>prev<font color="#990000">,</font> prev_str<font color="#990000">);</font>
+  <span style="color:#008080">string</span> prev_str <span style="color:#990000">=</span> <span style="color:#FF0000">"    "</span><span style="color:#990000">;</span>
+  Trunk<span style="color:#990000">*</span> trunk <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Trunk</span></b><span style="color:#990000">(</span>prev<span style="color:#990000">,</span> prev_str<span style="color:#990000">);</span>
 
-  <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">-&gt;</font>left<font color="#990000">,</font> trunk<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
+  <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> trunk<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
 
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(!</font>prev<font color="#990000">)</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"---"</font><font color="#990000">;</font>
-  <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>isLeft<font color="#990000">)</font> <font color="#FF0000">{</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">".---"</font><font color="#990000">;</font>
-    prev_str <font color="#990000">=</font> <font color="#FF0000">"   |"</font><font color="#990000">;</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"`---"</font><font color="#990000">;</font>
-    prev<font color="#990000">-&gt;</font>str <font color="#990000">=</font> prev_str<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(!</span>prev<span style="color:#990000">)</span>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"---"</span><span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>isRight<span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <i><span style="color:#9A1900">// github user @willzhang05 pointed out that I forgot to change this from isLeft to isRight on my first commit</span></i>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">".---"</span><span style="color:#990000">;</span>
+    prev_str <span style="color:#990000">=</span> <span style="color:#FF0000">"   |"</span><span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"`---"</span><span style="color:#990000">;</span>
+    prev<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> prev_str<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
 
-  <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>trunk<font color="#990000">);</font>
-  cout <font color="#990000">&lt;&lt;</font> root<font color="#990000">-&gt;</font>value <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+  <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>trunk<span style="color:#990000">);</span>
+  cout <span style="color:#990000">&lt;&lt;</span> root<span style="color:#990000">-&gt;</span>value <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>prev<font color="#990000">)</font> prev<font color="#990000">-&gt;</font>str <font color="#990000">=</font> prev_str<font color="#990000">;</font>
-  trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"   |"</font><font color="#990000">;</font>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>prev<span style="color:#990000">)</span> prev<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> prev_str<span style="color:#990000">;</span>
+  trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"   |"</span><span style="color:#990000">;</span>
 
-  <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">-&gt;</font>right<font color="#990000">,</font> trunk<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+  <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">-&gt;</span>left<span style="color:#990000">,</span> trunk<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> BinarySearchTree<font color="#990000">::</font><b><font color="#000000">printTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font> <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">,</font> NULL<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font> <font color="#FF0000">}</font></tt></pre>
+<span style="color:#009900">void</span> BinarySearchTree<span style="color:#990000">::</span><b><span style="color:#000000">printTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">,</span> NULL<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span> <span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/inlab/BinarySearchTree.cpp.html
+++ b/labs/lab05/code/inlab/BinarySearchTree.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/inlab/BinarySearchTree.h.html
+++ b/labs/lab05/code/inlab/BinarySearchTree.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/inlab/BinarySearchTree.h.html
+++ b/labs/lab05/code/inlab/BinarySearchTree.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,61 +8,61 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>BinarySearchTree.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> BST_H
-<b><font color="#000080">#define</font></b> BST_H
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> BST_H
+<b><span style="color:#000080">#define</span></b> BST_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"BinaryNode.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"BinaryNode.h"</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">struct</font></b> <font color="#008080">Trunk</font> <font color="#FF0000">{</font>
-  Trunk<font color="#990000">*</font> prev<font color="#990000">;</font>
-  <font color="#008080">string</font> str<font color="#990000">;</font>
+<b><span style="color:#0000FF">struct</span></b> <span style="color:#008080">Trunk</span> <span style="color:#FF0000">{</span>
+  Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">;</span>
+  <span style="color:#008080">string</span> str<span style="color:#990000">;</span>
 
-  <b><font color="#000000">Trunk</font></b><font color="#990000">(</font>Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#008080">string</font> str<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>prev <font color="#990000">=</font> prev<font color="#990000">;</font>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>str <font color="#990000">=</font> str<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <b><span style="color:#000000">Trunk</span></b><span style="color:#990000">(</span>Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#008080">string</span> str<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>prev <span style="color:#990000">=</span> prev<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> str<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">BinarySearchTree</font> <font color="#FF0000">{</font>
- <b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-  <b><font color="#000000">BinarySearchTree</font></b><font color="#990000">();</font>
-  <font color="#990000">~</font><b><font color="#000000">BinarySearchTree</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">BinarySearchTree</span> <span style="color:#FF0000">{</span>
+ <b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+  <b><span style="color:#000000">BinarySearchTree</span></b><span style="color:#990000">();</span>
+  <span style="color:#990000">~</span><b><span style="color:#000000">BinarySearchTree</span></b><span style="color:#990000">();</span>
 
-  <i><font color="#9A1900">// insert finds a position for x in the tree and places it there.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// remove finds x's position in the tree and removes it.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// printTree pretty-prints the tree to aid debugging.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">printTree</font></b><font color="#990000">();</font>
+  <i><span style="color:#9A1900">// insert finds a position for x in the tree and places it there.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// remove finds x's position in the tree and removes it.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// printTree pretty-prints the tree to aid debugging.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">();</span>
 
-  <i><font color="#9A1900">// pathTo finds x in the tree and returns a string representing the path it</font></i>
-  <i><font color="#9A1900">// took to get there.</font></i>
-  <font color="#008080">string</font> <b><font color="#000000">pathTo</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-  <i><font color="#9A1900">// find determines whether or not x exists in the tree.</font></i>
-  <font color="#009900">bool</font> <b><font color="#000000">find</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-  <i><font color="#9A1900">// numNodes returns the total number of nodes in the tree.</font></i>
-  <font color="#009900">int</font> <b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// pathTo finds x in the tree and returns a string representing the path it</span></i>
+  <i><span style="color:#9A1900">// took to get there.</span></i>
+  <span style="color:#008080">string</span> <b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// find determines whether or not x exists in the tree.</span></i>
+  <span style="color:#009900">bool</span> <b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// numNodes returns the total number of nodes in the tree.</span></i>
+  <span style="color:#009900">int</span> <b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
- <b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-  <i><font color="#9A1900">// Declare a root node</font></i>
-  BinaryNode<font color="#990000">*</font> root<font color="#990000">;</font>
+ <b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+  <i><span style="color:#9A1900">// Declare a root node</span></i>
+  BinaryNode<span style="color:#990000">*</span> root<span style="color:#990000">;</span>
 
-  <i><font color="#9A1900">// private helper for remove to allow recursion over different nodes. returns</font></i>
-  <i><font color="#9A1900">// a BinaryNode* that is assigned to the original node.</font></i>
-  BinaryNode<font color="#990000">*</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*&amp;</font> n<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// min finds the string with the smallest value in a subtree.</font></i>
-  <font color="#008080">string</font> <b><font color="#000000">min</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// private helper for remove to allow recursion over different nodes. returns</span></i>
+  <i><span style="color:#9A1900">// a BinaryNode* that is assigned to the original node.</span></i>
+  BinaryNode<span style="color:#990000">*</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// min finds the string with the smallest value in a subtree.</span></i>
+  <span style="color:#008080">string</span> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-  <i><font color="#9A1900">// private helper for printTree to allow recursion over different nodes.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">printTree</font></b><font color="#990000">(</font>BinaryNode<font color="#990000">*</font> root<font color="#990000">,</font> Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#009900">bool</font> isLeft<font color="#990000">);</font>
+  <i><span style="color:#9A1900">// private helper for printTree to allow recursion over different nodes.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>BinaryNode<span style="color:#990000">*</span> root<span style="color:#990000">,</span> Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#009900">bool</span> isRight<span style="color:#990000">);</span>
 
-  <i><font color="#9A1900">// Any other methods you need...</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// Any other methods you need...</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b></tt></pre>
+<b><span style="color:#000080">#endif</span></b></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLNode.cpp.html
+++ b/labs/lab05/code/postlab/AVLNode.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,23 +8,23 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>AVLNode.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"AVLNode.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"AVLNode.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-AVLNode<font color="#990000">::</font><b><font color="#000000">AVLNode</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  value <font color="#990000">=</font> <font color="#FF0000">"?"</font><font color="#990000">;</font>
-  left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-  right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-  height <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+AVLNode<span style="color:#990000">::</span><b><span style="color:#000000">AVLNode</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  value <span style="color:#990000">=</span> <span style="color:#FF0000">"?"</span><span style="color:#990000">;</span>
+  left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+  right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+  height <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-AVLNode<font color="#990000">::~</font><b><font color="#000000">AVLNode</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">delete</font></b> left<font color="#990000">;</font>
-  <b><font color="#0000FF">delete</font></b> right<font color="#990000">;</font>
-  left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-  right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font></tt></pre>
+AVLNode<span style="color:#990000">::~</span><b><span style="color:#000000">AVLNode</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">delete</span></b> left<span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">delete</span></b> right<span style="color:#990000">;</span>
+  left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+  right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLNode.cpp.html
+++ b/labs/lab05/code/postlab/AVLNode.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/postlab/AVLNode.h.html
+++ b/labs/lab05/code/postlab/AVLNode.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/postlab/AVLNode.h.html
+++ b/labs/lab05/code/postlab/AVLNode.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,24 +8,24 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>AVLNode.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> AVLNODE_H
-<b><font color="#000080">#define</font></b> AVLNODE_H
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> AVLNODE_H
+<b><span style="color:#000080">#define</span></b> AVLNODE_H
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">AVLNode</font> <font color="#FF0000">{</font>
-  <b><font color="#000000">AVLNode</font></b><font color="#990000">();</font>
-  <font color="#990000">~</font><b><font color="#000000">AVLNode</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">AVLNode</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#000000">AVLNode</span></b><span style="color:#990000">();</span>
+  <span style="color:#990000">~</span><b><span style="color:#000000">AVLNode</span></b><span style="color:#990000">();</span>
 
-  <font color="#008080">string</font> value<font color="#990000">;</font>
-  AVLNode<font color="#990000">*</font> left<font color="#990000">;</font>
-  AVLNode<font color="#990000">*</font> right<font color="#990000">;</font>
-  <font color="#009900">int</font> height<font color="#990000">;</font>
+  <span style="color:#008080">string</span> value<span style="color:#990000">;</span>
+  AVLNode<span style="color:#990000">*</span> left<span style="color:#990000">;</span>
+  AVLNode<span style="color:#990000">*</span> right<span style="color:#990000">;</span>
+  <span style="color:#009900">int</span> height<span style="color:#990000">;</span>
 
-  <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">AVLTree</font><font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">AVLTree</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b></tt></pre>
+<b><span style="color:#000080">#endif</span></b></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLPathTest.cpp.html
+++ b/labs/lab05/code/postlab/AVLPathTest.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,27 +8,27 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>AVLPathTest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"AVLTree.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"AVLTree.h"</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <font color="#008080">AVLTree</font> avl<font color="#990000">;</font>
-  <b><font color="#0000FF">while</font></b> <font color="#990000">(</font>cin<font color="#990000">.</font><b><font color="#000000">good</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> instr<font color="#990000">,</font> word<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> instr<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> word<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"I"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      avl<font color="#990000">.</font><b><font color="#000000">insert</font></b><font color="#990000">(</font>word<font color="#990000">);</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"R"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      avl<font color="#990000">.</font><b><font color="#000000">remove</font></b><font color="#990000">(</font>word<font color="#990000">);</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>instr <font color="#990000">==</font> <font color="#FF0000">"L"</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-      cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"AVL path: "</font> <font color="#990000">&lt;&lt;</font> avl<font color="#990000">.</font><b><font color="#000000">pathTo</font></b><font color="#990000">(</font>word<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-  <font color="#FF0000">}</font>
-  cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"AVL numNodes: "</font> <font color="#990000">&lt;&lt;</font> avl<font color="#990000">.</font><b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font></tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <span style="color:#008080">AVLTree</span> avl<span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span>cin<span style="color:#990000">.</span><b><span style="color:#000000">good</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> instr<span style="color:#990000">,</span> word<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> instr<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> word<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"I"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      avl<span style="color:#990000">.</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span>word<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"R"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      avl<span style="color:#990000">.</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>word<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>instr <span style="color:#990000">==</span> <span style="color:#FF0000">"L"</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"AVL path: "</span> <span style="color:#990000">&lt;&lt;</span> avl<span style="color:#990000">.</span><b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span>word<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+  <span style="color:#FF0000">}</span>
+  cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"AVL numNodes: "</span> <span style="color:#990000">&lt;&lt;</span> avl<span style="color:#990000">.</span><b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLPathTest.cpp.html
+++ b/labs/lab05/code/postlab/AVLPathTest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/postlab/AVLTree.cpp.html
+++ b/labs/lab05/code/postlab/AVLTree.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/postlab/AVLTree.cpp.html
+++ b/labs/lab05/code/postlab/AVLTree.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,167 +8,167 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>AVLTree.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"AVLTree.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"AVLNode.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"AVLTree.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"AVLNode.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-AVLTree<font color="#990000">::</font><b><font color="#000000">AVLTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font> root <font color="#990000">=</font> NULL<font color="#990000">;</font> <font color="#FF0000">}</font>
+AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">AVLTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span> root <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span> <span style="color:#FF0000">}</span>
 
-AVLTree<font color="#990000">::~</font><b><font color="#000000">AVLTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">delete</font></b> root<font color="#990000">;</font>
-  root <font color="#990000">=</font> NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+AVLTree<span style="color:#990000">::~</span><b><span style="color:#000000">AVLTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">delete</span></b> root<span style="color:#990000">;</span>
+  root <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// insert finds a position for x in the tree and places it there, rebalancing</font></i>
-<i><font color="#9A1900">// as necessary.</font></i>
-<font color="#009900">void</font> AVLTree<font color="#990000">::</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// insert finds a position for x in the tree and places it there, rebalancing</span></i>
+<i><span style="color:#9A1900">// as necessary.</span></i>
+<span style="color:#009900">void</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// remove finds x's position in the tree and removes it, rebalancing as</font></i>
-<i><font color="#9A1900">// necessary.</font></i>
-<font color="#009900">void</font> AVLTree<font color="#990000">::</font><b><font color="#000000">remove</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font> root <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>root<font color="#990000">,</font> x<font color="#990000">);</font> <font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// remove finds x's position in the tree and removes it, rebalancing as</span></i>
+<i><span style="color:#9A1900">// necessary.</span></i>
+<span style="color:#009900">void</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span> root <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>root<span style="color:#990000">,</span> x<span style="color:#990000">);</span> <span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// pathTo finds x in the tree and returns a string representing the path it</font></i>
-<i><font color="#9A1900">// took to get there.</font></i>
-<font color="#008080">string</font> AVLTree<font color="#990000">::</font><b><font color="#000000">pathTo</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// pathTo finds x in the tree and returns a string representing the path it</span></i>
+<i><span style="color:#9A1900">// took to get there.</span></i>
+<span style="color:#008080">string</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// find determines whether or not x exists in the tree.</font></i>
-<font color="#009900">bool</font> AVLTree<font color="#990000">::</font><b><font color="#000000">find</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// find determines whether or not x exists in the tree.</span></i>
+<span style="color:#009900">bool</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// numNodes returns the total number of nodes in the tree.</font></i>
-<font color="#009900">int</font> AVLTree<font color="#990000">::</font><b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// numNodes returns the total number of nodes in the tree.</span></i>
+<span style="color:#009900">int</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// balance makes sure that the subtree with root n maintains the AVL tree</font></i>
-<i><font color="#9A1900">// property, namely that the balance factor of n is either -1, 0, or 1.</font></i>
-<font color="#009900">void</font> AVLTree<font color="#990000">::</font><b><font color="#000000">balance</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// balance makes sure that the subtree with root n maintains the AVL tree</span></i>
+<i><span style="color:#9A1900">// property, namely that the balance factor of n is either -1, 0, or 1.</span></i>
+<span style="color:#009900">void</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">balance</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// rotateLeft performs a single rotation on node n with its right child.</font></i>
-AVLNode<font color="#990000">*</font> AVLTree<font color="#990000">::</font><b><font color="#000000">rotateLeft</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// rotateLeft performs a single rotation on node n with its right child.</span></i>
+AVLNode<span style="color:#990000">*</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">rotateLeft</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// rotateRight performs a single rotation on node n with its left child.</font></i>
-AVLNode<font color="#990000">*</font> AVLTree<font color="#990000">::</font><b><font color="#000000">rotateRight</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// YOUR IMPLEMENTATION GOES HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// rotateRight performs a single rotation on node n with its left child.</span></i>
+AVLNode<span style="color:#990000">*</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">rotateRight</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// YOUR IMPLEMENTATION GOES HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// private helper for remove to allow recursion over different nodes. returns</font></i>
-<i><font color="#9A1900">// an AVLNode* that is assigned to the original node.</font></i>
-AVLNode<font color="#990000">*</font> AVLTree<font color="#990000">::</font><b><font color="#000000">remove</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <i><font color="#9A1900">// first look for x</font></i>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">==</font> n<font color="#990000">-&gt;</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// found</font></i>
-    <i><font color="#9A1900">// no children</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL <font color="#990000">&amp;&amp;</font> n<font color="#990000">-&gt;</font>right <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> NULL<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// single child</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      AVLNode<font color="#990000">*</font> temp <font color="#990000">=</font> n<font color="#990000">-&gt;</font>right<font color="#990000">;</font>
-      n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n<font color="#990000">-&gt;</font>right <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-      AVLNode<font color="#990000">*</font> temp <font color="#990000">=</font> n<font color="#990000">-&gt;</font>left<font color="#990000">;</font>
-      n<font color="#990000">-&gt;</font>left <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">delete</font></b> n<font color="#990000">;</font>
-      n <font color="#990000">=</font> NULL<font color="#990000">;</font>
-      <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// two children -- tree may become unbalanced after deleting n</font></i>
-    <font color="#008080">string</font> sr <font color="#990000">=</font> <b><font color="#000000">min</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">);</font>
-    n<font color="#990000">-&gt;</font>value <font color="#990000">=</font> sr<font color="#990000">;</font>
-    n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">,</font> sr<font color="#990000">);</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">&lt;</font> n<font color="#990000">-&gt;</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    n<font color="#990000">-&gt;</font>left <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>left<font color="#990000">,</font> x<font color="#990000">);</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-    n<font color="#990000">-&gt;</font>right <font color="#990000">=</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">,</font> x<font color="#990000">);</font>
-  <font color="#FF0000">}</font>
-  n<font color="#990000">-&gt;</font>height <font color="#990000">=</font> <font color="#993399">1</font> <font color="#990000">+</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><b><font color="#000000">height</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>left<font color="#990000">),</font> <b><font color="#000000">height</font></b><font color="#990000">(</font>n<font color="#990000">-&gt;</font>right<font color="#990000">));</font>
-  <b><font color="#000000">balance</font></b><font color="#990000">(</font>n<font color="#990000">);</font>
-  <b><font color="#0000FF">return</font></b> n<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// private helper for remove to allow recursion over different nodes. returns</span></i>
+<i><span style="color:#9A1900">// an AVLNode* that is assigned to the original node.</span></i>
+AVLNode<span style="color:#990000">*</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <i><span style="color:#9A1900">// first look for x</span></i>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">==</span> n<span style="color:#990000">-&gt;</span>value<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// found</span></i>
+    <i><span style="color:#9A1900">// no children</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL <span style="color:#990000">&amp;&amp;</span> n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> NULL<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// single child</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      AVLNode<span style="color:#990000">*</span> temp <span style="color:#990000">=</span> n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">;</span>
+      n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+      AVLNode<span style="color:#990000">*</span> temp <span style="color:#990000">=</span> n<span style="color:#990000">-&gt;</span>left<span style="color:#990000">;</span>
+      n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">delete</span></b> n<span style="color:#990000">;</span>
+      n <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+      <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// two children -- tree may become unbalanced after deleting n</span></i>
+    <span style="color:#008080">string</span> sr <span style="color:#990000">=</span> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">);</span>
+    n<span style="color:#990000">-&gt;</span>value <span style="color:#990000">=</span> sr<span style="color:#990000">;</span>
+    n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> sr<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">&lt;</span> n<span style="color:#990000">-&gt;</span>value<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    n<span style="color:#990000">-&gt;</span>left <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left<span style="color:#990000">,</span> x<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+    n<span style="color:#990000">-&gt;</span>right <span style="color:#990000">=</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> x<span style="color:#990000">);</span>
+  <span style="color:#FF0000">}</span>
+  n<span style="color:#990000">-&gt;</span>height <span style="color:#990000">=</span> <span style="color:#993399">1</span> <span style="color:#990000">+</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><b><span style="color:#000000">height</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>left<span style="color:#990000">),</span> <b><span style="color:#000000">height</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-&gt;</span>right<span style="color:#990000">));</span>
+  <b><span style="color:#000000">balance</span></b><span style="color:#990000">(</span>n<span style="color:#990000">);</span>
+  <b><span style="color:#0000FF">return</span></b> n<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// min finds the string with the smallest value in a subtree.</font></i>
-<font color="#008080">string</font> AVLTree<font color="#990000">::</font><b><font color="#000000">min</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <i><font color="#9A1900">// go to bottom-left node</font></i>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>node<font color="#990000">-&gt;</font>left <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> node<font color="#990000">-&gt;</font>value<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <b><font color="#0000FF">return</font></b> <b><font color="#000000">min</font></b><font color="#990000">(</font>node<font color="#990000">-&gt;</font>left<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// min finds the string with the smallest value in a subtree.</span></i>
+<span style="color:#008080">string</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <i><span style="color:#9A1900">// go to bottom-left node</span></i>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>node<span style="color:#990000">-&gt;</span>left <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> node<span style="color:#990000">-&gt;</span>value<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>node<span style="color:#990000">-&gt;</span>left<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// height returns the value of the height field in a node. If the node is</font></i>
-<i><font color="#9A1900">// null, it returns -1.</font></i>
-<font color="#009900">int</font> AVLTree<font color="#990000">::</font><b><font color="#000000">height</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>node <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <b><font color="#0000FF">return</font></b> node<font color="#990000">-&gt;</font>height<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// height returns the value of the height field in a node. If the node is</span></i>
+<i><span style="color:#9A1900">// null, it returns -1.</span></i>
+<span style="color:#009900">int</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">height</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>node <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <b><span style="color:#0000FF">return</span></b> node<span style="color:#990000">-&gt;</span>height<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// max returns the greater of two integers.</font></i>
-<font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> a<font color="#990000">,</font> <font color="#009900">int</font> b<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>a <font color="#990000">&gt;</font> b<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> a<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-  <b><font color="#0000FF">return</font></b> b<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// max returns the greater of two integers.</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> a<span style="color:#990000">,</span> <span style="color:#009900">int</span> b<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>a <span style="color:#990000">&gt;</span> b<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> a<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  <b><span style="color:#0000FF">return</span></b> b<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Helper function to print branches of the binary tree</font></i>
-<font color="#009900">void</font> <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>Trunk<font color="#990000">*</font> p<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>p <font color="#990000">==</font> nullptr<font color="#990000">)</font> <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
-  <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>p<font color="#990000">-&gt;</font>prev<font color="#990000">);</font>
-  cout <font color="#990000">&lt;&lt;</font> p<font color="#990000">-&gt;</font>str<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Helper function to print branches of the binary tree</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>Trunk<span style="color:#990000">*</span> p<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>p <span style="color:#990000">==</span> nullptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
+  <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>p<span style="color:#990000">-&gt;</span>prev<span style="color:#990000">);</span>
+  cout <span style="color:#990000">&lt;&lt;</span> p<span style="color:#990000">-&gt;</span>str<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Recursive function to print binary tree</font></i>
-<i><font color="#9A1900">// It uses inorder traversal</font></i>
-<font color="#009900">void</font> AVLTree<font color="#990000">::</font><b><font color="#000000">printTree</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> root<font color="#990000">,</font> Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#009900">bool</font> isLeft<font color="#990000">)</font> <font color="#FF0000">{</font>
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>root <font color="#990000">==</font> NULL<font color="#990000">)</font> <b><font color="#0000FF">return</font></b><font color="#990000">;</font>
+<i><span style="color:#9A1900">// Recursive function to print binary tree</span></i>
+<i><span style="color:#9A1900">// It uses inorder traversal</span></i>
+<span style="color:#009900">void</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> root<span style="color:#990000">,</span> Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#009900">bool</span> isRight<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>root <span style="color:#990000">==</span> NULL<span style="color:#990000">)</span> <b><span style="color:#0000FF">return</span></b><span style="color:#990000">;</span>
 
-  <font color="#008080">string</font> prev_str <font color="#990000">=</font> <font color="#FF0000">"    "</font><font color="#990000">;</font>
-  Trunk<font color="#990000">*</font> trunk <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">Trunk</font></b><font color="#990000">(</font>prev<font color="#990000">,</font> prev_str<font color="#990000">);</font>
+  <span style="color:#008080">string</span> prev_str <span style="color:#990000">=</span> <span style="color:#FF0000">"    "</span><span style="color:#990000">;</span>
+  Trunk<span style="color:#990000">*</span> trunk <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Trunk</span></b><span style="color:#990000">(</span>prev<span style="color:#990000">,</span> prev_str<span style="color:#990000">);</span>
 
-  <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">-&gt;</font>left<font color="#990000">,</font> trunk<font color="#990000">,</font> <b><font color="#0000FF">true</font></b><font color="#990000">);</font>
+  <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">-&gt;</span>right<span style="color:#990000">,</span> trunk<span style="color:#990000">,</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">);</span>
 
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(!</font>prev<font color="#990000">)</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"---"</font><font color="#990000">;</font>
-  <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>isLeft<font color="#990000">)</font> <font color="#FF0000">{</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">".---"</font><font color="#990000">;</font>
-    prev_str <font color="#990000">=</font> <font color="#FF0000">"   |"</font><font color="#990000">;</font>
-  <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-    trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"`---"</font><font color="#990000">;</font>
-    prev<font color="#990000">-&gt;</font>str <font color="#990000">=</font> prev_str<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(!</span>prev<span style="color:#990000">)</span>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"---"</span><span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>isRight<span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <i><span style="color:#9A1900">// github user @willzhang05 pointed out that I forgot to change this from isLeft to isRight on my first commit</span></i>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">".---"</span><span style="color:#990000">;</span>
+    prev_str <span style="color:#990000">=</span> <span style="color:#FF0000">"   |"</span><span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+    trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"`---"</span><span style="color:#990000">;</span>
+    prev<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> prev_str<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
 
-  <b><font color="#000000">showTrunks</font></b><font color="#990000">(</font>trunk<font color="#990000">);</font>
-  cout <font color="#990000">&lt;&lt;</font> root<font color="#990000">-&gt;</font>value <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+  <b><span style="color:#000000">showTrunks</span></b><span style="color:#990000">(</span>trunk<span style="color:#990000">);</span>
+  cout <span style="color:#990000">&lt;&lt;</span> root<span style="color:#990000">-&gt;</span>value <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-  <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>prev<font color="#990000">)</font> prev<font color="#990000">-&gt;</font>str <font color="#990000">=</font> prev_str<font color="#990000">;</font>
-  trunk<font color="#990000">-&gt;</font>str <font color="#990000">=</font> <font color="#FF0000">"   |"</font><font color="#990000">;</font>
+  <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>prev<span style="color:#990000">)</span> prev<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> prev_str<span style="color:#990000">;</span>
+  trunk<span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> <span style="color:#FF0000">"   |"</span><span style="color:#990000">;</span>
 
-  <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">-&gt;</font>right<font color="#990000">,</font> trunk<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+  <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">-&gt;</span>left<span style="color:#990000">,</span> trunk<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> AVLTree<font color="#990000">::</font><b><font color="#000000">printTree</font></b><font color="#990000">()</font> <font color="#FF0000">{</font> <b><font color="#000000">printTree</font></b><font color="#990000">(</font>root<font color="#990000">,</font> NULL<font color="#990000">,</font> <b><font color="#0000FF">false</font></b><font color="#990000">);</font> <font color="#FF0000">}</font></tt></pre>
+<span style="color:#009900">void</span> AVLTree<span style="color:#990000">::</span><b><span style="color:#000000">printTree</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>root<span style="color:#990000">,</span> NULL<span style="color:#990000">,</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">);</span> <span style="color:#FF0000">}</span></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLTree.h.html
+++ b/labs/lab05/code/postlab/AVLTree.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,77 +8,77 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>AVLTree.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> AVL_H
-<b><font color="#000080">#define</font></b> AVL_H
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> AVL_H
+<b><span style="color:#000080">#define</span></b> AVL_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"AVLNode.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"AVLNode.h"</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">struct</font></b> <font color="#008080">Trunk</font> <font color="#FF0000">{</font>
-  Trunk<font color="#990000">*</font> prev<font color="#990000">;</font>
-  <font color="#008080">string</font> str<font color="#990000">;</font>
+<b><span style="color:#0000FF">struct</span></b> <span style="color:#008080">Trunk</span> <span style="color:#FF0000">{</span>
+  Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">;</span>
+  <span style="color:#008080">string</span> str<span style="color:#990000">;</span>
 
-  <b><font color="#000000">Trunk</font></b><font color="#990000">(</font>Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#008080">string</font> str<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>prev <font color="#990000">=</font> prev<font color="#990000">;</font>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>str <font color="#990000">=</font> str<font color="#990000">;</font>
-  <font color="#FF0000">}</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <b><span style="color:#000000">Trunk</span></b><span style="color:#990000">(</span>Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#008080">string</span> str<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>prev <span style="color:#990000">=</span> prev<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>str <span style="color:#990000">=</span> str<span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">AVLTree</font> <font color="#FF0000">{</font>
- <b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-  <b><font color="#000000">AVLTree</font></b><font color="#990000">();</font>
-  <font color="#990000">~</font><b><font color="#000000">AVLTree</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">AVLTree</span> <span style="color:#FF0000">{</span>
+ <b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+  <b><span style="color:#000000">AVLTree</span></b><span style="color:#990000">();</span>
+  <span style="color:#990000">~</span><b><span style="color:#000000">AVLTree</span></b><span style="color:#990000">();</span>
 
-  <i><font color="#9A1900">// insert finds a position for x in the tree and places it there, rebalancing</font></i>
-  <i><font color="#9A1900">// as necessary.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// remove finds x's position in the tree and removes it, rebalancing as</font></i>
-  <i><font color="#9A1900">// necessary.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// printTree pretty-prints the tree to aid debugging.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">printTree</font></b><font color="#990000">();</font>
+  <i><span style="color:#9A1900">// insert finds a position for x in the tree and places it there, rebalancing</span></i>
+  <i><span style="color:#9A1900">// as necessary.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// remove finds x's position in the tree and removes it, rebalancing as</span></i>
+  <i><span style="color:#9A1900">// necessary.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// printTree pretty-prints the tree to aid debugging.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">();</span>
 
-  <i><font color="#9A1900">// pathTo finds x in the tree and returns a string representing the path it</font></i>
-  <i><font color="#9A1900">// took to get there.</font></i>
-  <font color="#008080">string</font> <b><font color="#000000">pathTo</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-  <i><font color="#9A1900">// find determines whether or not x exists in the tree.</font></i>
-  <font color="#009900">bool</font> <b><font color="#000000">find</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-  <i><font color="#9A1900">// numNodes returns the total number of nodes in the tree.</font></i>
-  <font color="#009900">int</font> <b><font color="#000000">numNodes</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// pathTo finds x in the tree and returns a string representing the path it</span></i>
+  <i><span style="color:#9A1900">// took to get there.</span></i>
+  <span style="color:#008080">string</span> <b><span style="color:#000000">pathTo</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// find determines whether or not x exists in the tree.</span></i>
+  <span style="color:#009900">bool</span> <b><span style="color:#000000">find</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// numNodes returns the total number of nodes in the tree.</span></i>
+  <span style="color:#009900">int</span> <b><span style="color:#000000">numNodes</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
- <b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-  <i><font color="#9A1900">// Declare a root node</font></i>
-  AVLNode<font color="#990000">*</font> root<font color="#990000">;</font>
+ <b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+  <i><span style="color:#9A1900">// Declare a root node</span></i>
+  AVLNode<span style="color:#990000">*</span> root<span style="color:#990000">;</span>
 
-  <i><font color="#9A1900">// balance makes sure that the subtree with root n maintains the AVL tree</font></i>
-  <i><font color="#9A1900">// property, namely that the balance factor of n is either -1, 0, or 1.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">balance</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">);</font>
-  <i><font color="#9A1900">// rotateLeft performs a single rotation on node n with its right child.</font></i>
-  AVLNode<font color="#990000">*</font> <b><font color="#000000">rotateLeft</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">);</font>
-  <i><font color="#9A1900">// rotateRight performs a single rotation on node n with its left child.</font></i>
-  AVLNode<font color="#990000">*</font> <b><font color="#000000">rotateRight</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">);</font>
+  <i><span style="color:#9A1900">// balance makes sure that the subtree with root n maintains the AVL tree</span></i>
+  <i><span style="color:#9A1900">// property, namely that the balance factor of n is either -1, 0, or 1.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">balance</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// rotateLeft performs a single rotation on node n with its right child.</span></i>
+  AVLNode<span style="color:#990000">*</span> <b><span style="color:#000000">rotateLeft</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// rotateRight performs a single rotation on node n with its left child.</span></i>
+  AVLNode<span style="color:#990000">*</span> <b><span style="color:#000000">rotateRight</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">);</span>
 
-  <i><font color="#9A1900">// private helper for remove to allow recursion over different nodes. returns</font></i>
-  <i><font color="#9A1900">// an AVLNode* that is assigned to the original node.</font></i>
-  AVLNode<font color="#990000">*</font> <b><font color="#000000">remove</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*&amp;</font> n<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-  <i><font color="#9A1900">// min finds the string with the smallest value in a subtree.</font></i>
-  <font color="#008080">string</font> <b><font color="#000000">min</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-  <i><font color="#9A1900">// height returns the value of the height field in a node. If the node is</font></i>
-  <i><font color="#9A1900">// null, it returns -1.</font></i>
-  <font color="#009900">int</font> <b><font color="#000000">height</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> node<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// private helper for remove to allow recursion over different nodes. returns</span></i>
+  <i><span style="color:#9A1900">// an AVLNode* that is assigned to the original node.</span></i>
+  AVLNode<span style="color:#990000">*</span> <b><span style="color:#000000">remove</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*&amp;</span> n<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+  <i><span style="color:#9A1900">// min finds the string with the smallest value in a subtree.</span></i>
+  <span style="color:#008080">string</span> <b><span style="color:#000000">min</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// height returns the value of the height field in a node. If the node is</span></i>
+  <i><span style="color:#9A1900">// null, it returns -1.</span></i>
+  <span style="color:#009900">int</span> <b><span style="color:#000000">height</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> node<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-  <i><font color="#9A1900">// private helper for printTree to allow recursion over different nodes.</font></i>
-  <font color="#009900">void</font> <b><font color="#000000">printTree</font></b><font color="#990000">(</font>AVLNode<font color="#990000">*</font> root<font color="#990000">,</font> Trunk<font color="#990000">*</font> prev<font color="#990000">,</font> <font color="#009900">bool</font> isLeft<font color="#990000">);</font>
+  <i><span style="color:#9A1900">// private helper for printTree to allow recursion over different nodes.</span></i>
+  <span style="color:#009900">void</span> <b><span style="color:#000000">printTree</span></b><span style="color:#990000">(</span>AVLNode<span style="color:#990000">*</span> root<span style="color:#990000">,</span> Trunk<span style="color:#990000">*</span> prev<span style="color:#990000">,</span> <span style="color:#009900">bool</span> isRight<span style="color:#990000">);</span>
 
-  <i><font color="#9A1900">// Any other methods you need...</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+  <i><span style="color:#9A1900">// Any other methods you need...</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// max returns the greater of two integers.</font></i>
-<font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> a<font color="#990000">,</font> <font color="#009900">int</font> b<font color="#990000">);</font>
+<i><span style="color:#9A1900">// max returns the greater of two integers.</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> a<span style="color:#990000">,</span> <span style="color:#009900">int</span> b<span style="color:#990000">);</span>
 
-<b><font color="#000080">#endif</font></b></tt></pre>
+<b><span style="color:#000080">#endif</span></b></pre>
 </body>
 </html>

--- a/labs/lab05/code/postlab/AVLTree.h.html
+++ b/labs/lab05/code/postlab/AVLTree.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/prelab/TreeCalc.cpp.html
+++ b/labs/lab05/code/prelab/TreeCalc.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,94 +8,94 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TreeCalc.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Insert your header information here</font></i>
-<i><font color="#9A1900">// TreeCalc.cpp:  CS 2150 Tree Calculator method implementations</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Insert your header information here</span></i>
+<i><span style="color:#9A1900">// TreeCalc.cpp:  CS 2150 Tree Calculator method implementations</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"TreeCalc.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"TreeCalc.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">//Constructor</font></i>
-TreeCalc<font color="#990000">::</font><b><font color="#000000">TreeCalc</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Constructor</span></i>
+TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">TreeCalc</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Destructor- frees memory</font></i>
-TreeCalc<font color="#990000">::~</font><b><font color="#000000">TreeCalc</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Destructor- frees memory</span></i>
+TreeCalc<span style="color:#990000">::~</span><b><span style="color:#000000">TreeCalc</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Deletes tree/frees memory</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">cleanTree</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Deletes tree/frees memory</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">cleanTree</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Gets data from user</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">readInput</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> response<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter elements one by one in postfix notation"</font> <font color="#990000">&lt;&lt;</font> endl
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Any non-numeric or non-operator character,"</font>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" e.g. #, will terminate input"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter first element: "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
-    <i><font color="#9A1900">//while input is legal</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font><b><font color="#000000">isdigit</font></b><font color="#990000">(</font>response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">])</font> <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]==</font><font color="#FF0000">'/'</font> <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]==</font><font color="#FF0000">'*'</font>
-            <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]==</font><font color="#FF0000">'-'</font> <font color="#990000">||</font> response<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]==</font><font color="#FF0000">'+'</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">insert</font></b><font color="#990000">(</font>response<font color="#990000">);</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter next element: "</font><font color="#990000">;</font>
-        cin <font color="#990000">&gt;&gt;</font> response<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Gets data from user</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">readInput</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> response<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter elements one by one in postfix notation"</span> <span style="color:#990000">&lt;&lt;</span> endl
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Any non-numeric or non-operator character,"</span>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" e.g. #, will terminate input"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter first element: "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">//while input is legal</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span><b><span style="color:#000000">isdigit</span></b><span style="color:#990000">(</span>response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">])</span> <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]==</span><span style="color:#FF0000">'/'</span> <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]==</span><span style="color:#FF0000">'*'</span>
+            <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]==</span><span style="color:#FF0000">'-'</span> <span style="color:#990000">||</span> response<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]==</span><span style="color:#FF0000">'+'</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span>response<span style="color:#990000">);</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter next element: "</span><span style="color:#990000">;</span>
+        cin <span style="color:#990000">&gt;&gt;</span> response<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Puts value in tree stack</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string<font color="#990000">&amp;</font> val<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// insert a value into the tree</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Puts value in tree stack</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string<span style="color:#990000">&amp;</span> val<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// insert a value into the tree</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Prints data in prefix form</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">printPrefix</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// print the tree in prefix format</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Prints data in prefix form</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">printPrefix</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// print the tree in prefix format</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Prints data in infix form</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">printInfix</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// print tree in infix format with appropriate parentheses</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Prints data in infix form</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">printInfix</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// print tree in infix format with appropriate parentheses</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Prints data in postfix form</font></i>
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">printPostfix</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// print the tree in postfix form</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Prints data in postfix form</span></i>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">printPostfix</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// print the tree in postfix form</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Prints tree in all 3 (pre,in,post) forms</font></i>
+<i><span style="color:#9A1900">// Prints tree in all 3 (pre,in,post) forms</span></i>
 
-<font color="#009900">void</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">printOutput</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>mystack<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()!=</font><font color="#993399">0</font> <font color="#990000">&amp;&amp;</font> mystack<font color="#990000">.</font><b><font color="#000000">top</font></b><font color="#990000">()!=</font>NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Expression tree in postfix expression: "</font><font color="#990000">;</font>
-        <i><font color="#9A1900">// call your implementation of printPostfix()</font></i>
-        cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Expression tree in infix expression: "</font><font color="#990000">;</font>
-        <i><font color="#9A1900">// call your implementation of printInfix()</font></i>
-        cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Expression tree in prefix expression: "</font><font color="#990000">;</font>
-        <i><font color="#9A1900">// call your implementation of printPrefix()</font></i>
-        cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b>
-        cout<font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Size is 0."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">printOutput</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>mystack<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()!=</span><span style="color:#993399">0</span> <span style="color:#990000">&amp;&amp;</span> mystack<span style="color:#990000">.</span><b><span style="color:#000000">top</span></b><span style="color:#990000">()!=</span>NULL<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Expression tree in postfix expression: "</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// call your implementation of printPostfix()</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Expression tree in infix expression: "</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// call your implementation of printInfix()</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Expression tree in prefix expression: "</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// call your implementation of printPrefix()</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b>
+        cout<span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Size is 0."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Evaluates tree, returns value</font></i>
-<i><font color="#9A1900">// private calculate() method</font></i>
-<font color="#009900">int</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">calculate</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// Traverse the tree and calculates the result</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Evaluates tree, returns value</span></i>
+<i><span style="color:#9A1900">// private calculate() method</span></i>
+<span style="color:#009900">int</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">calculate</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// Traverse the tree and calculates the result</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Calls calculate, sets the stack back to a blank stack</font></i>
-<i><font color="#9A1900">// public calculate() method. Hides private data from user</font></i>
-<font color="#009900">int</font> TreeCalc<font color="#990000">::</font><b><font color="#000000">calculate</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// call private calculate method here</font></i>
-    <b><font color="#0000FF">return</font></b> i<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">//Calls calculate, sets the stack back to a blank stack</span></i>
+<i><span style="color:#9A1900">// public calculate() method. Hides private data from user</span></i>
+<span style="color:#009900">int</span> TreeCalc<span style="color:#990000">::</span><b><span style="color:#000000">calculate</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// call private calculate method here</span></i>
+    <b><span style="color:#0000FF">return</span></b> i<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab05/code/prelab/TreeCalc.cpp.html
+++ b/labs/lab05/code/prelab/TreeCalc.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/prelab/TreeCalc.h.html
+++ b/labs/lab05/code/prelab/TreeCalc.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,46 +8,46 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TreeCalc.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Add your header information here</font></i>
-<i><font color="#9A1900">// TreeCalc.h: Tree Calculator class definition</font></i>
-<i><font color="#9A1900">// CS 2150: Lab 5</font></i>
-<i><font color="#9A1900">// NOTE: You may use any stack implementation that you wish</font></i>
-<i><font color="#9A1900">// You must submit ALL code to make your project build correctly</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Add your header information here</span></i>
+<i><span style="color:#9A1900">// TreeCalc.h: Tree Calculator class definition</span></i>
+<i><span style="color:#9A1900">// CS 2150: Lab 5</span></i>
+<i><span style="color:#9A1900">// NOTE: You may use any stack implementation that you wish</span></i>
+<i><span style="color:#9A1900">// You must submit ALL code to make your project build correctly</span></i>
 
 
-<b><font color="#000080">#ifndef</font></b> TREECALC_H
-<b><font color="#000080">#define</font></b> TREECALC_H
+<b><span style="color:#000080">#ifndef</span></b> TREECALC_H
+<b><span style="color:#000080">#define</span></b> TREECALC_H
 
-<i><font color="#9A1900">// include your stack implementation here</font></i>
+<i><span style="color:#9A1900">// include your stack implementation here</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"TreeNode.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"TreeNode.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">TreeCalc</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">TreeCalc</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
 
-    <b><font color="#000000">TreeCalc</font></b><font color="#990000">();</font>						<i><font color="#9A1900">//Constructor</font></i>
-    <font color="#990000">~</font><b><font color="#000000">TreeCalc</font></b><font color="#990000">();</font>					<i><font color="#9A1900">//Destructor</font></i>
+    <b><span style="color:#000000">TreeCalc</span></b><span style="color:#990000">();</span>						<i><span style="color:#9A1900">//Constructor</span></i>
+    <span style="color:#990000">~</span><b><span style="color:#000000">TreeCalc</span></b><span style="color:#990000">();</span>					<i><span style="color:#9A1900">//Destructor</span></i>
 
-    <font color="#009900">void</font> <b><font color="#000000">cleanTree</font></b><font color="#990000">(</font>TreeNode <font color="#990000">*</font> ptr<font color="#990000">);</font>	<i><font color="#9A1900">//Deletes tree/frees memory</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">readInput</font></b><font color="#990000">();</font>				<i><font color="#9A1900">//gets data from user</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string <font color="#990000">&amp;</font> val<font color="#990000">);</font>	<i><font color="#9A1900">//puts value in tree</font></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">cleanTree</span></b><span style="color:#990000">(</span>TreeNode <span style="color:#990000">*</span> ptr<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Deletes tree/frees memory</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">readInput</span></b><span style="color:#990000">();</span>				<i><span style="color:#9A1900">//gets data from user</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string <span style="color:#990000">&amp;</span> val<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//puts value in tree</span></i>
 
-    <i><font color="#9A1900">// print methods</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">printPrefix</font></b><font color="#990000">(</font>TreeNode <font color="#990000">*</font> curNode<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>	<i><font color="#9A1900">//prints data in prefix form</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">printInfix</font></b><font color="#990000">(</font>TreeNode <font color="#990000">*</font> curNode<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>	<i><font color="#9A1900">//prints data in infix form</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">printPostfix</font></b><font color="#990000">(</font>TreeNode <font color="#990000">*</font> curNode<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font><i><font color="#9A1900">//prints data in postfix form</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">printOutput</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>				<i><font color="#9A1900">//prints in pre,in,post form</font></i>
-    <font color="#009900">int</font> <b><font color="#000000">calculate</font></b><font color="#990000">();</font>					<i><font color="#9A1900">//calls private calculate method</font></i>
+    <i><span style="color:#9A1900">// print methods</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">printPrefix</span></b><span style="color:#990000">(</span>TreeNode <span style="color:#990000">*</span> curNode<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>	<i><span style="color:#9A1900">//prints data in prefix form</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">printInfix</span></b><span style="color:#990000">(</span>TreeNode <span style="color:#990000">*</span> curNode<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>	<i><span style="color:#9A1900">//prints data in infix form</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">printPostfix</span></b><span style="color:#990000">(</span>TreeNode <span style="color:#990000">*</span> curNode<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span><i><span style="color:#9A1900">//prints data in postfix form</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">printOutput</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>				<i><span style="color:#9A1900">//prints in pre,in,post form</span></i>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">calculate</span></b><span style="color:#990000">();</span>					<i><span style="color:#9A1900">//calls private calculate method</span></i>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <i><font color="#9A1900">// declare a stack to hold your expression tree</font></i>
-    <font color="#009900">int</font> <b><font color="#000000">calculate</font></b><font color="#990000">(</font>TreeNode<font color="#990000">*</font> ptr<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>		<i><font color="#9A1900">//Evaluates tree, returns value</font></i>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <i><span style="color:#9A1900">// declare a stack to hold your expression tree</span></i>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">calculate</span></b><span style="color:#990000">(</span>TreeNode<span style="color:#990000">*</span> ptr<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>		<i><span style="color:#9A1900">//Evaluates tree, returns value</span></i>
 
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab05/code/prelab/TreeCalc.h.html
+++ b/labs/lab05/code/prelab/TreeCalc.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/prelab/TreeCalcTest.cpp.html
+++ b/labs/lab05/code/prelab/TreeCalcTest.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,28 +8,28 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TreeCalcTest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// TreeCalcTest.cpp</font></i>
-<i><font color="#9A1900">// CS 2150: Tree calculator test program</font></i>
-<i><font color="#9A1900">// Your code MUST work with this test program</font></i>
-<i><font color="#9A1900">// We will be using this program to test your implementations</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// TreeCalcTest.cpp</span></i>
+<i><span style="color:#9A1900">// CS 2150: Tree calculator test program</span></i>
+<i><span style="color:#9A1900">// Your code MUST work with this test program</span></i>
+<i><span style="color:#9A1900">// We will be using this program to test your implementations</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"TreeCalc.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"TreeCalc.h"</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">TreeCalc</font> tester<font color="#990000">;</font>
-    <i><font color="#9A1900">// read expression input from the user</font></i>
-    tester<font color="#990000">.</font><b><font color="#000000">readInput</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// print out the output in postorder, in order, preorder forms</font></i>
-    tester<font color="#990000">.</font><b><font color="#000000">printOutput</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// calculate the result of the expression tree</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result of the expression tree is "</font>
-         <font color="#990000">&lt;&lt;</font> tester<font color="#990000">.</font><b><font color="#000000">calculate</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">TreeCalc</span> tester<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// read expression input from the user</span></i>
+    tester<span style="color:#990000">.</span><b><span style="color:#000000">readInput</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// print out the output in postorder, in order, preorder forms</span></i>
+    tester<span style="color:#990000">.</span><b><span style="color:#000000">printOutput</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// calculate the result of the expression tree</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result of the expression tree is "</span>
+         <span style="color:#990000">&lt;&lt;</span> tester<span style="color:#990000">.</span><b><span style="color:#000000">calculate</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab05/code/prelab/TreeCalcTest.cpp.html
+++ b/labs/lab05/code/prelab/TreeCalcTest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/prelab/TreeNode.cpp.html
+++ b/labs/lab05/code/prelab/TreeNode.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab05/code/prelab/TreeNode.cpp.html
+++ b/labs/lab05/code/prelab/TreeNode.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,26 +8,26 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TreeNode.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Insert your header information here</font></i>
-<i><font color="#9A1900">// TreeNode.cpp:  Tree Node method implementations</font></i>
-<i><font color="#9A1900">// CS 2150: Lab 5</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Insert your header information here</span></i>
+<i><span style="color:#9A1900">// TreeNode.cpp:  Tree Node method implementations</span></i>
+<i><span style="color:#9A1900">// CS 2150: Lab 5</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"TreeNode.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"TreeNode.h"</span>
 
-<i><font color="#9A1900">//Default Constructor -left and right are NULL, value '?'</font></i>
-TreeNode<font color="#990000">::</font><b><font color="#000000">TreeNode</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    value<font color="#990000">=</font><font color="#FF0000">"?"</font><font color="#990000">;</font>
-    left<font color="#990000">=</font>NULL<font color="#990000">;</font>
-    right<font color="#990000">=</font>NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">//Default Constructor -left and right are NULL, value '?'</span></i>
+TreeNode<span style="color:#990000">::</span><b><span style="color:#000000">TreeNode</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    value<span style="color:#990000">=</span><span style="color:#FF0000">"?"</span><span style="color:#990000">;</span>
+    left<span style="color:#990000">=</span>NULL<span style="color:#990000">;</span>
+    right<span style="color:#990000">=</span>NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">//Constructor - sets value to val</font></i>
-TreeNode<font color="#990000">::</font><b><font color="#000000">TreeNode</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string <font color="#990000">&amp;</font> val<font color="#990000">)</font> <font color="#FF0000">{</font>
-    value<font color="#990000">=</font>val<font color="#990000">;</font>
-    left<font color="#990000">=</font>NULL<font color="#990000">;</font>
-    right<font color="#990000">=</font>NULL<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">//Constructor - sets value to val</span></i>
+TreeNode<span style="color:#990000">::</span><b><span style="color:#000000">TreeNode</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string <span style="color:#990000">&amp;</span> val<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    value<span style="color:#990000">=</span>val<span style="color:#990000">;</span>
+    left<span style="color:#990000">=</span>NULL<span style="color:#990000">;</span>
+    right<span style="color:#990000">=</span>NULL<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab05/code/prelab/TreeNode.h.html
+++ b/labs/lab05/code/prelab/TreeNode.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,29 +8,29 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TreeNode.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// TreeNode.h: TreeNode class definition</font></i>
-<i><font color="#9A1900">// CS 2150: Lab 5</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// TreeNode.h: TreeNode class definition</span></i>
+<i><span style="color:#9A1900">// CS 2150: Lab 5</span></i>
 
 
-<b><font color="#000080">#ifndef</font></b> TREENODE_H
-<b><font color="#000080">#define</font></b> TREENODE_H
+<b><span style="color:#000080">#ifndef</span></b> TREENODE_H
+<b><span style="color:#000080">#define</span></b> TREENODE_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">TreeNode</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">TreeNode</font></b><font color="#990000">();</font>						<i><font color="#9A1900">//Default Constructor</font></i>
-    <b><font color="#000000">TreeNode</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> string <font color="#990000">&amp;</font> val<font color="#990000">);</font>	<i><font color="#9A1900">//Constructor</font></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">TreeNode</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">TreeNode</span></b><span style="color:#990000">();</span>						<i><span style="color:#9A1900">//Default Constructor</span></i>
+    <b><span style="color:#000000">TreeNode</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> string <span style="color:#990000">&amp;</span> val<span style="color:#990000">);</span>	<i><span style="color:#9A1900">//Constructor</span></i>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">string</font> value<font color="#990000">;</font>
-    <font color="#008080">TreeNode</font> <font color="#990000">*</font>left<font color="#990000">,</font> <font color="#990000">*</font>right<font color="#990000">;</font>			<i><font color="#9A1900">// for trees</font></i>
-    <b><font color="#0000FF">friend</font></b> <b><font color="#0000FF">class</font></b> <font color="#008080">TreeCalc</font><font color="#990000">;</font>			<i><font color="#9A1900">//gives TreeCalc access to private data</font></i>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">string</span> value<span style="color:#990000">;</span>
+    <span style="color:#008080">TreeNode</span> <span style="color:#990000">*</span>left<span style="color:#990000">,</span> <span style="color:#990000">*</span>right<span style="color:#990000">;</span>			<i><span style="color:#9A1900">// for trees</span></i>
+    <b><span style="color:#0000FF">friend</span></b> <b><span style="color:#0000FF">class</span></b> <span style="color:#008080">TreeCalc</span><span style="color:#990000">;</span>			<i><span style="color:#9A1900">//gives TreeCalc access to private data</span></i>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab05/code/prelab/TreeNode.h.html
+++ b/labs/lab05/code/prelab/TreeNode.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/getWordInGrid.cpp.html
+++ b/labs/lab06/code/getWordInGrid.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/getWordInGrid.cpp.html
+++ b/labs/lab06/code/getWordInGrid.cpp.html
@@ -1,206 +1,206 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>getWordInGrid.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/** This file defines and demonstrates two necessary components for</font></i>
-<i><font color="#9A1900"> * the hash table lab for CS 2150.  The first is the use of the</font></i>
-<i><font color="#9A1900"> * getWordInGrid() function, which is used for retrieving a word in a</font></i>
-<i><font color="#9A1900"> * grid of letters in one of the cardinal 8 directions (north,</font></i>
-<i><font color="#9A1900"> * south-east, etc).  The second is the use of file streams to read in</font></i>
-<i><font color="#9A1900"> * input from a file, specifically one formatted as per the lab 6</font></i>
-<i><font color="#9A1900"> * guidelines.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Written by Aaron Bloomfield, 2009</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/** This file defines and demonstrates two necessary components for</span></i>
+<i><span style="color:#9A1900"> * the hash table lab for CS 2150.  The first is the use of the</span></i>
+<i><span style="color:#9A1900"> * getWordInGrid() function, which is used for retrieving a word in a</span></i>
+<i><span style="color:#9A1900"> * grid of letters in one of the cardinal 8 directions (north,</span></i>
+<i><span style="color:#9A1900"> * south-east, etc).  The second is the use of file streams to read in</span></i>
+<i><span style="color:#9A1900"> * input from a file, specifically one formatted as per the lab 6</span></i>
+<i><span style="color:#9A1900"> * guidelines.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Written by Aaron Bloomfield, 2009</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// We create a 2-D array of some big size, and assume that the grid</font></i>
-<i><font color="#9A1900">// read in will be less than this size (a valid assumption for lab 6)</font></i>
-<b><font color="#000080">#define</font></b> MAXROWS <font color="#993399">500</font>
-<b><font color="#000080">#define</font></b> MAXCOLS <font color="#993399">500</font>
-<font color="#009900">char</font> grid<font color="#990000">[</font>MAXROWS<font color="#990000">][</font>MAXCOLS<font color="#990000">];</font>
+<i><span style="color:#9A1900">// We create a 2-D array of some big size, and assume that the grid</span></i>
+<i><span style="color:#9A1900">// read in will be less than this size (a valid assumption for lab 6)</span></i>
+<b><span style="color:#000080">#define</span></b> MAXROWS <span style="color:#993399">500</span>
+<b><span style="color:#000080">#define</span></b> MAXCOLS <span style="color:#993399">500</span>
+<span style="color:#009900">char</span> grid<span style="color:#990000">[</span>MAXROWS<span style="color:#990000">][</span>MAXCOLS<span style="color:#990000">];</span>
 
-<i><font color="#9A1900">// Forward declarations</font></i>
-<font color="#009900">bool</font> <b><font color="#000000">readInGrid</font></b> <font color="#990000">(</font><font color="#008080">string</font> filename<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">&amp;</font>rows<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">&amp;</font>cols<font color="#990000">);</font>
-<font color="#009900">char</font><font color="#990000">*</font> <b><font color="#000000">getWordInGrid</font></b> <font color="#990000">(</font><font color="#009900">int</font> startRow<font color="#990000">,</font> <font color="#009900">int</font> startCol<font color="#990000">,</font> <font color="#009900">int</font> dir<font color="#990000">,</font> <font color="#009900">int</font> len<font color="#990000">,</font>
-                     <font color="#009900">int</font> numRows<font color="#990000">,</font> <font color="#009900">int</font> numCols<font color="#990000">);</font>
-
-
-
-<i><font color="#9A1900">/** The main() function shows how to call both the readInGrid()</font></i>
-<i><font color="#9A1900"> * function as well as the getWordInGrid() function.</font></i>
-<i><font color="#9A1900"> */</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// to hold the number of rows and cols in the input file</font></i>
-    <font color="#009900">int</font> rows<font color="#990000">,</font> cols<font color="#990000">;</font>
-    <i><font color="#9A1900">// attempt to read in the file</font></i>
-    <font color="#009900">bool</font> result <font color="#990000">=</font> <b><font color="#000000">readInGrid</font></b> <font color="#990000">(</font><font color="#FF0000">"5x8.grid.txt"</font><font color="#990000">,</font> rows<font color="#990000">,</font> cols<font color="#990000">);</font>
-    <i><font color="#9A1900">// if there is an error, report it</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>result <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error reading in file!"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font> <i><font color="#9A1900">// requires the &lt;stdlib.h&gt; #include header!</font></i>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// Get a word (of length 10), starting at position (2,2) in the</font></i>
-    <i><font color="#9A1900">// array, in each of the 8 directions</font></i>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">8</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">": "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">getWordInGrid</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">,</font><font color="#993399">2</font><font color="#990000">,</font>i<font color="#990000">,</font><font color="#993399">10</font><font color="#990000">,</font>rows<font color="#990000">,</font>cols<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// All done!</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Forward declarations</span></i>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">readInGrid</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> filename<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>rows<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>cols<span style="color:#990000">);</span>
+<span style="color:#009900">char</span><span style="color:#990000">*</span> <b><span style="color:#000000">getWordInGrid</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> startRow<span style="color:#990000">,</span> <span style="color:#009900">int</span> startCol<span style="color:#990000">,</span> <span style="color:#009900">int</span> dir<span style="color:#990000">,</span> <span style="color:#009900">int</span> len<span style="color:#990000">,</span>
+                     <span style="color:#009900">int</span> numRows<span style="color:#990000">,</span> <span style="color:#009900">int</span> numCols<span style="color:#990000">);</span>
 
 
 
-<i><font color="#9A1900">/** This function will read in a grid file, as per the format in the</font></i>
-<i><font color="#9A1900"> * CS 2150 lab 6 document, into a global grid[][] array.  It uses C++</font></i>
-<i><font color="#9A1900"> * file streams, and thus requires the the </font></i><b><font color="#0000FF">&lt;fstream&gt;</font></b><i><font color="#9A1900"> #include header.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@return</font><i><font color="#9A1900"> true or false, depending on whether the file was</font></i>
-<i><font color="#9A1900"> *         successfully opened.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> filename The file name to read in -- it's assumed to be in</font></i>
-<i><font color="#9A1900"> *                 the file format described in the lab document.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> rows The number of rows as specified in the input file;</font></i>
-<i><font color="#9A1900"> *             as this is a reference, it is set by the function.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> cols The number of columns as specified in the input file;</font></i>
-<i><font color="#9A1900"> *             as this is a reference, it is set by the function.</font></i>
-<i><font color="#9A1900"> */</font></i>
-<font color="#009900">bool</font> <b><font color="#000000">readInGrid</font></b> <font color="#990000">(</font><font color="#008080">string</font> filename<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">&amp;</font>rows<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">&amp;</font>cols<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// a C++ string to hold the line of data that is read in</font></i>
-    <font color="#008080">string</font> line<font color="#990000">;</font>
-    <i><font color="#9A1900">// set up the file stream to read in the file (takes in a C-style</font></i>
-    <i><font color="#9A1900">// char* string, not a C++ string object)</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">file</font></b><font color="#990000">(</font>filename<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <i><font color="#9A1900">// upon an error, return false</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>file<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <i><font color="#9A1900">// the first line is the number of rows: read it in</font></i>
-    file <font color="#990000">&gt;&gt;</font> rows<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"There are "</font> <font color="#990000">&lt;&lt;</font> rows <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" rows."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">getline</font></b> <font color="#990000">(</font>file<font color="#990000">,</font>line<font color="#990000">);</font> <i><font color="#9A1900">// eats up the return at the end of the line</font></i>
-    <i><font color="#9A1900">// the second line is the number of cols: read it in and parse it</font></i>
-    file <font color="#990000">&gt;&gt;</font> cols<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"There are "</font> <font color="#990000">&lt;&lt;</font> cols <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" cols."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">getline</font></b> <font color="#990000">(</font>file<font color="#990000">,</font>line<font color="#990000">);</font> <i><font color="#9A1900">// eats up the return at the end of the line</font></i>
-    <i><font color="#9A1900">// the third and last line is the data: read it in</font></i>
-    <b><font color="#000000">getline</font></b> <font color="#990000">(</font>file<font color="#990000">,</font>line<font color="#990000">);</font>
-    <i><font color="#9A1900">// close the file</font></i>
-    file<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// convert the string read in to the 2-D grid format into the</font></i>
-    <i><font color="#9A1900">// grid[][] array.  In the process, we'll print the grid to the</font></i>
-    <i><font color="#9A1900">// screen as well.</font></i>
-    <font color="#009900">int</font> pos <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> <i><font color="#9A1900">// the current position in the input data</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> r <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> r <font color="#990000">&lt;</font> rows<font color="#990000">;</font> r<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> c <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> c <font color="#990000">&lt;</font> cols<font color="#990000">;</font> c<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            grid<font color="#990000">[</font>r<font color="#990000">][</font>c<font color="#990000">]</font> <font color="#990000">=</font> line<font color="#990000">[</font>pos<font color="#990000">++];</font>
-            cout <font color="#990000">&lt;&lt;</font> grid<font color="#990000">[</font>r<font color="#990000">][</font>c<font color="#990000">];</font>
-        <font color="#FF0000">}</font>
-        cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// return success!</font></i>
-    <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">/** The main() function shows how to call both the readInGrid()</span></i>
+<i><span style="color:#9A1900"> * function as well as the getWordInGrid() function.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// to hold the number of rows and cols in the input file</span></i>
+    <span style="color:#009900">int</span> rows<span style="color:#990000">,</span> cols<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// attempt to read in the file</span></i>
+    <span style="color:#009900">bool</span> result <span style="color:#990000">=</span> <b><span style="color:#000000">readInGrid</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"5x8.grid.txt"</span><span style="color:#990000">,</span> rows<span style="color:#990000">,</span> cols<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// if there is an error, report it</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>result <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error reading in file!"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span> <i><span style="color:#9A1900">// requires the &lt;stdlib.h&gt; #include header!</span></i>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// Get a word (of length 10), starting at position (2,2) in the</span></i>
+    <i><span style="color:#9A1900">// array, in each of the 8 directions</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">8</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">getWordInGrid</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">,</span><span style="color:#993399">2</span><span style="color:#990000">,</span>i<span style="color:#990000">,</span><span style="color:#993399">10</span><span style="color:#990000">,</span>rows<span style="color:#990000">,</span>cols<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// All done!</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
 
 
-<i><font color="#9A1900">/** This function will retrieve a word in a grid of letters in a given</font></i>
-<i><font color="#9A1900"> * direction.  If the end of the grid is encountered before the length</font></i>
-<i><font color="#9A1900"> * of the desired string is reached, then a shorter string will be</font></i>
-<i><font color="#9A1900"> * returned.  The data is retrieved from a global char grid[][]</font></i>
-<i><font color="#9A1900"> * array, which is assumed to be defined (and in scope).  NOTE: The</font></i>
-<i><font color="#9A1900"> * return value is a static char[][] variable (for efficiency</font></i>
-<i><font color="#9A1900"> * reasons), so a successive return value will overwrite a previous</font></i>
-<i><font color="#9A1900"> * return value.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@return</font><i><font color="#9A1900"> A char* containing the letters in the provided direction</font></i>
-<i><font color="#9A1900"> *         (NOTE: it is returned in a static char array).</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> startRow The starting (row,col) position to find the word.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> startCol The starting (row,col) position to find the word.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> dir The direction to move: 0 is north (upwards), 1 is</font></i>
-<i><font color="#9A1900"> *            northeast, and it rotates around clockwise until it</font></i>
-<i><font color="#9A1900"> *            reaches 7 for northwest.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> len The desired length of the string to return (assuming</font></i>
-<i><font color="#9A1900"> *            the edge of the grid is not reached--if the edge of the</font></i>
-<i><font color="#9A1900"> *            grid is reached, it will return as many characters as</font></i>
-<i><font color="#9A1900"> *            possible up to the edge of the grid, so the returned</font></i>
-<i><font color="#9A1900"> *            string may not have the same length as this parameter</font></i>
-<i><font color="#9A1900"> *            indicates).</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> numRows The number of rows in the global char grid[][]</font></i>
-<i><font color="#9A1900"> *                array.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> numCols The number of columns in the global char grid[][]</font></i>
-<i><font color="#9A1900"> *                array.</font></i>
-<i><font color="#9A1900"> */</font></i>
-<font color="#009900">char</font><font color="#990000">*</font> <b><font color="#000000">getWordInGrid</font></b> <font color="#990000">(</font><font color="#009900">int</font> startRow<font color="#990000">,</font> <font color="#009900">int</font> startCol<font color="#990000">,</font> <font color="#009900">int</font> dir<font color="#990000">,</font> <font color="#009900">int</font> len<font color="#990000">,</font>
-                     <font color="#009900">int</font> numRows<font color="#990000">,</font> <font color="#009900">int</font> numCols<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// the static-ness of this variable prevents it from being</font></i>
-    <i><font color="#9A1900">// re-declared upon each function invocation.  It also prevents it</font></i>
-    <i><font color="#9A1900">// from being deallocated between invocations.  It's probably not</font></i>
-    <i><font color="#9A1900">// good programming practice, but it's an efficient means to return</font></i>
-    <i><font color="#9A1900">// a value.</font></i>
-    <b><font color="#0000FF">static</font></b> <font color="#009900">char</font> output<font color="#990000">[</font><font color="#993399">256</font><font color="#990000">];</font>
-    <i><font color="#9A1900">// make sure the length is not greater than the array size.</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> len <font color="#990000">&gt;=</font> <font color="#993399">255</font> <font color="#990000">)</font>
-        len <font color="#990000">=</font> <font color="#993399">255</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// the position in the output array, the current row, and the</font></i>
-    <i><font color="#9A1900">// current column</font></i>
-    <font color="#009900">int</font> pos <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">,</font> r <font color="#990000">=</font> startRow<font color="#990000">,</font> c <font color="#990000">=</font> startCol<font color="#990000">;</font>
-    <i><font color="#9A1900">// iterate once for each character in the output</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> len<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <i><font color="#9A1900">// if the current row or column is out of bounds, then break</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>c <font color="#990000">&gt;=</font> numCols<font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>r <font color="#990000">&gt;=</font> numRows<font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>r <font color="#990000">&lt;</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>c <font color="#990000">&lt;</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-        <i><font color="#9A1900">// set the next character in the output array to the next letter</font></i>
-        <i><font color="#9A1900">// in the grid</font></i>
-        output<font color="#990000">[</font>pos<font color="#990000">++]</font> <font color="#990000">=</font> grid<font color="#990000">[</font>r<font color="#990000">][</font>c<font color="#990000">];</font>
-        <i><font color="#9A1900">// move in the direction specified by the parameter</font></i>
-        <b><font color="#0000FF">switch</font></b> <font color="#990000">(</font>dir<font color="#990000">)</font> <font color="#FF0000">{</font> <i><font color="#9A1900">// assumes grid[0][0] is in the upper-left</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">0</font><font color="#990000">:</font>
-                r<font color="#990000">--;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// north</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">1</font><font color="#990000">:</font>
-                r<font color="#990000">--;</font>
-                c<font color="#990000">++;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// north-east</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">2</font><font color="#990000">:</font>
-                c<font color="#990000">++;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// east</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">3</font><font color="#990000">:</font>
-                r<font color="#990000">++;</font>
-                c<font color="#990000">++;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// south-east</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">4</font><font color="#990000">:</font>
-                r<font color="#990000">++;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// south</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">5</font><font color="#990000">:</font>
-                r<font color="#990000">++;</font>
-                c<font color="#990000">--;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// south-west</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">6</font><font color="#990000">:</font>
-                c<font color="#990000">--;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// west</font></i>
-            <b><font color="#0000FF">case</font></b> <font color="#993399">7</font><font color="#990000">:</font>
-                r<font color="#990000">--;</font>
-                c<font color="#990000">--;</font>
-                <b><font color="#0000FF">break</font></b><font color="#990000">;</font> <i><font color="#9A1900">// north-west</font></i>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// set the next character to zero (end-of-string)</font></i>
-    output<font color="#990000">[</font>pos<font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// return the string (a C-style char* string, not a C++ string</font></i>
-    <i><font color="#9A1900">// object)</font></i>
-    <b><font color="#0000FF">return</font></b> output<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">/** This function will read in a grid file, as per the format in the</span></i>
+<i><span style="color:#9A1900"> * CS 2150 lab 6 document, into a global grid[][] array.  It uses C++</span></i>
+<i><span style="color:#9A1900"> * file streams, and thus requires the the </span></i><b><span style="color:#0000FF">&lt;fstream&gt;</span></b><i><span style="color:#9A1900"> #include header.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@return</span><i><span style="color:#9A1900"> true or false, depending on whether the file was</span></i>
+<i><span style="color:#9A1900"> *         successfully opened.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> filename The file name to read in -- it's assumed to be in</span></i>
+<i><span style="color:#9A1900"> *                 the file format described in the lab document.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> rows The number of rows as specified in the input file;</span></i>
+<i><span style="color:#9A1900"> *             as this is a reference, it is set by the function.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> cols The number of columns as specified in the input file;</span></i>
+<i><span style="color:#9A1900"> *             as this is a reference, it is set by the function.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">readInGrid</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> filename<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>rows<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span>cols<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// a C++ string to hold the line of data that is read in</span></i>
+    <span style="color:#008080">string</span> line<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// set up the file stream to read in the file (takes in a C-style</span></i>
+    <i><span style="color:#9A1900">// char* string, not a C++ string object)</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">file</span></b><span style="color:#990000">(</span>filename<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <i><span style="color:#9A1900">// upon an error, return false</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>file<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// the first line is the number of rows: read it in</span></i>
+    file <span style="color:#990000">&gt;&gt;</span> rows<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"There are "</span> <span style="color:#990000">&lt;&lt;</span> rows <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" rows."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">getline</span></b> <span style="color:#990000">(</span>file<span style="color:#990000">,</span>line<span style="color:#990000">);</span> <i><span style="color:#9A1900">// eats up the return at the end of the line</span></i>
+    <i><span style="color:#9A1900">// the second line is the number of cols: read it in and parse it</span></i>
+    file <span style="color:#990000">&gt;&gt;</span> cols<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"There are "</span> <span style="color:#990000">&lt;&lt;</span> cols <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" cols."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">getline</span></b> <span style="color:#990000">(</span>file<span style="color:#990000">,</span>line<span style="color:#990000">);</span> <i><span style="color:#9A1900">// eats up the return at the end of the line</span></i>
+    <i><span style="color:#9A1900">// the third and last line is the data: read it in</span></i>
+    <b><span style="color:#000000">getline</span></b> <span style="color:#990000">(</span>file<span style="color:#990000">,</span>line<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// close the file</span></i>
+    file<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// convert the string read in to the 2-D grid format into the</span></i>
+    <i><span style="color:#9A1900">// grid[][] array.  In the process, we'll print the grid to the</span></i>
+    <i><span style="color:#9A1900">// screen as well.</span></i>
+    <span style="color:#009900">int</span> pos <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> <i><span style="color:#9A1900">// the current position in the input data</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> r <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> r <span style="color:#990000">&lt;</span> rows<span style="color:#990000">;</span> r<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> c <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> c <span style="color:#990000">&lt;</span> cols<span style="color:#990000">;</span> c<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            grid<span style="color:#990000">[</span>r<span style="color:#990000">][</span>c<span style="color:#990000">]</span> <span style="color:#990000">=</span> line<span style="color:#990000">[</span>pos<span style="color:#990000">++];</span>
+            cout <span style="color:#990000">&lt;&lt;</span> grid<span style="color:#990000">[</span>r<span style="color:#990000">][</span>c<span style="color:#990000">];</span>
+        <span style="color:#FF0000">}</span>
+        cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// return success!</span></i>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+
+
+
+<i><span style="color:#9A1900">/** This function will retrieve a word in a grid of letters in a given</span></i>
+<i><span style="color:#9A1900"> * direction.  If the end of the grid is encountered before the length</span></i>
+<i><span style="color:#9A1900"> * of the desired string is reached, then a shorter string will be</span></i>
+<i><span style="color:#9A1900"> * returned.  The data is retrieved from a global char grid[][]</span></i>
+<i><span style="color:#9A1900"> * array, which is assumed to be defined (and in scope).  NOTE: The</span></i>
+<i><span style="color:#9A1900"> * return value is a static char[][] variable (for efficiency</span></i>
+<i><span style="color:#9A1900"> * reasons), so a successive return value will overwrite a previous</span></i>
+<i><span style="color:#9A1900"> * return value.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@return</span><i><span style="color:#9A1900"> A char* containing the letters in the provided direction</span></i>
+<i><span style="color:#9A1900"> *         (NOTE: it is returned in a static char array).</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> startRow The starting (row,col) position to find the word.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> startCol The starting (row,col) position to find the word.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> dir The direction to move: 0 is north (upwards), 1 is</span></i>
+<i><span style="color:#9A1900"> *            northeast, and it rotates around clockwise until it</span></i>
+<i><span style="color:#9A1900"> *            reaches 7 for northwest.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> len The desired length of the string to return (assuming</span></i>
+<i><span style="color:#9A1900"> *            the edge of the grid is not reached--if the edge of the</span></i>
+<i><span style="color:#9A1900"> *            grid is reached, it will return as many characters as</span></i>
+<i><span style="color:#9A1900"> *            possible up to the edge of the grid, so the returned</span></i>
+<i><span style="color:#9A1900"> *            string may not have the same length as this parameter</span></i>
+<i><span style="color:#9A1900"> *            indicates).</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> numRows The number of rows in the global char grid[][]</span></i>
+<i><span style="color:#9A1900"> *                array.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> numCols The number of columns in the global char grid[][]</span></i>
+<i><span style="color:#9A1900"> *                array.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<span style="color:#009900">char</span><span style="color:#990000">*</span> <b><span style="color:#000000">getWordInGrid</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> startRow<span style="color:#990000">,</span> <span style="color:#009900">int</span> startCol<span style="color:#990000">,</span> <span style="color:#009900">int</span> dir<span style="color:#990000">,</span> <span style="color:#009900">int</span> len<span style="color:#990000">,</span>
+                     <span style="color:#009900">int</span> numRows<span style="color:#990000">,</span> <span style="color:#009900">int</span> numCols<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// the static-ness of this variable prevents it from being</span></i>
+    <i><span style="color:#9A1900">// re-declared upon each function invocation.  It also prevents it</span></i>
+    <i><span style="color:#9A1900">// from being deallocated between invocations.  It's probably not</span></i>
+    <i><span style="color:#9A1900">// good programming practice, but it's an efficient means to return</span></i>
+    <i><span style="color:#9A1900">// a value.</span></i>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">char</span> output<span style="color:#990000">[</span><span style="color:#993399">256</span><span style="color:#990000">];</span>
+    <i><span style="color:#9A1900">// make sure the length is not greater than the array size.</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> len <span style="color:#990000">&gt;=</span> <span style="color:#993399">255</span> <span style="color:#990000">)</span>
+        len <span style="color:#990000">=</span> <span style="color:#993399">255</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// the position in the output array, the current row, and the</span></i>
+    <i><span style="color:#9A1900">// current column</span></i>
+    <span style="color:#009900">int</span> pos <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">,</span> r <span style="color:#990000">=</span> startRow<span style="color:#990000">,</span> c <span style="color:#990000">=</span> startCol<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// iterate once for each character in the output</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> len<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <i><span style="color:#9A1900">// if the current row or column is out of bounds, then break</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>c <span style="color:#990000">&gt;=</span> numCols<span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>r <span style="color:#990000">&gt;=</span> numRows<span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>r <span style="color:#990000">&lt;</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>c <span style="color:#990000">&lt;</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// set the next character in the output array to the next letter</span></i>
+        <i><span style="color:#9A1900">// in the grid</span></i>
+        output<span style="color:#990000">[</span>pos<span style="color:#990000">++]</span> <span style="color:#990000">=</span> grid<span style="color:#990000">[</span>r<span style="color:#990000">][</span>c<span style="color:#990000">];</span>
+        <i><span style="color:#9A1900">// move in the direction specified by the parameter</span></i>
+        <b><span style="color:#0000FF">switch</span></b> <span style="color:#990000">(</span>dir<span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <i><span style="color:#9A1900">// assumes grid[0][0] is in the upper-left</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">0</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">--;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// north</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">1</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">--;</span>
+                c<span style="color:#990000">++;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// north-east</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">2</span><span style="color:#990000">:</span>
+                c<span style="color:#990000">++;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// east</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">3</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">++;</span>
+                c<span style="color:#990000">++;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// south-east</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">4</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">++;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// south</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">5</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">++;</span>
+                c<span style="color:#990000">--;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// south-west</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">6</span><span style="color:#990000">:</span>
+                c<span style="color:#990000">--;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// west</span></i>
+            <b><span style="color:#0000FF">case</span></b> <span style="color:#993399">7</span><span style="color:#990000">:</span>
+                r<span style="color:#990000">--;</span>
+                c<span style="color:#990000">--;</span>
+                <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span> <i><span style="color:#9A1900">// north-west</span></i>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// set the next character to zero (end-of-string)</span></i>
+    output<span style="color:#990000">[</span>pos<span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// return the string (a C-style char* string, not a C++ string</span></i>
+    <i><span style="color:#9A1900">// object)</span></i>
+    <b><span style="color:#0000FF">return</span></b> output<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab06/code/primenumber.cpp.html
+++ b/labs/lab06/code/primenumber.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/primenumber.cpp.html
+++ b/labs/lab06/code/primenumber.cpp.html
@@ -1,50 +1,50 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>primenumber.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Prime number generation code</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// written by Aaron Bloomfield, 2014</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Prime number generation code</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// written by Aaron Bloomfield, 2014</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// yes, there are much faster -- and much better -- ways to check if a</font></i>
-<i><font color="#9A1900">// number is prime (see the Sieve of Eratosthenes, for one example),</font></i>
-<i><font color="#9A1900">// but this code will work correctly, it is fairly straightforward,</font></i>
-<i><font color="#9A1900">// and it is fast enough for our purposes in the hash lab</font></i>
-<font color="#009900">bool</font> <b><font color="#000000">checkprime</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> p<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> p <font color="#990000">&lt;=</font> <font color="#993399">1</font> <font color="#990000">)</font> <i><font color="#9A1900">// 0 and 1 are not primes; the are both special cases</font></i>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> p <font color="#990000">==</font> <font color="#993399">2</font> <font color="#990000">)</font> <i><font color="#9A1900">// 2 is prime</font></i>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> p <font color="#990000">%</font> <font color="#993399">2</font> <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font> <i><font color="#9A1900">// even numbers other than 2 are not prime</font></i>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font> i<font color="#990000">*</font>i <font color="#990000">&lt;=</font> p<font color="#990000">;</font> i <font color="#990000">+=</font> <font color="#993399">2</font> <font color="#990000">)</font> <i><font color="#9A1900">// only go up to the sqrt of p</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> p <font color="#990000">%</font> i <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// yes, there are much faster -- and much better -- ways to check if a</span></i>
+<i><span style="color:#9A1900">// number is prime (see the Sieve of Eratosthenes, for one example),</span></i>
+<i><span style="color:#9A1900">// but this code will work correctly, it is fairly straightforward,</span></i>
+<i><span style="color:#9A1900">// and it is fast enough for our purposes in the hash lab</span></i>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">checkprime</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> p<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> p <span style="color:#990000">&lt;=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// 0 and 1 are not primes; the are both special cases</span></i>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> p <span style="color:#990000">==</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// 2 is prime</span></i>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> p <span style="color:#990000">%</span> <span style="color:#993399">2</span> <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// even numbers other than 2 are not prime</span></i>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span> i<span style="color:#990000">*</span>i <span style="color:#990000">&lt;=</span> p<span style="color:#990000">;</span> i <span style="color:#990000">+=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// only go up to the sqrt of p</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> p <span style="color:#990000">%</span> i <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">getNextPrime</font></b> <font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">checkprime</font></b><font color="#990000">(++</font>n<font color="#990000">)</font> <font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> n<font color="#990000">;</font> <i><font color="#9A1900">// all your primes are belong to us</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">getNextPrime</span></b> <span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">checkprime</span></b><span style="color:#990000">(++</span>n<span style="color:#990000">)</span> <span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> n<span style="color:#990000">;</span> <i><span style="color:#9A1900">// all your primes are belong to us</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> x<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter number: "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> x<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" is prime: "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">checkprime</font></b><font color="#990000">(</font>x<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"next higest prime: "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">getNextPrime</font></b><font color="#990000">(</font>x<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> x<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter number: "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> x<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" is prime: "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">checkprime</span></b><span style="color:#990000">(</span>x<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"next higest prime: "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">getNextPrime</span></b><span style="color:#990000">(</span>x<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab06/code/timer.cpp.html
+++ b/labs/lab06/code/timer.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/timer.cpp.html
+++ b/labs/lab06/code/timer.cpp.html
@@ -1,81 +1,81 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>timer.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</span></i>
+<i><span style="color:#9A1900">// systems) you will have to include the -lrt flag to your compiler.</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;math.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;cstring&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;sstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;math.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;cstring&gt;</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"timer.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"timer.h"</span>
 
-timer<font color="#990000">::</font><b><font color="#000000">timer</font></b><font color="#990000">(</font>timer <font color="#990000">&amp;</font> t<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">running</font></b><font color="#990000">(</font>t<font color="#990000">.</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#000000">memcpy</font></b><font color="#990000">(&amp;</font>startVar<font color="#990000">,</font> <font color="#990000">&amp;(</font>t<font color="#990000">.</font>startVar<font color="#990000">),</font> <b><font color="#0000FF">sizeof</font></b> <font color="#990000">(</font>timeval<font color="#990000">));</font>
-    <b><font color="#000000">memcpy</font></b><font color="#990000">(&amp;</font>stopVar<font color="#990000">,</font>  <font color="#990000">&amp;(</font>t<font color="#990000">.</font>stopVar<font color="#990000">),</font>  <b><font color="#0000FF">sizeof</font></b> <font color="#990000">(</font>timeval<font color="#990000">));</font>
-<font color="#FF0000">}</font>
+timer<span style="color:#990000">::</span><b><span style="color:#000000">timer</span></b><span style="color:#990000">(</span>timer <span style="color:#990000">&amp;</span> t<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">running</span></b><span style="color:#990000">(</span>t<span style="color:#990000">.</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#000000">memcpy</span></b><span style="color:#990000">(&amp;</span>startVar<span style="color:#990000">,</span> <span style="color:#990000">&amp;(</span>t<span style="color:#990000">.</span>startVar<span style="color:#990000">),</span> <b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(</span>timeval<span style="color:#990000">));</span>
+    <b><span style="color:#000000">memcpy</span></b><span style="color:#990000">(&amp;</span>stopVar<span style="color:#990000">,</span>  <span style="color:#990000">&amp;(</span>t<span style="color:#990000">.</span>stopVar<span style="color:#990000">),</span>  <b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(</span>timeval<span style="color:#990000">));</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> timer<font color="#990000">::</font><b><font color="#000000">start</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(!</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-        running <font color="#990000">=</font> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-        <b><font color="#000000">gettimeofday</font></b><font color="#990000">(&amp;</font>startVar<font color="#990000">,</font>NULL<font color="#990000">);</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">start</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(!</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        running <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+        <b><span style="color:#000000">gettimeofday</span></b><span style="color:#990000">(&amp;</span>startVar<span style="color:#990000">,</span>NULL<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> timer<font color="#990000">::</font><b><font color="#000000">stop</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-        running <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-        <b><font color="#000000">gettimeofday</font></b><font color="#990000">(&amp;</font>stopVar<font color="#990000">,</font>NULL<font color="#990000">);</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">stop</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        running <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <b><span style="color:#000000">gettimeofday</span></b><span style="color:#990000">(&amp;</span>stopVar<span style="color:#990000">,</span>NULL<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-ostream <font color="#990000">&amp;</font> timer<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">(</font>ostream <font color="#990000">&amp;</font> out<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(</font>out <font color="#990000">&lt;&lt;</font> <b><font color="#000000">toString</font></b><font color="#990000">());</font>
-<font color="#FF0000">}</font>
+ostream <span style="color:#990000">&amp;</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">(</span>ostream <span style="color:#990000">&amp;</span> out<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(</span>out <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">toString</span></b><span style="color:#990000">());</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">double</font> timer<font color="#990000">::</font><b><font color="#000000">getTime</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">time_t</font> sec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_sec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_sec<font color="#990000">;</font>
-    <font color="#009900">long</font> usec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_usec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_usec<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> sec <font color="#990000">+</font> usec<font color="#990000">/</font><font color="#993399">1000000.0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">double</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">getTime</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">time_t</span> sec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_sec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_sec<span style="color:#990000">;</span>
+    <span style="color:#009900">long</span> usec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_usec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_usec<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> sec <span style="color:#990000">+</span> usec<span style="color:#990000">/</span><span style="color:#993399">1000000.0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#008080">string</font> timer<font color="#990000">::</font><b><font color="#000000">toString</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">ostringstream</font> out<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>running<font color="#990000">)</font>
-        out <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Timer still running</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        <font color="#008080">time_t</font> sec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_sec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_sec<font color="#990000">;</font>
-        <font color="#009900">long</font> usec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_usec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_usec<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> usec <font color="#990000">&lt;</font> <font color="#993399">0</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            sec<font color="#990000">--;</font>
-            usec <font color="#990000">+=</font> <font color="#993399">1000000</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        out <font color="#990000">&lt;&lt;</font> sec <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"."</font>
-            <font color="#990000">&lt;&lt;</font> <font color="#990000">((</font>usec<font color="#990000">&lt;</font><font color="#993399">100000</font><font color="#990000">)?</font><font color="#FF0000">"0"</font><font color="#990000">:</font><font color="#FF0000">""</font><font color="#990000">)</font>
-            <font color="#990000">&lt;&lt;</font> <font color="#990000">((</font>usec<font color="#990000">&lt;</font><font color="#993399">10000</font><font color="#990000">)?</font><font color="#FF0000">"0"</font><font color="#990000">:</font><font color="#FF0000">""</font><font color="#990000">)</font>
-            <font color="#990000">&lt;&lt;</font> <font color="#990000">((</font>usec<font color="#990000">&lt;</font><font color="#993399">1000</font><font color="#990000">)?</font><font color="#FF0000">"0"</font><font color="#990000">:</font><font color="#FF0000">""</font><font color="#990000">)</font>
-            <font color="#990000">&lt;&lt;</font> <font color="#990000">((</font>usec<font color="#990000">&lt;</font><font color="#993399">100</font><font color="#990000">)?</font><font color="#FF0000">"0"</font><font color="#990000">:</font><font color="#FF0000">""</font><font color="#990000">)</font>
-            <font color="#990000">&lt;&lt;</font> <font color="#990000">((</font>usec<font color="#990000">&lt;</font><font color="#993399">10</font><font color="#990000">)?</font><font color="#FF0000">"0"</font><font color="#990000">:</font><font color="#FF0000">""</font><font color="#990000">)</font>
-            <font color="#990000">&lt;&lt;</font> usec<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> out<font color="#990000">.</font><b><font color="#000000">str</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
+<span style="color:#008080">string</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">toString</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">ostringstream</span> out<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>running<span style="color:#990000">)</span>
+        out <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Timer still running</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">time_t</span> sec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_sec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_sec<span style="color:#990000">;</span>
+        <span style="color:#009900">long</span> usec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_usec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_usec<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> usec <span style="color:#990000">&lt;</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            sec<span style="color:#990000">--;</span>
+            usec <span style="color:#990000">+=</span> <span style="color:#993399">1000000</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        out <span style="color:#990000">&lt;&lt;</span> sec <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"."</span>
+            <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">((</span>usec<span style="color:#990000">&lt;</span><span style="color:#993399">100000</span><span style="color:#990000">)?</span><span style="color:#FF0000">"0"</span><span style="color:#990000">:</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">((</span>usec<span style="color:#990000">&lt;</span><span style="color:#993399">10000</span><span style="color:#990000">)?</span><span style="color:#FF0000">"0"</span><span style="color:#990000">:</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">((</span>usec<span style="color:#990000">&lt;</span><span style="color:#993399">1000</span><span style="color:#990000">)?</span><span style="color:#FF0000">"0"</span><span style="color:#990000">:</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">((</span>usec<span style="color:#990000">&lt;</span><span style="color:#993399">100</span><span style="color:#990000">)?</span><span style="color:#FF0000">"0"</span><span style="color:#990000">:</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">((</span>usec<span style="color:#990000">&lt;</span><span style="color:#993399">10</span><span style="color:#990000">)?</span><span style="color:#FF0000">"0"</span><span style="color:#990000">:</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&lt;&lt;</span> usec<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> out<span style="color:#990000">.</span><b><span style="color:#000000">str</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
 
-ostream <font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font><font color="#008080">ostream</font> <font color="#990000">&amp;</font>out<font color="#990000">,</font> <font color="#008080">timer</font> <font color="#990000">&amp;</font>t<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> t<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">(</font>out<font color="#990000">);</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+ostream <span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span><span style="color:#008080">ostream</span> <span style="color:#990000">&amp;</span>out<span style="color:#990000">,</span> <span style="color:#008080">timer</span> <span style="color:#990000">&amp;</span>t<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> t<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">(</span>out<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab06/code/timer.h.html
+++ b/labs/lab06/code/timer.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/timer.h.html
+++ b/labs/lab06/code/timer.h.html
@@ -1,49 +1,49 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>timer.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// This timer typically has 1/1000000 second (1 micro-second) accuracy</font></i>
-<i><font color="#9A1900">// under most Linux distributions</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</span></i>
+<i><span style="color:#9A1900">// systems) you will have to include the -lrt flag to your compiler.</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// This timer typically has 1/1000000 second (1 micro-second) accuracy</span></i>
+<i><span style="color:#9A1900">// under most Linux distributions</span></i>
 
-<b><font color="#000080">#ifndef</font></b> TIMER_H
-<b><font color="#000080">#define</font></b> TIMER_H
+<b><span style="color:#000080">#ifndef</span></b> TIMER_H
+<b><span style="color:#000080">#define</span></b> TIMER_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sys/time.h&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;sys/time.h&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">timer</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">timeval</font> startVar<font color="#990000">,</font> stopVar<font color="#990000">;</font>
-    <font color="#009900">bool</font> running<font color="#990000">;</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">timer</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">timeval</span> startVar<span style="color:#990000">,</span> stopVar<span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> running<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">timer</font></b><font color="#990000">()</font> <font color="#990000">:</font> <b><font color="#000000">running</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{}</font>
-    <font color="#990000">~</font><b><font color="#000000">timer</font></b><font color="#990000">()</font> <font color="#FF0000">{}</font>
-    <b><font color="#000000">timer</font></b><font color="#990000">(</font>timer <font color="#990000">&amp;</font> myTimer<font color="#990000">);</font>
-    <font color="#009900">int</font> <b><font color="#000000">start</font></b><font color="#990000">();</font>
-    <font color="#009900">int</font> <b><font color="#000000">stop</font></b><font color="#990000">();</font>
-    <font color="#008080">string</font> <b><font color="#000000">toString</font></b><font color="#990000">();</font>
-    ostream <font color="#990000">&amp;</font> <b><font color="#000000">print</font></b><font color="#990000">(</font><font color="#008080">ostream</font> <font color="#990000">&amp;</font>theStream<font color="#990000">);</font>
-    <font color="#009900">double</font> <b><font color="#000000">getTime</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">timer</span></b><span style="color:#990000">()</span> <span style="color:#990000">:</span> <b><span style="color:#000000">running</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{}</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">timer</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{}</span>
+    <b><span style="color:#000000">timer</span></b><span style="color:#990000">(</span>timer <span style="color:#990000">&amp;</span> myTimer<span style="color:#990000">);</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">start</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">stop</span></b><span style="color:#990000">();</span>
+    <span style="color:#008080">string</span> <b><span style="color:#000000">toString</span></b><span style="color:#990000">();</span>
+    ostream <span style="color:#990000">&amp;</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">(</span><span style="color:#008080">ostream</span> <span style="color:#990000">&amp;</span>theStream<span style="color:#990000">);</span>
+    <span style="color:#009900">double</span> <b><span style="color:#000000">getTime</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-ostream <font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font>ostream <font color="#990000">&amp;</font> theStream<font color="#990000">,</font> timer <font color="#990000">&amp;</font> theTimer<font color="#990000">);</font>
+ostream <span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span>ostream <span style="color:#990000">&amp;</span> theStream<span style="color:#990000">,</span> timer <span style="color:#990000">&amp;</span> theTimer<span style="color:#990000">);</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab06/code/timer_test.cpp.html
+++ b/labs/lab06/code/timer_test.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab06/code/timer_test.cpp.html
+++ b/labs/lab06/code/timer_test.cpp.html
@@ -1,30 +1,30 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>timer_test.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</span></i>
+<i><span style="color:#9A1900">// systems) you will have to include the -lrt flag to your compiler.</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"timer.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"timer.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">timer</font> t<font color="#990000">;</font>
-    t<font color="#990000">.</font><b><font color="#000000">start</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// do something that takes some time...</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">1000000000</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">);</font>
-    t<font color="#990000">.</font><b><font color="#000000">stop</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> t <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> t<font color="#990000">.</font><b><font color="#000000">getTime</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">timer</span> t<span style="color:#990000">;</span>
+    t<span style="color:#990000">.</span><b><span style="color:#000000">start</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// do something that takes some time...</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">1000000000</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">);</span>
+    t<span style="color:#990000">.</span><b><span style="color:#000000">stop</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> t <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> t<span style="color:#990000">.</span><b><span style="color:#000000">getTime</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab07/bubblesort.cpp.html
+++ b/labs/lab07/bubblesort.cpp.html
@@ -1,74 +1,74 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>bubblesort.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// Bubblesort of an array of 5 integers.</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// Pass through the array right to left.  On each pass through the</font></i>
-<i><font color="#9A1900">// outer loop, the smallest remaining value will "bubble" over to its</font></i>
-<i><font color="#9A1900">// appropriate final location in the left side of the array.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// Bubblesort of an array of 5 integers.</span></i>
+<i><span style="color:#9A1900">//</span></i>
+<i><span style="color:#9A1900">// Pass through the array right to left.  On each pass through the</span></i>
+<i><span style="color:#9A1900">// outer loop, the smallest remaining value will "bubble" over to its</span></i>
+<i><span style="color:#9A1900">// appropriate final location in the left side of the array.</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">const</font></b> <font color="#009900">int</font> MAX<font color="#990000">=</font><font color="#993399">5</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">const</span></b> <span style="color:#009900">int</span> MAX<span style="color:#990000">=</span><span style="color:#993399">5</span><span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> A<font color="#990000">[</font>MAX<font color="#990000">];</font>
-    <font color="#009900">int</font> temp<font color="#990000">;</font>
-    <font color="#009900">int</font> k<font color="#990000">;</font>
-    <i><font color="#9A1900">// The following output line should NOT be encoded into IBCM -- it</font></i>
-    <i><font color="#9A1900">// is just to make the C++ implementation easier to understand</font></i>
-    <i><font color="#9A1900">// when run</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter "</font> <font color="#990000">&lt;&lt;</font> MAX <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" numbers to sort, one per line."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// read in the array values.  For IBCM implementation, assume that</font></i>
-    <i><font color="#9A1900">// array is hard coded AFTER the end of the program to perform</font></i>
-    <i><font color="#9A1900">// bubblesort</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font>k <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> k <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> <font color="#990000">++</font>k<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cin <font color="#990000">&gt;&gt;</font> A<font color="#990000">[</font>k<font color="#990000">];</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// print out the user input to the screen</font></i>
-    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Original: "</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font>k <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> k <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> <font color="#990000">++</font>k<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> A<font color="#990000">[</font>k<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// Your IBCM program should be these 2 nested for loops plus some</font></i>
-    <i><font color="#9A1900">// additional variable declarations to store the information you</font></i>
-    <i><font color="#9A1900">// need.  This is what you have to implement in IBCM.</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> <font color="#990000">++</font>i<font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> j <font color="#990000">=</font> MAX<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font> j <font color="#990000">&gt;</font> i<font color="#990000">;</font> <font color="#990000">--</font>j<font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>A<font color="#990000">[</font>j<font color="#990000">]</font> <font color="#990000">&lt;</font> A<font color="#990000">[</font>j<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">])</font> <font color="#FF0000">{</font>
-                <i><font color="#9A1900">//	swap(A[j], A[j-1]);</font></i>
-                temp <font color="#990000">=</font> A<font color="#990000">[</font>j<font color="#990000">];</font>
-                A<font color="#990000">[</font>j<font color="#990000">]</font> <font color="#990000">=</font> A<font color="#990000">[</font>j<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">];</font>
-                A<font color="#990000">[</font>j<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">=</font> temp<font color="#990000">;</font>
-            <font color="#FF0000">}</font>
-        <font color="#FF0000">}</font>
-        <i><font color="#9A1900">// You don't have to worry about all this output for the IBCM</font></i>
-        <i><font color="#9A1900">// version.</font></i>
-        cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After Pass "</font><font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"  "</font><font color="#990000">;</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font>k <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> k <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> <font color="#990000">++</font>k<font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> A<font color="#990000">[</font>k<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// You DO NOT have to implement this. It is only provided so that</font></i>
-    <i><font color="#9A1900">// You may build and run the program via g++ to understand how the</font></i>
-    <i><font color="#9A1900">// algorithm works.</font></i>
-    cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Sorted: "</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font>k <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> k <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> <font color="#990000">++</font>k<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> A<font color="#990000">[</font>k<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> A<span style="color:#990000">[</span>MAX<span style="color:#990000">];</span>
+    <span style="color:#009900">int</span> temp<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> k<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// The following output line should NOT be encoded into IBCM -- it</span></i>
+    <i><span style="color:#9A1900">// is just to make the C++ implementation easier to understand</span></i>
+    <i><span style="color:#9A1900">// when run</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter "</span> <span style="color:#990000">&lt;&lt;</span> MAX <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" numbers to sort, one per line."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// read in the array values.  For IBCM implementation, assume that</span></i>
+    <i><span style="color:#9A1900">// array is hard coded AFTER the end of the program to perform</span></i>
+    <i><span style="color:#9A1900">// bubblesort</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span>k <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> k <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> <span style="color:#990000">++</span>k<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cin <span style="color:#990000">&gt;&gt;</span> A<span style="color:#990000">[</span>k<span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// print out the user input to the screen</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Original: "</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span>k <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> k <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> <span style="color:#990000">++</span>k<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> A<span style="color:#990000">[</span>k<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// Your IBCM program should be these 2 nested for loops plus some</span></i>
+    <i><span style="color:#9A1900">// additional variable declarations to store the information you</span></i>
+    <i><span style="color:#9A1900">// need.  This is what you have to implement in IBCM.</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> j <span style="color:#990000">=</span> MAX<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span> j <span style="color:#990000">&gt;</span> i<span style="color:#990000">;</span> <span style="color:#990000">--</span>j<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>A<span style="color:#990000">[</span>j<span style="color:#990000">]</span> <span style="color:#990000">&lt;</span> A<span style="color:#990000">[</span>j<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">])</span> <span style="color:#FF0000">{</span>
+                <i><span style="color:#9A1900">//	swap(A[j], A[j-1]);</span></i>
+                temp <span style="color:#990000">=</span> A<span style="color:#990000">[</span>j<span style="color:#990000">];</span>
+                A<span style="color:#990000">[</span>j<span style="color:#990000">]</span> <span style="color:#990000">=</span> A<span style="color:#990000">[</span>j<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+                A<span style="color:#990000">[</span>j<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+            <span style="color:#FF0000">}</span>
+        <span style="color:#FF0000">}</span>
+        <i><span style="color:#9A1900">// You don't have to worry about all this output for the IBCM</span></i>
+        <i><span style="color:#9A1900">// version.</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After Pass "</span><span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"  "</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span>k <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> k <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> <span style="color:#990000">++</span>k<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> A<span style="color:#990000">[</span>k<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// You DO NOT have to implement this. It is only provided so that</span></i>
+    <i><span style="color:#9A1900">// You may build and run the program via g++ to understand how the</span></i>
+    <i><span style="color:#9A1900">// algorithm works.</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Sorted: "</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span>k <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> k <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> <span style="color:#990000">++</span>k<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> A<span style="color:#990000">[</span>k<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab07/bubblesort.cpp.html
+++ b/labs/lab07/bubblesort.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab07/counter.cpp.html
+++ b/labs/lab07/counter.cpp.html
@@ -1,119 +1,119 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>counter.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sys/time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;sys/time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;sstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
 
-<i><font color="#9A1900">// this is the timer class from lab 6, included here so as not to</font></i>
-<i><font color="#9A1900">// require multiple files to compile</font></i>
-<b><font color="#0000FF">class</font></b> <font color="#008080">timer</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">timeval</font> startVar<font color="#990000">,</font> stopVar<font color="#990000">;</font>
-    <font color="#009900">bool</font> running<font color="#990000">;</font>
+<i><span style="color:#9A1900">// this is the timer class from lab 6, included here so as not to</span></i>
+<i><span style="color:#9A1900">// require multiple files to compile</span></i>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">timer</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">timeval</span> startVar<span style="color:#990000">,</span> stopVar<span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> running<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">timer</font></b><font color="#990000">()</font> <font color="#990000">:</font> <b><font color="#000000">running</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{}</font>
-    <font color="#990000">~</font><b><font color="#000000">timer</font></b><font color="#990000">()</font> <font color="#FF0000">{}</font>
-    <b><font color="#000000">timer</font></b><font color="#990000">(</font>timer <font color="#990000">&amp;</font> myTimer<font color="#990000">);</font>
-    <font color="#009900">int</font> <b><font color="#000000">start</font></b><font color="#990000">();</font>
-    <font color="#009900">int</font> <b><font color="#000000">stop</font></b><font color="#990000">();</font>
-    <font color="#008080">string</font> <b><font color="#000000">toString</font></b><font color="#990000">();</font>
-    ostream <font color="#990000">&amp;</font> <b><font color="#000000">print</font></b><font color="#990000">(</font><font color="#008080">ostream</font> <font color="#990000">&amp;</font>theStream<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">timer</span></b><span style="color:#990000">()</span> <span style="color:#990000">:</span> <b><span style="color:#000000">running</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{}</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">timer</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{}</span>
+    <b><span style="color:#000000">timer</span></b><span style="color:#990000">(</span>timer <span style="color:#990000">&amp;</span> myTimer<span style="color:#990000">);</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">start</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">stop</span></b><span style="color:#990000">();</span>
+    <span style="color:#008080">string</span> <b><span style="color:#000000">toString</span></b><span style="color:#990000">();</span>
+    ostream <span style="color:#990000">&amp;</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">(</span><span style="color:#008080">ostream</span> <span style="color:#990000">&amp;</span>theStream<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-timer<font color="#990000">::</font><b><font color="#000000">timer</font></b><font color="#990000">(</font>timer <font color="#990000">&amp;</font> t<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">running</font></b><font color="#990000">(</font>t<font color="#990000">.</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#000000">memcpy</font></b><font color="#990000">(&amp;</font>startVar<font color="#990000">,</font> <font color="#990000">&amp;(</font>t<font color="#990000">.</font>startVar<font color="#990000">),</font> <b><font color="#0000FF">sizeof</font></b> <font color="#990000">(</font>timeval<font color="#990000">));</font>
-    <b><font color="#000000">memcpy</font></b><font color="#990000">(&amp;</font>stopVar<font color="#990000">,</font>  <font color="#990000">&amp;(</font>t<font color="#990000">.</font>stopVar<font color="#990000">),</font>  <b><font color="#0000FF">sizeof</font></b> <font color="#990000">(</font>timeval<font color="#990000">));</font>
-<font color="#FF0000">}</font>
+timer<span style="color:#990000">::</span><b><span style="color:#000000">timer</span></b><span style="color:#990000">(</span>timer <span style="color:#990000">&amp;</span> t<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">running</span></b><span style="color:#990000">(</span>t<span style="color:#990000">.</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#000000">memcpy</span></b><span style="color:#990000">(&amp;</span>startVar<span style="color:#990000">,</span> <span style="color:#990000">&amp;(</span>t<span style="color:#990000">.</span>startVar<span style="color:#990000">),</span> <b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(</span>timeval<span style="color:#990000">));</span>
+    <b><span style="color:#000000">memcpy</span></b><span style="color:#990000">(&amp;</span>stopVar<span style="color:#990000">,</span>  <span style="color:#990000">&amp;(</span>t<span style="color:#990000">.</span>stopVar<span style="color:#990000">),</span>  <b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(</span>timeval<span style="color:#990000">));</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> timer<font color="#990000">::</font><b><font color="#000000">start</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(!</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-        running <font color="#990000">=</font> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-        <b><font color="#000000">gettimeofday</font></b><font color="#990000">(&amp;</font>startVar<font color="#990000">,</font>NULL<font color="#990000">);</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">start</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(!</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        running <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+        <b><span style="color:#000000">gettimeofday</span></b><span style="color:#990000">(&amp;</span>startVar<span style="color:#990000">,</span>NULL<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> timer<font color="#990000">::</font><b><font color="#000000">stop</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>running<font color="#990000">)</font> <font color="#FF0000">{</font>
-        running <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-        <b><font color="#000000">gettimeofday</font></b><font color="#990000">(&amp;</font>stopVar<font color="#990000">,</font>NULL<font color="#990000">);</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">stop</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>running<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        running <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <b><span style="color:#000000">gettimeofday</span></b><span style="color:#990000">(&amp;</span>stopVar<span style="color:#990000">,</span>NULL<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-ostream <font color="#990000">&amp;</font> timer<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">(</font>ostream <font color="#990000">&amp;</font> out<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(</font>out <font color="#990000">&lt;&lt;</font> <b><font color="#000000">toString</font></b><font color="#990000">());</font>
-<font color="#FF0000">}</font>
+ostream <span style="color:#990000">&amp;</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">(</span>ostream <span style="color:#990000">&amp;</span> out<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(</span>out <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">toString</span></b><span style="color:#990000">());</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#008080">string</font> timer<font color="#990000">::</font><b><font color="#000000">toString</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">ostringstream</font> out<font color="#990000">;</font>
-    <font color="#009900">int</font> ms<font color="#990000">,</font> s<font color="#990000">,</font> m<font color="#990000">,</font> h<font color="#990000">;</font>
-    <font color="#009900">int</font> totalmsec<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>running<font color="#990000">)</font>
-        out <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Timer still running</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        <font color="#008080">time_t</font> sec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_sec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_sec<font color="#990000">;</font>
-        <font color="#009900">long</font> usec <font color="#990000">=</font> stopVar<font color="#990000">.</font>tv_usec <font color="#990000">-</font> startVar<font color="#990000">.</font>tv_usec<font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> usec <font color="#990000">&lt;</font> <font color="#993399">0</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            sec<font color="#990000">--;</font>
-            usec <font color="#990000">+=</font> <font color="#993399">1000000</font><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        out <font color="#990000">&lt;&lt;</font> <font color="#990000">(</font>sec<font color="#990000">*</font><font color="#993399">1000</font><font color="#990000">+</font>usec<font color="#990000">/</font><font color="#993399">1000</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> out<font color="#990000">.</font><b><font color="#000000">str</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
+<span style="color:#008080">string</span> timer<span style="color:#990000">::</span><b><span style="color:#000000">toString</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">ostringstream</span> out<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> ms<span style="color:#990000">,</span> s<span style="color:#990000">,</span> m<span style="color:#990000">,</span> h<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> totalmsec<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>running<span style="color:#990000">)</span>
+        out <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Timer still running</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">time_t</span> sec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_sec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_sec<span style="color:#990000">;</span>
+        <span style="color:#009900">long</span> usec <span style="color:#990000">=</span> stopVar<span style="color:#990000">.</span>tv_usec <span style="color:#990000">-</span> startVar<span style="color:#990000">.</span>tv_usec<span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> usec <span style="color:#990000">&lt;</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            sec<span style="color:#990000">--;</span>
+            usec <span style="color:#990000">+=</span> <span style="color:#993399">1000000</span><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        out <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">(</span>sec<span style="color:#990000">*</span><span style="color:#993399">1000</span><span style="color:#990000">+</span>usec<span style="color:#990000">/</span><span style="color:#993399">1000</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> out<span style="color:#990000">.</span><b><span style="color:#000000">str</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
 
-ostream <font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font><font color="#008080">ostream</font> <font color="#990000">&amp;</font>out<font color="#990000">,</font> <font color="#008080">timer</font> <font color="#990000">&amp;</font>t<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> t<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">(</font>out<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+ostream <span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span><span style="color:#008080">ostream</span> <span style="color:#990000">&amp;</span>out<span style="color:#990000">,</span> <span style="color:#008080">timer</span> <span style="color:#990000">&amp;</span>t<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> t<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">(</span>out<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
 
-<i><font color="#9A1900">// this main method just counts the time taken to iterate 1 billion</font></i>
-<i><font color="#9A1900">// times through an idle loop</font></i>
+<i><span style="color:#9A1900">// this main method just counts the time taken to iterate 1 billion</span></i>
+<i><span style="color:#9A1900">// times through an idle loop</span></i>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// check the number of parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">!=</font> <font color="#993399">2</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"usage: "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" &lt;iterations&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// convert the second parameter to a int</font></i>
-    <font color="#009900">int</font> e<font color="#990000">,</font> ret<font color="#990000">;</font>
-    ret <font color="#990000">=</font> <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>e<font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> ret <font color="#990000">!=</font> <font color="#993399">1</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"error reading input: '"</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"'"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b> <font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// compute 10^e</font></i>
-    <font color="#009900">long</font> n <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> e<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        n <font color="#990000">*=</font> <font color="#993399">10</font><font color="#990000">;</font>
-    <font color="#008080">timer</font> t<font color="#990000">;</font>
-    t<font color="#990000">.</font><b><font color="#000000">start</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// do something that takes some time...</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">long</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> n<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">);</font>
-    t<font color="#990000">.</font><b><font color="#000000">stop</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> t <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// check the number of parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"usage: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" &lt;iterations&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// convert the second parameter to a int</span></i>
+    <span style="color:#009900">int</span> e<span style="color:#990000">,</span> ret<span style="color:#990000">;</span>
+    ret <span style="color:#990000">=</span> <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>e<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> ret <span style="color:#990000">!=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"error reading input: '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b> <span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// compute 10^e</span></i>
+    <span style="color:#009900">long</span> n <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> e<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        n <span style="color:#990000">*=</span> <span style="color:#993399">10</span><span style="color:#990000">;</span>
+    <span style="color:#008080">timer</span> t<span style="color:#990000">;</span>
+    t<span style="color:#990000">.</span><b><span style="color:#000000">start</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// do something that takes some time...</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">long</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> n<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">);</span>
+    t<span style="color:#990000">.</span><b><span style="color:#000000">stop</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> t <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab07/counter.cpp.html
+++ b/labs/lab07/counter.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-32bit/Makefile.html
+++ b/labs/lab08-32bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-32bit/Makefile.html
+++ b/labs/lab08-32bit/Makefile.html
@@ -1,54 +1,54 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Makefile</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900"># Makefile for CS 2150 pre-lab 8</font></i>
-<i><font color="#9A1900"># This Makefile shows how to link assembly with C/C++</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900"># Makefile for CS 2150 pre-lab 8</span></i>
+<i><span style="color:#9A1900"># This Makefile shows how to link assembly with C/C++</span></i>
 
-<i><font color="#9A1900"># Defines the C++ compiler we'll be using</font></i>
-<font color="#009900">CXX	=</font> g<font color="#990000">++</font> -m<font color="#993399">32</font>
+<i><span style="color:#9A1900"># Defines the C++ compiler we'll be using</span></i>
+<span style="color:#009900">CXX	=</span> g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span>
 
-<i><font color="#9A1900"># Defines the flags we'll be passing to the C++ compiler</font></i>
-<font color="#009900">CXXFLAGS	=</font> -Wall -g
+<i><span style="color:#9A1900"># Defines the flags we'll be passing to the C++ compiler</span></i>
+<span style="color:#009900">CXXFLAGS	=</span> -Wall -g
 
-<i><font color="#9A1900"># Defines the assembler</font></i>
-<font color="#009900">AS	=</font> nasm
+<i><span style="color:#9A1900"># Defines the assembler</span></i>
+<span style="color:#009900">AS	=</span> nasm
 
-<i><font color="#9A1900"># Defines the flags for the assembler</font></i>
-<font color="#009900">ASFLAGS	=</font> -f elf
+<i><span style="color:#9A1900"># Defines the flags for the assembler</span></i>
+<span style="color:#009900">ASFLAGS	=</span> -f elf -g
 
-<i><font color="#9A1900"># All of the .o files for our program</font></i>
-<font color="#009900">OFILES	=</font> vecsum.o main.o
+<i><span style="color:#9A1900"># All of the .o files for our program</span></i>
+<span style="color:#009900">OFILES	=</span> vecsum.o main.o
 
-<i><font color="#9A1900"># This tells make to create a .o file from a .cpp file, using the</font></i>
-<i><font color="#9A1900"># defaults above (i.e. the CXX and CXXFLAGS macros)</font></i>
-<b><font color="#000080">.SUFFIXES:</font></b> .o .cpp
+<i><span style="color:#9A1900"># This tells make to create a .o file from a .cpp file, using the</span></i>
+<i><span style="color:#9A1900"># defaults above (i.e. the CXX and CXXFLAGS macros)</span></i>
+<b><span style="color:#000080">.SUFFIXES:</span></b> .o .cpp
 
-<i><font color="#9A1900"># This tells make to create a .o file from a .s file, using the</font></i>
-<i><font color="#9A1900"># defaults above (i.e. the AS and ASFLAGS macros)</font></i>
-<b><font color="#000080">.SUFFIXES:</font></b> .o .s
+<i><span style="color:#9A1900"># This tells make to create a .o file from a .s file, using the</span></i>
+<i><span style="color:#9A1900"># defaults above (i.e. the AS and ASFLAGS macros)</span></i>
+<b><span style="color:#000080">.SUFFIXES:</span></b> .o .s
 
-<i><font color="#9A1900"># How to compile our final program.  Note that we do NOT specify an</font></i>
-<i><font color="#9A1900"># output executable name -- in order for this to work with the grading</font></i>
-<i><font color="#9A1900"># system, the file needs to be a.out (a.exe in Cygwin).</font></i>
-<font color="#990000">main:</font>	<font color="#009900">$(OFILES)</font>
-	<font color="#009900">$(CXX)</font> <font color="#009900">$(CXXFLAGS)</font> <font color="#009900">$(OFILES)</font>
+<i><span style="color:#9A1900"># How to compile our final program.  Note that we do NOT specify an</span></i>
+<i><span style="color:#9A1900"># output executable name -- in order for this to work with the grading</span></i>
+<i><span style="color:#9A1900"># system, the file needs to be a.out (a.exe in Cygwin).</span></i>
+<span style="color:#990000">main:</span>	<span style="color:#009900">$(OFILES)</span>
+	<span style="color:#009900">$(CXX)</span> <span style="color:#009900">$(CXXFLAGS)</span> <span style="color:#009900">$(OFILES)</span>
 
-<i><font color="#9A1900"># This will clean up (remove) all our object files.  The -f option</font></i>
-<i><font color="#9A1900"># tells rm to forcily remove the files (i.e. don't ask if they should</font></i>
-<i><font color="#9A1900"># be removed or not).  This removes object files (*.o) and Emacs</font></i>
-<i><font color="#9A1900"># backup files (*~)</font></i>
-<font color="#990000">clean:</font>
-	/bin/rm -f <font color="#990000">*</font>.o <font color="#990000">*~</font>
+<i><span style="color:#9A1900"># This will clean up (remove) all our object files.  The -f option</span></i>
+<i><span style="color:#9A1900"># tells rm to forcily remove the files (i.e. don't ask if they should</span></i>
+<i><span style="color:#9A1900"># be removed or not).  This removes object files (*.o) and Emacs</span></i>
+<i><span style="color:#9A1900"># backup files (*~)</span></i>
+<span style="color:#990000">clean:</span>
+	/bin/rm -f <span style="color:#990000">*</span>.o <span style="color:#990000">*~</span>
 
-<i><font color="#9A1900"># We don't have any dependencies for this small program</font></i>
-</tt></pre>
+<i><span style="color:#9A1900"># We don't have any dependencies for this small program</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab08-32bit/main.cpp.html
+++ b/labs/lab08-32bit/main.cpp.html
@@ -1,56 +1,56 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>main.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// main.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// main.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;cstdlib&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;cstdlib&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">vecsum</font></b> <font color="#990000">(</font><font color="#009900">int</font> <font color="#990000">*,</font> <font color="#009900">int</font><font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">vecsum</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> <span style="color:#990000">*,</span> <span style="color:#009900">int</span><span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// Purpose: This main program produces a vector of random</font></i>
-<i><font color="#9A1900">//          numbers between 0 and 99, then calls the</font></i>
-<i><font color="#9A1900">//          externally defined function 'vecsum' to add</font></i>
-<i><font color="#9A1900">//          up the elements of the vector.</font></i>
-<i><font color="#9A1900">// Author:  Adam Ferrari</font></i>
+<i><span style="color:#9A1900">// Purpose: This main program produces a vector of random</span></i>
+<i><span style="color:#9A1900">//          numbers between 0 and 99, then calls the</span></i>
+<i><span style="color:#9A1900">//          externally defined function 'vecsum' to add</span></i>
+<i><span style="color:#9A1900">//          up the elements of the vector.</span></i>
+<i><span style="color:#9A1900">// Author:  Adam Ferrari</span></i>
 
-<font color="#009900">int</font>  <b><font color="#000000">main</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font>  n<font color="#990000">,</font> <font color="#990000">*</font>vec<font color="#990000">,</font> sum<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Please enter a vector size:  "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> n<font color="#990000">;</font>
+<span style="color:#009900">int</span>  <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span>  n<span style="color:#990000">,</span> <span style="color:#990000">*</span>vec<span style="color:#990000">,</span> sum<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Please enter a vector size:  "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> n<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// sanity check the vector size</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n <font color="#990000">&lt;=</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Vector size must be greater than zero.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// sanity check the vector size</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n <span style="color:#990000">&lt;=</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Vector size must be greater than zero.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <i><font color="#9A1900">// allocate, initialize, and display vector</font></i>
-    vec <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <font color="#009900">int</font><font color="#990000">[</font>n<font color="#990000">];</font>
+    <i><span style="color:#9A1900">// allocate, initialize, and display vector</span></i>
+    vec <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">int</span><span style="color:#990000">[</span>n<span style="color:#990000">];</span>
 
-    <i><font color="#9A1900">// use current time as random seed</font></i>
-    <b><font color="#000000">srand</font></b><font color="#990000">((</font><font color="#009900">unsigned</font><font color="#990000">)</font> <b><font color="#000000">time</font></b><font color="#990000">(</font>NULL<font color="#990000">));</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> n<font color="#990000">;</font> <font color="#990000">++</font>i<font color="#990000">)</font> <font color="#FF0000">{</font>
-        vec<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">=</font> <b><font color="#000000">rand</font></b><font color="#990000">()</font> <font color="#990000">%</font> <font color="#993399">100</font><font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">vec["</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"] = "</font> <font color="#990000">&lt;&lt;</font> vec<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// use current time as random seed</span></i>
+    <b><span style="color:#000000">srand</span></b><span style="color:#990000">((</span><span style="color:#009900">unsigned</span><span style="color:#990000">)</span> <b><span style="color:#000000">time</span></b><span style="color:#990000">(</span>NULL<span style="color:#990000">));</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> n<span style="color:#990000">;</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        vec<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">=</span> <b><span style="color:#000000">rand</span></b><span style="color:#990000">()</span> <span style="color:#990000">%</span> <span style="color:#993399">100</span><span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">vec["</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"] = "</span> <span style="color:#990000">&lt;&lt;</span> vec<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <i><font color="#9A1900">// sum up the vector and print out results</font></i>
-    sum <font color="#990000">=</font> <b><font color="#000000">vecsum</font></b><font color="#990000">(</font>vec<font color="#990000">,</font> n<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The sum of all vector elements is "</font> <font color="#990000">&lt;&lt;</font> sum <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <i><span style="color:#9A1900">// sum up the vector and print out results</span></i>
+    sum <span style="color:#990000">=</span> <b><span style="color:#000000">vecsum</span></b><span style="color:#990000">(</span>vec<span style="color:#990000">,</span> n<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The sum of all vector elements is "</span> <span style="color:#990000">&lt;&lt;</span> sum <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab08-32bit/main.cpp.html
+++ b/labs/lab08-32bit/main.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-32bit/vecsum.s.html
+++ b/labs/lab08-32bit/vecsum.s.html
@@ -1,72 +1,72 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>vecsum.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">; vecsum.s</font></i>
-<i><font color="#9A1900">;</font></i>
-<i><font color="#9A1900">; Author  : Adam Ferrari</font></i>
-<i><font color="#9A1900">; Date    : Jan 29, 1998</font></i>
-<i><font color="#9A1900">; Purpose : This file contains the implementation of the function</font></i>
-<i><font color="#9A1900">;           vecsum, which adds up a vector of integers.</font></i>
-<i><font color="#9A1900">; Modified for NASM by Aaron Bloomfield on 9 Nov 2007</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">; vecsum.s</span></i>
+<i><span style="color:#9A1900">;</span></i>
+<i><span style="color:#9A1900">; Author  : Adam Ferrari</span></i>
+<i><span style="color:#9A1900">; Date    : Jan 29, 1998</span></i>
+<i><span style="color:#9A1900">; Purpose : This file contains the implementation of the function</span></i>
+<i><span style="color:#9A1900">;           vecsum, which adds up a vector of integers.</span></i>
+<i><span style="color:#9A1900">; Modified for NASM by Aaron Bloomfield on 9 Nov 2007</span></i>
 	
 	global vecsum
 
-	section <font color="#990000">.</font>text
+	section <span style="color:#990000">.</span>text
 
-<i><font color="#9A1900">;</font></i>
-<i><font color="#9A1900">; vecsum</font></i>
-<i><font color="#9A1900">; Parameter 1  - the starting address of a sequence of 32-bit integers.</font></i>
-<i><font color="#9A1900">; Parameter 2  - the number of integers in the sequence.</font></i>
-<i><font color="#9A1900">; Return value - the sum of the integers in the sequence.</font></i>
-<i><font color="#9A1900">;</font></i>
+<i><span style="color:#9A1900">;</span></i>
+<i><span style="color:#9A1900">; vecsum</span></i>
+<i><span style="color:#9A1900">; Parameter 1  - the starting address of a sequence of 32-bit integers.</span></i>
+<i><span style="color:#9A1900">; Parameter 2  - the number of integers in the sequence.</span></i>
+<i><span style="color:#9A1900">; Return value - the sum of the integers in the sequence.</span></i>
+<i><span style="color:#9A1900">;</span></i>
 
-<b><font color="#000080">vecsum:</font></b>
-	<i><font color="#9A1900">; Standard prologue</font></i>
-	<b><font color="#0000FF">push</font></b>  <font color="#009900">ebp</font>		<i><font color="#9A1900">; Save the old base pointer</font></i>
-	<b><font color="#0000FF">mov</font></b>   <font color="#009900">ebp</font><font color="#990000">,</font> <font color="#009900">esp</font>		<i><font color="#9A1900">; Set new value of the base pointer</font></i>
-	<b><font color="#0000FF">push</font></b>  <font color="#009900">esi</font>		<i><font color="#9A1900">; Save registers</font></i>
+<b><span style="color:#000080">vecsum:</span></b>
+	<i><span style="color:#9A1900">; Standard prologue</span></i>
+	<b><span style="color:#0000FF">push</span></b>  <span style="color:#009900">ebp</span>		<i><span style="color:#9A1900">; Save the old base pointer</span></i>
+	<b><span style="color:#0000FF">mov</span></b>   <span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>		<i><span style="color:#9A1900">; Set new value of the base pointer</span></i>
+	<b><span style="color:#0000FF">push</span></b>  <span style="color:#009900">esi</span>		<i><span style="color:#9A1900">; Save registers</span></i>
 
-	<b><font color="#0000FF">xor</font></b>   <font color="#009900">eax</font><font color="#990000">,</font> <font color="#009900">eax</font>		<i><font color="#9A1900">; Place zero in EAX. We will keep a running</font></i>
-				<i><font color="#9A1900">; sum of the vector elements in EAX.</font></i>
+	<b><span style="color:#0000FF">xor</span></b>   <span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>		<i><span style="color:#9A1900">; Place zero in EAX. We will keep a running</span></i>
+				<i><span style="color:#9A1900">; sum of the vector elements in EAX.</span></i>
 
-	<b><font color="#0000FF">mov</font></b>   <font color="#009900">esi</font><font color="#990000">,</font> <font color="#990000">[</font><font color="#009900">ebp</font><font color="#990000">+</font><font color="#993399">8</font><font color="#990000">]</font>	<i><font color="#9A1900">; Put the vector starting address in ESI.</font></i>
-	<b><font color="#0000FF">mov</font></b>   <font color="#009900">ecx</font><font color="#990000">,</font> <font color="#990000">[</font><font color="#009900">ebp</font><font color="#990000">+</font><font color="#993399">12</font><font color="#990000">]</font>	<i><font color="#9A1900">; Put the vector size in ECX. We will use</font></i>
-				<i><font color="#9A1900">; ECX to indicate how many vector elements</font></i>
-				<i><font color="#9A1900">; are left to add into the sum.</font></i>
+	<b><span style="color:#0000FF">mov</span></b>   <span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>	<i><span style="color:#9A1900">; Put the vector starting address in ESI.</span></i>
+	<b><span style="color:#0000FF">mov</span></b>   <span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>	<i><span style="color:#9A1900">; Put the vector size in ECX. We will use</span></i>
+				<i><span style="color:#9A1900">; ECX to indicate how many vector elements</span></i>
+				<i><span style="color:#9A1900">; are left to add into the sum.</span></i>
 
-	<b><font color="#0000FF">cmp</font></b>   <font color="#009900">ecx</font><font color="#990000">,</font> <font color="#993399">0</font>		<i><font color="#9A1900">; If there are not more than zero elemen</font></i>
-	<b><font color="#0000FF">jle</font></b>   vecsum_done	<i><font color="#9A1900">; in the array, skip to the end and return</font></i>
-				<i><font color="#9A1900">; zero (already in EAX).</font></i>
+	<b><span style="color:#0000FF">cmp</span></b>   <span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>		<i><span style="color:#9A1900">; If there are not more than zero elemen</span></i>
+	<b><span style="color:#0000FF">jle</span></b>   vecsum_done	<i><span style="color:#9A1900">; in the array, skip to the end and return</span></i>
+				<i><span style="color:#9A1900">; zero (already in EAX).</span></i>
 
-vecsum_loop<font color="#990000">:</font>
-	<b><font color="#0000FF">mov</font></b>   <font color="#009900">edx</font><font color="#990000">,</font> <font color="#990000">[</font><font color="#009900">esi</font><font color="#990000">]</font>	<i><font color="#9A1900">; Put the current vector element into EDX.</font></i>
-	<b><font color="#0000FF">add</font></b>   <font color="#009900">eax</font><font color="#990000">,</font> <font color="#009900">edx</font>		<i><font color="#9A1900">; Add the current vector element into the</font></i>
-				<i><font color="#9A1900">; running sum.</font></i>
-	<b><font color="#0000FF">add</font></b>   <font color="#009900">esi</font><font color="#990000">,</font> <font color="#993399">4</font>		<i><font color="#9A1900">; Increment ESI to point to the next</font></i>
-				<i><font color="#9A1900">; vector element (4 bytes away).</font></i>
-	<b><font color="#0000FF">dec</font></b>   <font color="#009900">ecx</font>		<i><font color="#9A1900">; Decrement ECX, the counter of how many</font></i>
-				<i><font color="#9A1900">; left to do.</font></i>
-	<b><font color="#0000FF">cmp</font></b>   <font color="#009900">ecx</font><font color="#990000">,</font> <font color="#993399">0</font>		<i><font color="#9A1900">; If there are more than zero elements</font></i>
-	<b><font color="#0000FF">jg</font></b>    vecsum_loop	<i><font color="#9A1900">; left to add up, then do the loop again.</font></i>
+vecsum_loop<span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>   <span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esi</span><span style="color:#990000">]</span>	<i><span style="color:#9A1900">; Put the current vector element into EDX.</span></i>
+	<b><span style="color:#0000FF">add</span></b>   <span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">edx</span>		<i><span style="color:#9A1900">; Add the current vector element into the</span></i>
+				<i><span style="color:#9A1900">; running sum.</span></i>
+	<b><span style="color:#0000FF">add</span></b>   <span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>		<i><span style="color:#9A1900">; Increment ESI to point to the next</span></i>
+				<i><span style="color:#9A1900">; vector element (4 bytes away).</span></i>
+	<b><span style="color:#0000FF">dec</span></b>   <span style="color:#009900">ecx</span>		<i><span style="color:#9A1900">; Decrement ECX, the counter of how many</span></i>
+				<i><span style="color:#9A1900">; left to do.</span></i>
+	<b><span style="color:#0000FF">cmp</span></b>   <span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>		<i><span style="color:#9A1900">; If there are more than zero elements</span></i>
+	<b><span style="color:#0000FF">jg</span></b>    vecsum_loop	<i><span style="color:#9A1900">; left to add up, then do the loop again.</span></i>
 
-vecsum_done<font color="#990000">:</font>
-	<i><font color="#9A1900">; At this point, the loop is done, and we have the sum of the</font></i>
-	<i><font color="#9A1900">; vector elements in EAX, which is exactly where we want the</font></i>
-	<i><font color="#9A1900">; return value to be.</font></i>
+vecsum_done<span style="color:#990000">:</span>
+	<i><span style="color:#9A1900">; At this point, the loop is done, and we have the sum of the</span></i>
+	<i><span style="color:#9A1900">; vector elements in EAX, which is exactly where we want the</span></i>
+	<i><span style="color:#9A1900">; return value to be.</span></i>
 
-	<i><font color="#9A1900">; Standard epilogue</font></i>
-	<b><font color="#0000FF">pop</font></b>   <font color="#009900">esi</font>		<i><font color="#9A1900">; Restore registers that we used.</font></i>
-				<i><font color="#9A1900">; Note - no local variables to dealocate.</font></i>
-	<b><font color="#0000FF">pop</font></b>   <font color="#009900">ebp</font>		<i><font color="#9A1900">; Restore the caller's base pointer.</font></i>
-	<b><font color="#0000FF">ret</font></b>			<i><font color="#9A1900">; Return to the caller.</font></i>
-</tt></pre>
+	<i><span style="color:#9A1900">; Standard epilogue</span></i>
+	<b><span style="color:#0000FF">pop</span></b>   <span style="color:#009900">esi</span>		<i><span style="color:#9A1900">; Restore registers that we used.</span></i>
+				<i><span style="color:#9A1900">; Note - no local variables to dealocate.</span></i>
+	<b><span style="color:#0000FF">pop</span></b>   <span style="color:#009900">ebp</span>		<i><span style="color:#9A1900">; Restore the caller's base pointer.</span></i>
+	<b><span style="color:#0000FF">ret</span></b>			<i><span style="color:#9A1900">; Return to the caller.</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab08-32bit/vecsum.s.html
+++ b/labs/lab08-32bit/vecsum.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/Makefile.html
+++ b/labs/lab08-64bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/Makefile.html
+++ b/labs/lab08-64bit/Makefile.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,47 +8,47 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Makefile</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900"># Makefile for CS 2150 pre-lab 8</font></i>
-<i><font color="#9A1900"># This Makefile shows how to link assembly with C/C++</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900"># Makefile for CS 2150 pre-lab 8</span></i>
+<i><span style="color:#9A1900"># This Makefile shows how to link assembly with C/C++</span></i>
 
-<i><font color="#9A1900"># Defines the C++ compiler we'll be using</font></i>
-<font color="#009900">CXX	=</font> clang<font color="#990000">++</font> -m<font color="#993399">64</font>
+<i><span style="color:#9A1900"># Defines the C++ compiler we'll be using</span></i>
+<span style="color:#009900">CXX	=</span> clang<span style="color:#990000">++</span> -m<span style="color:#993399">64</span>
 
-<i><font color="#9A1900"># Defines the flags we'll be passing to the C++ compiler</font></i>
-<font color="#009900">CXXFLAGS	=</font> -Wall -g
+<i><span style="color:#9A1900"># Defines the flags we'll be passing to the C++ compiler</span></i>
+<span style="color:#009900">CXXFLAGS	=</span> -Wall -g
 
-<i><font color="#9A1900"># Defines the assembler</font></i>
-<font color="#009900">AS	=</font> nasm
+<i><span style="color:#9A1900"># Defines the assembler</span></i>
+<span style="color:#009900">AS	=</span> nasm
 
-<i><font color="#9A1900"># Defines the flags for the assembler</font></i>
-<font color="#009900">ASFLAGS	=</font> -f elf64 -g
+<i><span style="color:#9A1900"># Defines the flags for the assembler</span></i>
+<span style="color:#009900">ASFLAGS	=</span> -f elf64 -g
 
-<i><font color="#9A1900"># All of the .o files for our program</font></i>
-<font color="#009900">OFILES	=</font> vecsum.o main.o
+<i><span style="color:#9A1900"># All of the .o files for our program</span></i>
+<span style="color:#009900">OFILES	=</span> vecsum.o main.o
 
-<i><font color="#9A1900"># This tells make to create a .o file from a .cpp file, using the</font></i>
-<i><font color="#9A1900"># defaults above (i.e. the CXX and CXXFLAGS macros)</font></i>
-<b><font color="#000080">.SUFFIXES:</font></b> .o .cpp
+<i><span style="color:#9A1900"># This tells make to create a .o file from a .cpp file, using the</span></i>
+<i><span style="color:#9A1900"># defaults above (i.e. the CXX and CXXFLAGS macros)</span></i>
+<b><span style="color:#000080">.SUFFIXES:</span></b> .o .cpp
 
-<i><font color="#9A1900"># This tells make to create a .o file from a .s file, using the</font></i>
-<i><font color="#9A1900"># defaults above (i.e. the AS and ASFLAGS macros)</font></i>
-<b><font color="#000080">.SUFFIXES:</font></b> .o .s
+<i><span style="color:#9A1900"># This tells make to create a .o file from a .s file, using the</span></i>
+<i><span style="color:#9A1900"># defaults above (i.e. the AS and ASFLAGS macros)</span></i>
+<b><span style="color:#000080">.SUFFIXES:</span></b> .o .s
 
-<i><font color="#9A1900"># How to compile our final program.  Note that we do NOT specify an</font></i>
-<i><font color="#9A1900"># output executable name -- in order for this to work with the grading</font></i>
-<i><font color="#9A1900"># system, the file needs to be a.out (a.exe in Cygwin).</font></i>
-<font color="#990000">main:</font>	<font color="#009900">$(OFILES)</font>
-	<font color="#009900">$(CXX)</font> <font color="#009900">$(CXXFLAGS)</font> <font color="#009900">$(OFILES)</font>
+<i><span style="color:#9A1900"># How to compile our final program.  Note that we do NOT specify an</span></i>
+<i><span style="color:#9A1900"># output executable name -- in order for this to work with the grading</span></i>
+<i><span style="color:#9A1900"># system, the file needs to be a.out (a.exe in Cygwin).</span></i>
+<span style="color:#990000">main:</span>	<span style="color:#009900">$(OFILES)</span>
+	<span style="color:#009900">$(CXX)</span> <span style="color:#009900">$(CXXFLAGS)</span> <span style="color:#009900">$(OFILES)</span>
 
-<i><font color="#9A1900"># This will clean up (remove) all our object files.  The -f option</font></i>
-<i><font color="#9A1900"># tells rm to forcily remove the files (i.e. don't ask if they should</font></i>
-<i><font color="#9A1900"># be removed or not).  This removes object files (*.o) and Emacs</font></i>
-<i><font color="#9A1900"># backup files (*~)</font></i>
-<font color="#990000">clean:</font>
-	/bin/rm -f <font color="#990000">*</font>.o <font color="#990000">*~</font>
+<i><span style="color:#9A1900"># This will clean up (remove) all our object files.  The -f option</span></i>
+<i><span style="color:#9A1900"># tells rm to forcily remove the files (i.e. don't ask if they should</span></i>
+<i><span style="color:#9A1900"># be removed or not).  This removes object files (*.o) and Emacs</span></i>
+<i><span style="color:#9A1900"># backup files (*~)</span></i>
+<span style="color:#990000">clean:</span>
+	/bin/rm -f <span style="color:#990000">*</span>.o <span style="color:#990000">*~</span>
 
-<i><font color="#9A1900"># We don't have any dependencies for this small program</font></i>
-</tt></pre>
+<i><span style="color:#9A1900"># We don't have any dependencies for this small program</span></i>
+</pre>
 </body>
 </html>

--- a/labs/lab08-64bit/main.cpp.html
+++ b/labs/lab08-64bit/main.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/main.cpp.html
+++ b/labs/lab08-64bit/main.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,60 +8,60 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>main.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// main.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// main.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;cstdlib&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;cstdlib&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">long</font> <b><font color="#000000">vecsum</font></b> <font color="#990000">(</font><font color="#009900">long</font><font color="#990000">*,</font> <font color="#009900">long</font><font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">long</span> <b><span style="color:#000000">vecsum</span></b> <span style="color:#990000">(</span><span style="color:#009900">long</span><span style="color:#990000">*,</span> <span style="color:#009900">long</span><span style="color:#990000">);</span>
 
-<i><font color="#9A1900">// Purpose: This main program produces a vector of random numbers</font></i>
-<i><font color="#9A1900">// between 0 and 99, then calls the externally defined function</font></i>
-<i><font color="#9A1900">// 'vecsum' to add up the elements of the vector.</font></i>
+<i><span style="color:#9A1900">// Purpose: This main program produces a vector of random numbers</span></i>
+<i><span style="color:#9A1900">// between 0 and 99, then calls the externally defined function</span></i>
+<i><span style="color:#9A1900">// 'vecsum' to add up the elements of the vector.</span></i>
 
-<i><font color="#9A1900">// Originally written by Adam Ferrari, and updated by Aaron Bloomfield</font></i>
+<i><span style="color:#9A1900">// Originally written by Adam Ferrari, and updated by Aaron Bloomfield</span></i>
 
-<font color="#009900">int</font>  <b><font color="#000000">main</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
+<span style="color:#009900">int</span>  <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
 
-    <i><font color="#9A1900">// delcare the local variables</font></i>
-    <font color="#009900">long</font>  n<font color="#990000">,</font> <font color="#990000">*</font>vec<font color="#990000">,</font> sum<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// delcare the local variables</span></i>
+    <span style="color:#009900">long</span>  n<span style="color:#990000">,</span> <span style="color:#990000">*</span>vec<span style="color:#990000">,</span> sum<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// how big is the array we want to use?</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Please enter a array size:  "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> n<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// how big is the array we want to use?</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Please enter a array size:  "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> n<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// sanity check the array size</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>n <font color="#990000">&lt;=</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        cerr <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Array size must be greater than zero.</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// sanity check the array size</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>n <span style="color:#990000">&lt;=</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Array size must be greater than zero.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <i><font color="#9A1900">// allocate the array</font></i>
-    vec <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <font color="#009900">long</font><font color="#990000">[</font>n<font color="#990000">];</font>
+    <i><span style="color:#9A1900">// allocate the array</span></i>
+    vec <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">long</span><span style="color:#990000">[</span>n<span style="color:#990000">];</span>
 
-    <i><font color="#9A1900">// use current time as random seed</font></i>
-    <b><font color="#000000">srand</font></b><font color="#990000">((</font><font color="#009900">unsigned</font><font color="#990000">)</font> <b><font color="#000000">time</font></b><font color="#990000">(</font>NULL<font color="#990000">));</font>
+    <i><span style="color:#9A1900">// use current time as random seed</span></i>
+    <b><span style="color:#000000">srand</span></b><span style="color:#990000">((</span><span style="color:#009900">unsigned</span><span style="color:#990000">)</span> <b><span style="color:#000000">time</span></b><span style="color:#990000">(</span>NULL<span style="color:#990000">));</span>
 
-    <i><font color="#9A1900">// fill the array with random values</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">long</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> n<font color="#990000">;</font> <font color="#990000">++</font>i<font color="#990000">)</font> <font color="#FF0000">{</font>
-        vec<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">=</font> <b><font color="#000000">rand</font></b><font color="#990000">()</font> <font color="#990000">%</font> <font color="#993399">100</font><font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">vec["</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"] = "</font> <font color="#990000">&lt;&lt;</font> vec<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// fill the array with random values</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">long</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> n<span style="color:#990000">;</span> <span style="color:#990000">++</span>i<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        vec<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">=</span> <b><span style="color:#000000">rand</span></b><span style="color:#990000">()</span> <span style="color:#990000">%</span> <span style="color:#993399">100</span><span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">vec["</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"] = "</span> <span style="color:#990000">&lt;&lt;</span> vec<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <i><font color="#9A1900">// sum up the array and print out results</font></i>
-    sum <font color="#990000">=</font> <b><font color="#000000">vecsum</font></b><font color="#990000">(</font>vec<font color="#990000">,</font> n<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The sum of all array elements is "</font> <font color="#990000">&lt;&lt;</font> sum <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// sum up the array and print out results</span></i>
+    sum <span style="color:#990000">=</span> <b><span style="color:#000000">vecsum</span></b><span style="color:#990000">(</span>vec<span style="color:#990000">,</span> n<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The sum of all array elements is "</span> <span style="color:#990000">&lt;&lt;</span> sum <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// properly deallocate the array</font></i>
-    <b><font color="#0000FF">delete</font></b> <font color="#990000">[]</font> vec<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// properly deallocate the array</span></i>
+    <b><span style="color:#0000FF">delete</span></b> <span style="color:#990000">[]</span> vec<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// all done!</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <i><span style="color:#9A1900">// all done!</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab08-64bit/mergeSort.s.html
+++ b/labs/lab08-64bit/mergeSort.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/mergeSort.s.html
+++ b/labs/lab08-64bit/mergeSort.s.html
@@ -1,141 +1,145 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
 <title>mergeSort.s</title>
 </head>
-<body bgcolor="white">
-<pre>
-<span style='color:#9A1900; '>; University of Virginia</span>
-<span style='color:#9A1900; '>; CS 2150 In-Lab 8</span>
-<span style='color:#9A1900; '>; Spring 2018</span>
-<span style='color:#9A1900; '>; mergeSort.s</span>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">; University of Virginia</span></i>
+<i><span style="color:#9A1900">; CS 2150 In-Lab 8</span></i>
+<i><span style="color:#9A1900">; Spring 2018</span></i>
+<i><span style="color:#9A1900">; mergeSort.s	</span></i>
 
 	global mergeSort
 	global merge
 
-	section <span style='color:#9A1900; '>.</span>text
+	section <span style="color:#990000">.</span>text
 
 
-<span style='color:#9A1900; '>; Parameter 1 is a pointer to the int array </span>
-<span style='color:#9A1900; '>; Parameter 2 is the left index in the array </span>
-<span style='color:#9A1900; '>; Parameter 3 is the right index in the array</span>
-<span style='color:#9A1900; '>; Return type is void </span>
-<b><span style='color:#000080; '>mergeSort:</span></b>
+<i><span style="color:#9A1900">; Parameter 1 is a pointer to the int array </span></i>
+<i><span style="color:#9A1900">; Parameter 2 is the left index in the array </span></i>
+<i><span style="color:#9A1900">; Parameter 3 is the right index in the array</span></i>
+<i><span style="color:#9A1900">; Return type is void </span></i>
+<b><span style="color:#000080">mergeSort:</span></b>
 
-	<span style='color:#9A1900; '>; Implement mergeSort here</span>
+	<i><span style="color:#9A1900">; Implement mergeSort here</span></i>
 	
 
 
 
-<span style='color:#9A1900; '>; Parameter 1 is a pointer to the int array </span>
-<span style='color:#9A1900; '>; Parameter 2 is the left index in the array</span>
-<span style='color:#9A1900; '>; Parameter 3 is the middle index in the array </span>
-<span style='color:#9A1900; '>; Parameter 4 is the right index in the array</span>
-<span style='color:#9A1900; '>; Return type is void </span>
-<b><span style='color:#000080; '>merge:</span></b>
-	<span style='color:#9A1900; '>; Save callee-save registers</span>
-	<span style='color:#9A1900; '>; Store local variables </span>
-	<span style='color:#0000ff; font-weight:bold; '>push</span> rbx			<span style='color:#9A1900; '>; int i</span>
-	<span style='color:#0000ff; font-weight:bold; '>push</span> r1<span style='color:#800000; '>2</span>			<span style='color:#9A1900; '>; int j</span>
-	<span style='color:#0000ff; font-weight:bold; '>push</span> r1<span style='color:#800000; '>3</span>			<span style='color:#9A1900; '>; int k</span>
-	<span style='color:#0000ff; font-weight:bold; '>push</span> r1<span style='color:#800000; '>4</span>			<span style='color:#9A1900; '>; int n1</span>
-	<span style='color:#0000ff; font-weight:bold; '>push</span> r1<span style='color:#800000; '>5</span>			<span style='color:#9A1900; '>; int n2</span>
+<i><span style="color:#9A1900">; Parameter 1 is a pointer to the int array </span></i>
+<i><span style="color:#9A1900">; Parameter 2 is the left index in the array</span></i>
+<i><span style="color:#9A1900">; Parameter 3 is the middle index in the array </span></i>
+<i><span style="color:#9A1900">; Parameter 4 is the right index in the array</span></i>
+<i><span style="color:#9A1900">; Return type is void </span></i>
+<b><span style="color:#000080">merge:</span></b>
+	<i><span style="color:#9A1900">; Save callee-save registers</span></i>
+	<i><span style="color:#9A1900">; Store local variables </span></i>
+	<b><span style="color:#0000FF">push</span></b> rbx			<i><span style="color:#9A1900">; int i</span></i>
+	<b><span style="color:#0000FF">push</span></b> r<span style="color:#993399">12</span>			<i><span style="color:#9A1900">; int j</span></i>
+	<b><span style="color:#0000FF">push</span></b> r<span style="color:#993399">13</span>			<i><span style="color:#9A1900">; int k</span></i>
+	<b><span style="color:#0000FF">push</span></b> r<span style="color:#993399">14</span>			<i><span style="color:#9A1900">; int n1</span></i>
+	<b><span style="color:#0000FF">push</span></b> r<span style="color:#993399">15</span>			<i><span style="color:#9A1900">; int n2</span></i>
 	
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>,</span> rdx			<span style='color:#9A1900; '>; n1 = mid - left + 1</span>
-	<span style='color:#0000ff; font-weight:bold; '>sub</span> r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>,</span> rsi
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>4</span>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">14</span><span style="color:#990000">,</span> rdx			<i><span style="color:#9A1900">; n1 = mid - left + 1</span></i>
+	<b><span style="color:#0000FF">sub</span></b> r<span style="color:#993399">14</span><span style="color:#990000">,</span> rsi
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">14</span>
 
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r1<span style='color:#800000; '>5</span><span style='color:#0000ff; '>,</span> rcx			<span style='color:#9A1900; '>; n2 = right - mid </span>
-	<span style='color:#0000ff; font-weight:bold; '>sub</span> r1<span style='color:#800000; '>5</span><span style='color:#0000ff; '>,</span> rdx
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">15</span><span style="color:#990000">,</span> rcx			<i><span style="color:#9A1900">; n2 = right - mid </span></i>
+	<b><span style="color:#0000FF">sub</span></b> r<span style="color:#993399">15</span><span style="color:#990000">,</span> rdx
 
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>1</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>+</span>r1<span style='color:#800000; '>5</span><span style='color:#0000ff; '>]</span>		<span style='color:#9A1900; '>; r11 = rsp offset = 4(n1 + n2)</span>
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>1</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>1</span><span style='color:#0000ff; '>]</span>		
-	<span style='color:#0000ff; font-weight:bold; '>sub</span> rsp<span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>1</span>			<span style='color:#9A1900; '>; allocate space for temp arrays</span>
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">11</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>r<span style="color:#993399">14</span><span style="color:#990000">+</span>r<span style="color:#993399">15</span><span style="color:#990000">]</span>		<i><span style="color:#9A1900">; r11 = rsp offset = 4(n1 + n2)</span></i>
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">11</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">11</span><span style="color:#990000">]</span>		
+	<b><span style="color:#0000FF">sub</span></b> rsp<span style="color:#990000">,</span> r<span style="color:#993399">11</span>			<i><span style="color:#9A1900">; allocate space for temp arrays</span></i>
 
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> rbx<span style='color:#0000ff; '>,</span> <span style='color:#800000; '>0</span>			<span style='color:#9A1900; '>; i = 0</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>,</span> <span style='color:#800000; '>0</span>			<span style='color:#9A1900; '>; j = 0</span>
+	<b><span style="color:#0000FF">mov</span></b> rbx<span style="color:#990000">,</span> <span style="color:#993399">0</span>			<i><span style="color:#9A1900">; i = 0</span></i>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>			<i><span style="color:#9A1900">; j = 0</span></i>
 	
-<span style='color:#9A1900; '>; Copy elements of arr[] into L[]	</span>
-<b><span style='color:#000080; '>copyLloop:</span></b>
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> rbx<span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>4</span>			<span style='color:#9A1900; '>; is i >= n1?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>copyRloop
-					<span style='color:#9A1900; '>; L[i] = arr[left + i]</span>
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>rsi<span style='color:#0000ff; '>+</span>rbx<span style='color:#0000ff; '>]</span>		
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>]</span>	<span style='color:#9A1900; '>; r10 = arr[left + i]</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>rbx<span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; L[i] = r10</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> rbx				<span style='color:#9A1900; '>; i++</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>copyLloop
+<i><span style="color:#9A1900">; Copy elements of arr[] into L[]	</span></i>
+<b><span style="color:#000080">copyLloop:</span></b>
+	<b><span style="color:#0000FF">cmp</span></b> rbx<span style="color:#990000">,</span> r<span style="color:#993399">14</span>			<i><span style="color:#9A1900">; is i &gt;= n1?</span></i>
+	<b><span style="color:#0000FF">jge</span></b> copyRloop
+					<i><span style="color:#9A1900">; L[i] = arr[left + i]</span></i>
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">10</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>rsi<span style="color:#990000">+</span>rbx<span style="color:#990000">]</span>		
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">10</span><span style="color:#990000">]</span>	<i><span style="color:#9A1900">; r10 = arr[left + i]</span></i>
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>rbx<span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; L[i] = r10</span></i>
+	<b><span style="color:#0000FF">inc</span></b> rbx				<i><span style="color:#9A1900">; i++</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> copyLloop
 
-<span style='color:#9A1900; '>; Copy elements of arr[] into R[]</span>
-<b><span style='color:#000080; '>copyRloop:</span></b>
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>5</span>			<span style='color:#9A1900; '>; is j >= n2?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>endcopyR
- 					<span style='color:#9A1900; '>; R[j] = arr[mid + 1 + j]</span>
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>rdx<span style='color:#0000ff; '>+</span>r1<span style='color:#800000; '>2</span><span style='color:#800000; '>+1</span><span style='color:#0000ff; '>]</span>	
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>]</span>	<span style='color:#9A1900; '>; r10 = arr[mid + 1 + j]</span>
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> rax<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>+</span>r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>]</span>		
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>rax<span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; R[j] = r10</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>2</span>				<span style='color:#9A1900; '>; j++</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>copyRloop
+<i><span style="color:#9A1900">; Copy elements of arr[] into R[]</span></i>
+<b><span style="color:#000080">copyRloop:</span></b>
+	<b><span style="color:#0000FF">cmp</span></b> r<span style="color:#993399">12</span><span style="color:#990000">,</span> r<span style="color:#993399">15</span>			<i><span style="color:#9A1900">; is j &gt;= n2?</span></i>
+	<b><span style="color:#0000FF">jge</span></b> endcopyR
+ 					<i><span style="color:#9A1900">; R[j] = arr[mid + 1 + j]</span></i>
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">10</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>rdx<span style="color:#990000">+</span>r<span style="color:#993399">12</span><span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">]</span>	
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">10</span><span style="color:#990000">]</span>	<i><span style="color:#9A1900">; r10 = arr[mid + 1 + j]</span></i>
+	<b><span style="color:#0000FF">lea</span></b> rax<span style="color:#990000">,</span> <span style="color:#990000">[</span>r<span style="color:#993399">12</span><span style="color:#990000">+</span>r<span style="color:#993399">14</span><span style="color:#990000">]</span>		
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>rax<span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; R[j] = r10</span></i>
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">12</span>				<i><span style="color:#9A1900">; j++</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> copyRloop
 
-<b><span style='color:#000080; '>endcopyR:</span></b>	
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> rbx<span style='color:#0000ff; '>,</span> <span style='color:#800000; '>0</span>			<span style='color:#9A1900; '>; i = 0</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>,</span> <span style='color:#800000; '>0</span>			<span style='color:#9A1900; '>; j = 0</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r1<span style='color:#800000; '>3</span><span style='color:#0000ff; '>,</span> rsi			<span style='color:#9A1900; '>; k = left</span>
+<b><span style="color:#000080">endcopyR:</span></b>	
+	<b><span style="color:#0000FF">mov</span></b> rbx<span style="color:#990000">,</span> <span style="color:#993399">0</span>			<i><span style="color:#9A1900">; i = 0</span></i>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>			<i><span style="color:#9A1900">; j = 0</span></i>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">13</span><span style="color:#990000">,</span> rsi			<i><span style="color:#9A1900">; k = left</span></i>
 
-<span style='color:#9A1900; '>; Merge L[] and R[] into arr[]</span>
-<b><span style='color:#000080; '>mergeLoop:</span></b>
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> rbx<span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>4</span>			<span style='color:#9A1900; '>; is i >= n1 or j >= n2?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>loopL
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>5</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>loopL
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>+</span>r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>]</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>]</span> 	<span style='color:#9A1900; '>; r10d = R[j]</span>
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>rbx<span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; is L[i] &lt;= R[j]?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jle </span>if
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>3</span><span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; arr[k] = R[j]</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>2</span>				<span style='color:#9A1900; '>; j++</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>endif
-<b><span style='color:#000080; '>if:</span></b>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>rbx<span style='color:#0000ff; '>]</span> 
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>3</span><span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; arr[k] = L[i] </span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> rbx				<span style='color:#9A1900; '>; i++</span>
-<b><span style='color:#000080; '>endif:</span></b>	
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>3</span>				<span style='color:#9A1900; '>; k++	</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>mergeLoop
+<i><span style="color:#9A1900">; Merge L[] and R[] into arr[]</span></i>
+<b><span style="color:#000080">mergeLoop:</span></b>
+	<b><span style="color:#0000FF">cmp</span></b> rbx<span style="color:#990000">,</span> r<span style="color:#993399">14</span>			<i><span style="color:#9A1900">; is i &gt;= n1 or j &gt;= n2?</span></i>
+	<b><span style="color:#0000FF">jge</span></b> loopL
+	<b><span style="color:#0000FF">cmp</span></b> r<span style="color:#993399">12</span><span style="color:#990000">,</span> r<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">jge</span></b> loopL
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">10</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>r<span style="color:#993399">12</span><span style="color:#990000">+</span>r<span style="color:#993399">14</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">10</span><span style="color:#990000">]</span> 	<i><span style="color:#9A1900">; r10d = R[j]</span></i>
+	<b><span style="color:#0000FF">cmp</span></b> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>rbx<span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; is L[i] &lt;= R[j]?</span></i>
+	<b><span style="color:#0000FF">jle</span></b> if
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">13</span><span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; arr[k] = R[j]</span></i>
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">12</span>				<i><span style="color:#9A1900">; j++</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> endif 
+<b><span style="color:#000080">if:</span></b>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>rbx<span style="color:#990000">]</span> 
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">13</span><span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; arr[k] = L[i] </span></i>
+	<b><span style="color:#0000FF">inc</span></b> rbx				<i><span style="color:#9A1900">; i++</span></i>
+<b><span style="color:#000080">endif:</span></b>	
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">13</span>				<i><span style="color:#9A1900">; k++	</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> mergeLoop
 	
-<span style='color:#9A1900; '>; Copy elements of L[] into arr[]</span>
-<b><span style='color:#000080; '>loopL:</span></b>				
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> rbx<span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>4</span>			<span style='color:#9A1900; '>; is i >= n1?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>loopR
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>rbx<span style='color:#0000ff; '>]</span> 
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>3</span><span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; arr[k] = L[i]</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> rbx				<span style='color:#9A1900; '>; i++</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>3</span>				<span style='color:#9A1900; '>; k++</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>loopL
+<i><span style="color:#9A1900">; Copy elements of L[] into arr[]</span></i>
+<b><span style="color:#000080">loopL:</span></b>				
+	<b><span style="color:#0000FF">cmp</span></b> rbx<span style="color:#990000">,</span> r<span style="color:#993399">14</span>			<i><span style="color:#9A1900">; is i &gt;= n1?</span></i>
+	<b><span style="color:#0000FF">jge</span></b> loopR
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>rbx<span style="color:#990000">]</span> 
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">13</span><span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; arr[k] = L[i]</span></i>
+	<b><span style="color:#0000FF">inc</span></b> rbx				<i><span style="color:#9A1900">; i++</span></i>
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">13</span>				<i><span style="color:#9A1900">; k++</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> loopL
 
-<span style='color:#9A1900; '>; Copy elements of R[] into arr[]</span>
-<b><span style='color:#000080; '>loopR:</span></b>	
-	<span style='color:#0000ff; font-weight:bold; '>cmp</span> r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>5</span>			<span style='color:#9A1900; '>; is j >= n2?</span>
-	<span style='color:#0000ff; font-weight:bold; '>jge </span>endR
-	<span style='color:#0000ff; font-weight:bold; '>lea</span> r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>,</span> <span style='color:#0000ff; '>[</span>r1<span style='color:#800000; '>2</span><span style='color:#0000ff; '>+</span>r1<span style='color:#800000; '>4</span><span style='color:#0000ff; '>]</span>
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> r10d<span style='color:#0000ff; '>,</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rsp<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>0</span><span style='color:#0000ff; '>]</span> 	
-	<span style='color:#0000ff; font-weight:bold; '>mov</span> <span style='color:#0000ff; font-weight:bold; '>DWORD</span> <span style='color:#0000ff; '>[</span>rdi<span style='color:#0000ff; '>+</span><span style='color:#800000; '>4</span><span style='color:#0000ff; '>*</span>r1<span style='color:#800000; '>3</span><span style='color:#0000ff; '>]</span><span style='color:#0000ff; '>,</span> r10d	<span style='color:#9A1900; '>; arr[k] = R[j]</span>
+<i><span style="color:#9A1900">; Copy elements of R[] into arr[]</span></i>
+<b><span style="color:#000080">loopR:</span></b>	
+	<b><span style="color:#0000FF">cmp</span></b> r<span style="color:#993399">12</span><span style="color:#990000">,</span> r<span style="color:#993399">15</span>			<i><span style="color:#9A1900">; is j &gt;= n2?</span></i>
+	<b><span style="color:#0000FF">jge</span></b> endR
+	<b><span style="color:#0000FF">lea</span></b> r<span style="color:#993399">10</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>r<span style="color:#993399">12</span><span style="color:#990000">+</span>r<span style="color:#993399">14</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b> r<span style="color:#993399">10</span>d<span style="color:#990000">,</span> DWORD <span style="color:#990000">[</span>rsp<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">10</span><span style="color:#990000">]</span> 	
+	<b><span style="color:#0000FF">mov</span></b> DWORD <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">*</span>r<span style="color:#993399">13</span><span style="color:#990000">],</span> r<span style="color:#993399">10</span>d	<i><span style="color:#9A1900">; arr[k] = R[j]</span></i>
 
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>2</span>				<span style='color:#9A1900; '>; j++</span>
-	<span style='color:#0000ff; font-weight:bold; '>inc</span> r1<span style='color:#800000; '>3</span>				<span style='color:#9A1900; '>; k++</span>
-	<span style='color:#0000ff; font-weight:bold; '>jmp </span>loopR
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">12</span>				<i><span style="color:#9A1900">; j++</span></i>
+	<b><span style="color:#0000FF">inc</span></b> r<span style="color:#993399">13</span>				<i><span style="color:#9A1900">; k++</span></i>
+	<b><span style="color:#0000FF">jmp</span></b> loopR
 	
-<b><span style='color:#000080; '>endR:</span></b>
-	<span style='color:#9A1900; '>; deallocate temp arrays</span>
-	<span style='color:#9A1900; '>; restore callee-save registers</span>
-	<span style='color:#0000ff; font-weight:bold; '>add</span> rsp<span style='color:#0000ff; '>,</span> r1<span style='color:#800000; '>1</span>	
-	<span style='color:#0000ff; font-weight:bold; '>pop</span> r1<span style='color:#800000; '>5</span>			
-	<span style='color:#0000ff; font-weight:bold; '>pop</span> r1<span style='color:#800000; '>4</span>
-	<span style='color:#0000ff; font-weight:bold; '>pop</span> r1<span style='color:#800000; '>3</span>
-	<span style='color:#0000ff; font-weight:bold; '>pop</span> r1<span style='color:#800000; '>2</span>
-	<span style='color:#0000ff; font-weight:bold; '>pop</span> rbx
-	<span style='color:#0000ff; font-weight:bold; '>ret</span>
+<b><span style="color:#000080">endR:</span></b>
+	<i><span style="color:#9A1900">; deallocate temp arrays</span></i>
+	<i><span style="color:#9A1900">; restore callee-save registers</span></i>
+	<b><span style="color:#0000FF">add</span></b> rsp<span style="color:#990000">,</span> r<span style="color:#993399">11</span>	
+	<b><span style="color:#0000FF">pop</span></b> r<span style="color:#993399">15</span>			
+	<b><span style="color:#0000FF">pop</span></b> r<span style="color:#993399">14</span>
+	<b><span style="color:#0000FF">pop</span></b> r<span style="color:#993399">13</span>
+	<b><span style="color:#0000FF">pop</span></b> r<span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">pop</span></b> rbx
+	<b><span style="color:#0000FF">ret</span></b>
 </pre>
 </body>
 </html>

--- a/labs/lab08-64bit/testMergeSort.cpp.html
+++ b/labs/lab08-64bit/testMergeSort.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/testMergeSort.cpp.html
+++ b/labs/lab08-64bit/testMergeSort.cpp.html
@@ -1,56 +1,60 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
 <title>testMergeSort.cpp</title>
 </head>
-<body bgcolor="white">
-<pre>
-<font style="color: #9A1900">/*</font>
-<font style="color: #9A1900">University of Virginia</font>
-<font style="color: #9A1900">CS 2150 In-Lab 8</font>
-<font style="color: #9A1900">Spring 2018 </font>
-<font style="color: #9A1900">Test file for mergeSort</font>
-<font style="color: #9A1900">*/</font>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900">University of Virginia</span></i>
+<i><span style="color:#9A1900">CS 2150 In-Lab 8</span></i>
+<i><span style="color:#9A1900">Spring 2018 </span></i>
+<i><span style="color:#9A1900">Test file for mergeSort</span></i>
+<i><span style="color:#9A1900">*/</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font style="color: #0000ff">extern</font></b> <font style="color: #FF0000">&quot;C&quot;</font> <font style="color: #009900">void</font> <b><font color="#000000">mergeSort</font></b><font style="color: #9A1900">(</font><font style="color: #009900">int</font> * arr, <font style="color: #009900">int</font> left, <font style="color: #009900">int</font> right<font style="color: #9A1900">);</font>
-<b><font style="color: #0000ff">extern</font></b> <font style="color: #FF0000">&quot;C&quot;</font> <font style="color: #009900">void</font> <b><font style="color: #000000">merge</font></b><font style="color: #9A1900">(</font><font style="color: #009900">int</font> * arr, <font style="color: #009900">int</font> left, <font style="color: #009900">int</font> mid, <font style="color: #009900">int</font> right<font style="color: #9A1900">);</font>
-      
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">void</span> <b><span style="color:#000000">mergeSort</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> <span style="color:#990000">*</span> arr<span style="color:#990000">,</span> <span style="color:#009900">int</span> left<span style="color:#990000">,</span> <span style="color:#009900">int</span> right<span style="color:#990000">);</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">void</span> <b><span style="color:#000000">merge</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> <span style="color:#990000">*</span> arr<span style="color:#990000">,</span> <span style="color:#009900">int</span> left<span style="color:#990000">,</span> <span style="color:#009900">int</span> mid<span style="color:#990000">,</span> <span style="color:#009900">int</span> right<span style="color:#990000">);</span>
+ 
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span><span style="color:#FF0000">{</span>
 
-    <font style="color: #009900">int</font> size;
-    <font style='color:#9A1900; '>// prompt for array size</font>
-    <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '>Enter the array size: </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-    <font style='color:#7f0055; font-weight:bold; '>cin</font> >> size<font style='color:#9A1900; '>;</font>
-    <font style='color:#009900; '>int</font> * arr = <font style='color:#7f0055; font-weight:bold; '>new</font> <font style='color:#009900;'>int</font>[size]<font style='color:#9A1900; '>;</font>
-    
-    <font style='color:#9A1900; '>// read in array values </font>
-    <font style='color:#0000FF; font-weight:bold; '>for</font>(<font style='color:#009900; '>int</font> i = 0; i &lt; size; i++){
-        <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '>Enter value </font><font style='color:#FF0000; '>&quot;</font> &lt;&lt; i &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '>: </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-        <b><font style='color:#7f0055;'>cin</font></b> >> arr[i]<font style='color:#9A1900; '>;</font>
-    }
-    
-    <font style='color:#9A1900; '>// print unsorted array</font>
-    <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '>Unsorted array: </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-    <font style='color:#0000FF; font-weight:bold; '>for</font>(<font style='color:#009900; '>int</font> i = 0; i &lt; size; i++){
-        <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; arr[i] &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '> </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-    }
-    <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; <font style='color:#7f0055; font-weight:bold; '>endl</font><font style='color:#9A1900; '>;</font>
-    
-    <b>mergeSort</b><font style="color: #9A1900;">(</font>arr, 0, size-1<font style="color: #9A1900;">);</font>
-    
-    <font style='color:#9A1900; '>// print sorted array</font>
-    <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '>Sorted array: </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-    <font style='color:#0000FF; font-weight:bold; '>for</font>(<font style='color:#009900; '>int</font> i = 0; i &lt; size; i++){
-        <font style='color:#7f0055; font-weight:bold; '>cout</font> &lt;&lt; arr[i] &lt;&lt; <font style='color:#FF0000; '>&quot;</font><font style='color:#FF0000; '> </font><font style='color:#FF0000; '>&quot;</font><font style='color:#9A1900; '>;</font>
-    }
-    <b><font style='color:#7f0055; '>cout</font></b> &lt;&lt; <font style='color:#7f0055; font-weight:bold; '>endl</font><font style='color:#9A1900; '>;</font>
-    
-    <b><font style="color: #0000ff">return</font></b> 0<font style="color: #9A1900">;</font>
+  <span style="color:#009900">int</span> size<span style="color:#990000">;</span>
+  <i><span style="color:#9A1900">// prompt for array size</span></i>
+  cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter the array size: "</span><span style="color:#990000">;</span>
+  cin <span style="color:#990000">&gt;&gt;</span> size<span style="color:#990000">;</span>
+  <span style="color:#009900">int</span> <span style="color:#990000">*</span> arr <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">int</span><span style="color:#990000">[</span>size<span style="color:#990000">];</span>
 
-<font style="color: #FF0000">}</font>
+  <i><span style="color:#9A1900">// read in array values </span></i>
+  <b><span style="color:#0000FF">for</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> size<span style="color:#990000">;</span> i<span style="color:#990000">++)</span><span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">": "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> arr<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+  <span style="color:#FF0000">}</span>
+
+  <i><span style="color:#9A1900">// print unsorted array</span></i>
+  cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Unsorted array: "</span><span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">for</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> size<span style="color:#990000">;</span> i<span style="color:#990000">++)</span><span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> arr<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+  <b><span style="color:#000000">mergeSort</span></b><span style="color:#990000">(</span>arr<span style="color:#990000">,</span> <span style="color:#993399">0</span><span style="color:#990000">,</span> size<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+
+  <i><span style="color:#9A1900">// print sorted array</span></i>
+  cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Sorted array: "</span><span style="color:#990000">;</span>
+  <b><span style="color:#0000FF">for</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> size<span style="color:#990000">;</span> i<span style="color:#990000">++)</span><span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> arr<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+  <span style="color:#FF0000">}</span>
+  cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+  <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+
+<span style="color:#FF0000">}</span>
 </pre>
 </body>
 </html>

--- a/labs/lab08-64bit/vecsum.s.html
+++ b/labs/lab08-64bit/vecsum.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab08-64bit/vecsum.s.html
+++ b/labs/lab08-64bit/vecsum.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,41 +8,41 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>vecsum.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">; vecsum.s</font></i>
-<i><font color="#9A1900">;</font></i>
-<i><font color="#9A1900">; Purpose : This file contains the implementation of the function</font></i>
-<i><font color="#9A1900">;           vecsum, which adds up a vector of integers.</font></i>
-<i><font color="#9A1900">;</font></i>
-<i><font color="#9A1900">; Parameter 1 (in rdi) is the starting address of a sequence of 64-bit longs</font></i>
-<i><font color="#9A1900">; Parameter 2 (in rsi) is the number of integers in the sequence</font></i>
-<i><font color="#9A1900">; Return value is a long that is the sum of the integers in the sequence</font></i>
-<i><font color="#9A1900">;</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">; vecsum.s</span></i>
+<i><span style="color:#9A1900">;</span></i>
+<i><span style="color:#9A1900">; Purpose : This file contains the implementation of the function</span></i>
+<i><span style="color:#9A1900">;           vecsum, which adds up a vector of integers.</span></i>
+<i><span style="color:#9A1900">;</span></i>
+<i><span style="color:#9A1900">; Parameter 1 (in rdi) is the starting address of a sequence of 64-bit longs</span></i>
+<i><span style="color:#9A1900">; Parameter 2 (in rsi) is the number of integers in the sequence</span></i>
+<i><span style="color:#9A1900">; Return value is a long that is the sum of the integers in the sequence</span></i>
+<i><span style="color:#9A1900">;</span></i>
 
 	global vecsum
 
-	section <font color="#990000">.</font>text
+	section <span style="color:#990000">.</span>text
 
-<b><font color="#000080">vecsum:</font></b>
-	<i><font color="#9A1900">; Standard prologue: we do not have to create any local</font></i>
-	<i><font color="#9A1900">; variables (those values will be kept in registers), and </font></i>
-	<i><font color="#9A1900">; we are not using any callee-saved registers.</font></i>
+<b><span style="color:#000080">vecsum:</span></b>
+	<i><span style="color:#9A1900">; Standard prologue: we do not have to create any local</span></i>
+	<i><span style="color:#9A1900">; variables (those values will be kept in registers), and </span></i>
+	<i><span style="color:#9A1900">; we are not using any callee-saved registers.</span></i>
 
-	<i><font color="#9A1900">; Subroutine body:</font></i>
-	<b><font color="#0000FF">xor</font></b>	rax<font color="#990000">,</font> rax	 <i><font color="#9A1900">; zero out the return register</font></i>
-	<b><font color="#0000FF">xor</font></b>	r<font color="#993399">10</font><font color="#990000">,</font> r<font color="#993399">10</font>	 <i><font color="#9A1900">; zero out the counter i</font></i>
-<b><font color="#000080">start:</font></b>	
-	<b><font color="#0000FF">cmp</font></b>	r<font color="#993399">10</font><font color="#990000">,</font> rsi	 <i><font color="#9A1900">; does i == n?</font></i>
-	<b><font color="#0000FF">je</font></b>	done		 <i><font color="#9A1900">; if so, we are done with the loop</font></i>
-	<b><font color="#0000FF">add</font></b>	rax<font color="#990000">,</font> <font color="#990000">[</font>rdi<font color="#990000">+</font><font color="#993399">8</font><font color="#990000">*</font>r<font color="#993399">10</font><font color="#990000">]</font> <i><font color="#9A1900">; add a[i] to rax</font></i>
-	<b><font color="#0000FF">inc</font></b>	r<font color="#993399">10</font>		 <i><font color="#9A1900">; increment our counter i</font></i>
-	<b><font color="#0000FF">jmp</font></b>	start		 <i><font color="#9A1900">; we are done with this loop iteration</font></i>
-<b><font color="#000080">done:</font></b>	
+	<i><span style="color:#9A1900">; Subroutine body:</span></i>
+	<b><span style="color:#0000FF">xor</span></b>	rax<span style="color:#990000">,</span> rax	 <i><span style="color:#9A1900">; zero out the return register</span></i>
+	<b><span style="color:#0000FF">xor</span></b>	r<span style="color:#993399">10</span><span style="color:#990000">,</span> r<span style="color:#993399">10</span>	 <i><span style="color:#9A1900">; zero out the counter i</span></i>
+<b><span style="color:#000080">start:</span></b>	
+	<b><span style="color:#0000FF">cmp</span></b>	r<span style="color:#993399">10</span><span style="color:#990000">,</span> rsi	 <i><span style="color:#9A1900">; does i == n?</span></i>
+	<b><span style="color:#0000FF">je</span></b>	done		 <i><span style="color:#9A1900">; if so, we are done with the loop</span></i>
+	<b><span style="color:#0000FF">add</span></b>	rax<span style="color:#990000">,</span> <span style="color:#990000">[</span>rdi<span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">*</span>r<span style="color:#993399">10</span><span style="color:#990000">]</span> <i><span style="color:#9A1900">; add a[i] to rax</span></i>
+	<b><span style="color:#0000FF">inc</span></b>	r<span style="color:#993399">10</span>		 <i><span style="color:#9A1900">; increment our counter i</span></i>
+	<b><span style="color:#0000FF">jmp</span></b>	start		 <i><span style="color:#9A1900">; we are done with this loop iteration</span></i>
+<b><span style="color:#000080">done:</span></b>	
 
-	<i><font color="#9A1900">; Standard epilogue: the return value is already in rax, we</font></i>
-	<i><font color="#9A1900">; do not have any callee-saved registers to restore, and we do not</font></i>
-	<i><font color="#9A1900">; have any local variables to deallocate, so all we do is return</font></i>
-	<b><font color="#0000FF">ret</font></b>
-</tt></pre>
+	<i><span style="color:#9A1900">; Standard epilogue: the return value is already in rax, we</span></i>
+	<i><span style="color:#9A1900">; do not have any callee-saved registers to restore, and we do not</span></i>
+	<i><span style="color:#9A1900">; have any local variables to deallocate, so all we do is return</span></i>
+	<b><span style="color:#0000FF">ret</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab10/fileio.cpp.html
+++ b/labs/lab10/fileio.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab10/fileio.cpp.html
+++ b/labs/lab10/fileio.cpp.html
@@ -1,62 +1,62 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>fileio.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This program shows how C-based file I/O works.  It will print a</font></i>
-<i><font color="#9A1900">// file to the screen two times.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This program shows how C-based file I/O works.  It will print a</span></i>
+<i><span style="color:#9A1900">// file to the screen two times.</span></i>
 
-<i><font color="#9A1900">// included so we can use cout</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<i><font color="#9A1900">// stdlib.h is where exit() lives</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
+<i><span style="color:#9A1900">// included so we can use cout</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<i><span style="color:#9A1900">// stdlib.h is where exit() lives</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// include the standard I/O library</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
+<i><span style="color:#9A1900">// include the standard I/O library</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
 
-<i><font color="#9A1900">// we want to use parameters</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// verify the correct number of parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">!=</font> <font color="#993399">2</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Must supply the input file name as the one and only parameter"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// attempt to open the supplied file.  FILE is a type designed to</font></i>
-    <i><font color="#9A1900">// hold file pointers.  The first parameter to fopen() is the</font></i>
-    <i><font color="#9A1900">// filename.  The second parameter is the mode -- "r" means it</font></i>
-    <i><font color="#9A1900">// will read from the file.</font></i>
-    <font color="#008080">FILE</font> <font color="#990000">*</font>fp <font color="#990000">=</font> <b><font color="#000000">fopen</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font> <font color="#FF0000">"r"</font><font color="#990000">);</font>
-    <i><font color="#9A1900">// if the file wasn't found, output and error message and exit</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> fp <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"File '"</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' does not exist!"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read in each character, one by one.  Note that the fgetc() will</font></i>
-    <i><font color="#9A1900">// read in a single character from a file, and returns EOF when it</font></i>
-    <i><font color="#9A1900">// reaches the end of a file.</font></i>
-    <font color="#009900">char</font> g<font color="#990000">;</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <font color="#990000">(</font>g <font color="#990000">=</font> <b><font color="#000000">fgetc</font></b><font color="#990000">(</font>fp<font color="#990000">))</font> <font color="#990000">!=</font> EOF <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> g<font color="#990000">;</font>
-    <i><font color="#9A1900">// a nice pretty separator</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// rewinds the file pointer, so that it starts reading the file</font></i>
-    <i><font color="#9A1900">// again from the beginning</font></i>
-    <b><font color="#000000">rewind</font></b><font color="#990000">(</font>fp<font color="#990000">);</font>
-    <i><font color="#9A1900">// read the file again, and print to the screen</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <font color="#990000">(</font>g <font color="#990000">=</font> <b><font color="#000000">fgetc</font></b><font color="#990000">(</font>fp<font color="#990000">))</font> <font color="#990000">!=</font> EOF <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> g<font color="#990000">;</font>
-    <i><font color="#9A1900">// close the file</font></i>
-    <b><font color="#000000">fclose</font></b><font color="#990000">(</font>fp<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// we want to use parameters</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// verify the correct number of parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Must supply the input file name as the one and only parameter"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// attempt to open the supplied file.  FILE is a type designed to</span></i>
+    <i><span style="color:#9A1900">// hold file pointers.  The first parameter to fopen() is the</span></i>
+    <i><span style="color:#9A1900">// filename.  The second parameter is the mode -- "r" means it</span></i>
+    <i><span style="color:#9A1900">// will read from the file.</span></i>
+    <span style="color:#008080">FILE</span> <span style="color:#990000">*</span>fp <span style="color:#990000">=</span> <b><span style="color:#000000">fopen</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> <span style="color:#FF0000">"r"</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// if the file wasn't found, output and error message and exit</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> fp <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"File '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' does not exist!"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read in each character, one by one.  Note that the fgetc() will</span></i>
+    <i><span style="color:#9A1900">// read in a single character from a file, and returns EOF when it</span></i>
+    <i><span style="color:#9A1900">// reaches the end of a file.</span></i>
+    <span style="color:#009900">char</span> g<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>g <span style="color:#990000">=</span> <b><span style="color:#000000">fgetc</span></b><span style="color:#990000">(</span>fp<span style="color:#990000">))</span> <span style="color:#990000">!=</span> EOF <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> g<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// a nice pretty separator</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// rewinds the file pointer, so that it starts reading the file</span></i>
+    <i><span style="color:#9A1900">// again from the beginning</span></i>
+    <b><span style="color:#000000">rewind</span></b><span style="color:#990000">(</span>fp<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// read the file again, and print to the screen</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>g <span style="color:#990000">=</span> <b><span style="color:#000000">fgetc</span></b><span style="color:#990000">(</span>fp<span style="color:#990000">))</span> <span style="color:#990000">!=</span> EOF <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> g<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// close the file</span></i>
+    <b><span style="color:#000000">fclose</span></b><span style="color:#990000">(</span>fp<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-</tt></pre>
+</pre>
 </body>
 </html>

--- a/labs/lab10/inlab-skeleton.cpp.html
+++ b/labs/lab10/inlab-skeleton.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab10/inlab-skeleton.cpp.html
+++ b/labs/lab10/inlab-skeleton.cpp.html
@@ -1,74 +1,74 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>inlab-skeleton.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This program is the skeleton code for the lab 10 in-lab.  It uses</font></i>
-<i><font color="#9A1900">// C++ streams for the file input, and just prints out the data when</font></i>
-<i><font color="#9A1900">// read in from the file.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This program is the skeleton code for the lab 10 in-lab.  It uses</span></i>
+<i><span style="color:#9A1900">// C++ streams for the file input, and just prints out the data when</span></i>
+<i><span style="color:#9A1900">// read in from the file.</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;sstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// main(): we want to use parameters</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// verify the correct number of parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">!=</font> <font color="#993399">2</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Must supply the input file name as the only parameter"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// attempt to open the supplied file; must be opened in binary</font></i>
-    <i><font color="#9A1900">// mode, as otherwise whitespace is discarded</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">file</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font> ifstream<font color="#990000">::</font>binary<font color="#990000">);</font>
-    <i><font color="#9A1900">// report any problems opening the file and then exit</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>file<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Unable to open file '"</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"'."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read in the first section of the file: the prefix codes</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <b><font color="#0000FF">true</font></b> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#008080">string</font> character<font color="#990000">,</font> prefix<font color="#990000">;</font>
-        <i><font color="#9A1900">// read in the first token on the line</font></i>
-        file <font color="#990000">&gt;&gt;</font> character<font color="#990000">;</font>
-        <i><font color="#9A1900">// did we hit the separator?</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>character<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'-'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>character<font color="#990000">.</font><b><font color="#000000">length</font></b><font color="#990000">()</font> <font color="#990000">&gt;</font> <font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-        <i><font color="#9A1900">// check for space</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> character <font color="#990000">==</font> <font color="#FF0000">"space"</font> <font color="#990000">)</font>
-            character <font color="#990000">=</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-        <i><font color="#9A1900">// read in the prefix code</font></i>
-        file <font color="#990000">&gt;&gt;</font> prefix<font color="#990000">;</font>
-        <i><font color="#9A1900">// do something with the prefix code</font></i>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"character '"</font> <font color="#990000">&lt;&lt;</font> character <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"' has prefix code '"</font>
-             <font color="#990000">&lt;&lt;</font> prefix <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"'"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read in the second section of the file: the encoded message</font></i>
-    <font color="#008080">stringstream</font> sstm<font color="#990000">;</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <b><font color="#0000FF">true</font></b> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#008080">string</font> bits<font color="#990000">;</font>
-        <i><font color="#9A1900">// read in the next set of 1's and 0's</font></i>
-        file <font color="#990000">&gt;&gt;</font> bits<font color="#990000">;</font>
-        <i><font color="#9A1900">// check for the separator</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> bits<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'-'</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-        <i><font color="#9A1900">// add it to the stringstream</font></i>
-        sstm <font color="#990000">&lt;&lt;</font> bits<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#008080">string</font> allbits <font color="#990000">=</font> sstm<font color="#990000">.</font><b><font color="#000000">str</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// at this point, all the bits are in the 'allbits' string</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"All the bits: "</font> <font color="#990000">&lt;&lt;</font> allbits <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// close the file before exiting</font></i>
-    file<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">// main(): we want to use parameters</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// verify the correct number of parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Must supply the input file name as the only parameter"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// attempt to open the supplied file; must be opened in binary</span></i>
+    <i><span style="color:#9A1900">// mode, as otherwise whitespace is discarded</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">file</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> ifstream<span style="color:#990000">::</span>binary<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// report any problems opening the file and then exit</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>file<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Unable to open file '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read in the first section of the file: the prefix codes</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">true</span></b> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">string</span> character<span style="color:#990000">,</span> prefix<span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// read in the first token on the line</span></i>
+        file <span style="color:#990000">&gt;&gt;</span> character<span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// did we hit the separator?</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>character<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'-'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>character<span style="color:#990000">.</span><b><span style="color:#000000">length</span></b><span style="color:#990000">()</span> <span style="color:#990000">&gt;</span> <span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// check for space</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> character <span style="color:#990000">==</span> <span style="color:#FF0000">"space"</span> <span style="color:#990000">)</span>
+            character <span style="color:#990000">=</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// read in the prefix code</span></i>
+        file <span style="color:#990000">&gt;&gt;</span> prefix<span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// do something with the prefix code</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"character '"</span> <span style="color:#990000">&lt;&lt;</span> character <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"' has prefix code '"</span>
+             <span style="color:#990000">&lt;&lt;</span> prefix <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read in the second section of the file: the encoded message</span></i>
+    <span style="color:#008080">stringstream</span> sstm<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <b><span style="color:#0000FF">true</span></b> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#008080">string</span> bits<span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// read in the next set of 1's and 0's</span></i>
+        file <span style="color:#990000">&gt;&gt;</span> bits<span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// check for the separator</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> bits<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'-'</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// add it to the stringstream</span></i>
+        sstm <span style="color:#990000">&lt;&lt;</span> bits<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#008080">string</span> allbits <span style="color:#990000">=</span> sstm<span style="color:#990000">.</span><b><span style="color:#000000">str</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// at this point, all the bits are in the 'allbits' string</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"All the bits: "</span> <span style="color:#990000">&lt;&lt;</span> allbits <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// close the file before exiting</span></i>
+    file<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab11/fileio2.cpp.html
+++ b/labs/lab11/fileio2.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab11/fileio2.cpp.html
+++ b/labs/lab11/fileio2.cpp.html
@@ -1,49 +1,49 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>fileio2.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This program shows how C-based file I/O works.  It will open a</font></i>
-<i><font color="#9A1900">// file, read in the first two strings, and print them to the screen.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This program shows how C-based file I/O works.  It will open a</span></i>
+<i><span style="color:#9A1900">// file, read in the first two strings, and print them to the screen.</span></i>
 
-<i><font color="#9A1900">// included so we can use cout</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<i><span style="color:#9A1900">// included so we can use cout</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// we want to use parameters</font></i>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// verify the correct number of parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">!=</font> <font color="#993399">2</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Must supply the input file name as the one and only parameter"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// attempt to open the supplied file</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">file</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font> ifstream<font color="#990000">::</font>binary<font color="#990000">);</font>
-    <i><font color="#9A1900">// report any problems opening the file and then exit</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>file<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Unable to open file '"</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"'."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read in two strings</font></i>
-    <font color="#008080">string</font> s1<font color="#990000">,</font> s2<font color="#990000">;</font>
-    file <font color="#990000">&gt;&gt;</font> s1<font color="#990000">;</font>
-    file <font color="#990000">&gt;&gt;</font> s2<font color="#990000">;</font>
-    <i><font color="#9A1900">// output those strings</font></i>
-    cout <font color="#990000">&lt;&lt;</font> s1 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> s2 <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// string comparison done with ==, but not shown here</font></i>
-    <i><font color="#9A1900">// close the file before exiting</font></i>
-    file<font color="#990000">.</font><b><font color="#000000">close</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// we want to use parameters</span></i>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// verify the correct number of parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Must supply the input file name as the one and only parameter"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// attempt to open the supplied file</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">file</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> ifstream<span style="color:#990000">::</span>binary<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// report any problems opening the file and then exit</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>file<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Unable to open file '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read in two strings</span></i>
+    <span style="color:#008080">string</span> s1<span style="color:#990000">,</span> s2<span style="color:#990000">;</span>
+    file <span style="color:#990000">&gt;&gt;</span> s1<span style="color:#990000">;</span>
+    file <span style="color:#990000">&gt;&gt;</span> s2<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output those strings</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> s1 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> s2 <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// string comparison done with ==, but not shown here</span></i>
+    <i><span style="color:#9A1900">// close the file before exiting</span></i>
+    file<span style="color:#990000">.</span><b><span style="color:#000000">close</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
 
-</tt></pre>
+</pre>
 </body>
 </html>

--- a/labs/lab11/middleearth.cpp.html
+++ b/labs/lab11/middleearth.cpp.html
@@ -1,174 +1,174 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>middleearth.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"middleearth.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"middleearth.h"</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;algorithm&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;math.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;algorithm&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;math.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
 
-<i><font color="#9A1900">// The list of all the place names that we'll be using</font></i>
-<font color="#008080">string</font> all_city_names<font color="#990000">[]</font> <font color="#990000">=</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// human towns, cities and strongholds</font></i>
-    <font color="#FF0000">"Bree"</font><font color="#990000">,</font>             <i><font color="#9A1900">// a human and hobbit town between the Shire and Rivendell</font></i>
-    <font color="#FF0000">"Isengard"</font><font color="#990000">,</font>         <i><font color="#9A1900">// the tower fortress where Saruman resided; Gandalf was imprisoned there.</font></i>
-    <font color="#FF0000">"Minas Tirith"</font><font color="#990000">,</font>     <i><font color="#9A1900">// capital of Gondor, the "white city"; home to Boromir, Denethor, and later, Aragorn</font></i>
-    <font color="#FF0000">"Osgiliath"</font><font color="#990000">,</font>        <i><font color="#9A1900">// city on the river Anduin; is at the other end of Pelennor Fields from M. Tirith</font></i>
-    <font color="#FF0000">"Edoras"</font><font color="#990000">,</font>           <i><font color="#9A1900">// the capital city of Rohan, where King Theoden resides</font></i>
-    <font color="#FF0000">"Helm's Deep"</font><font color="#990000">,</font>      <i><font color="#9A1900">// fortress of Rohan, it is where the people of Edoras fled to from the orc invasion</font></i>
-    <font color="#FF0000">"Dunharrow"</font><font color="#990000">,</font>        <i><font color="#9A1900">// a refuge of Rohan, it is where Elrond presents the sword to Aragorn in the movie</font></i>
-    <i><font color="#9A1900">// dwarf cities</font></i>
-    <font color="#FF0000">"Moria"</font><font color="#990000">,</font>            <i><font color="#9A1900">// the enormous dwarven underground complex that the Fellowship traveled through</font></i>
-    <i><font color="#9A1900">// elvish cities</font></i>
-    <font color="#FF0000">"Lothlorien"</font><font color="#990000">,</font>       <i><font color="#9A1900">// the elvish tree-city, home of Lady Galadriel and Lord Celeborn</font></i>
-    <font color="#FF0000">"Rivendell"</font><font color="#990000">,</font>        <i><font color="#9A1900">// the elvish city that is home to Lord Elrond</font></i>
-    <font color="#FF0000">"The Grey Havens"</font><font color="#990000">,</font>  <i><font color="#9A1900">// the port city on the western coast from which the elves travel westward</font></i>
-    <i><font color="#9A1900">// hobbit villages</font></i>
-    <font color="#FF0000">"Bucklebury"</font><font color="#990000">,</font>       <i><font color="#9A1900">// a Shire village, it has a ferry across the Brandywine River that the Hobbits use</font></i>
-    <font color="#FF0000">"Bywater"</font><font color="#990000">,</font>          <i><font color="#9A1900">// a Shire village, it is the site of the Battle of Bywater (removed from the movie)</font></i>
-    <font color="#FF0000">"Hobbiton"</font><font color="#990000">,</font>         <i><font color="#9A1900">// a Shire village, it is home to Bilbo and, later, Frodo</font></i>
-    <font color="#FF0000">"Michel Delving"</font><font color="#990000">,</font>   <i><font color="#9A1900">// a Shire village, it is the chief town of the Shire</font></i>
-    <i><font color="#9A1900">// Mordor places</font></i>
-    <font color="#FF0000">"Orodruin"</font><font color="#990000">,</font>         <i><font color="#9A1900">// Mount Doom in Mordor, it is where the Ring was made, and later, unmade</font></i>
-    <font color="#FF0000">"Barad-Dur"</font><font color="#990000">,</font>        <i><font color="#9A1900">// Sauron's fortress that was part castle, part mountain</font></i>
-    <font color="#FF0000">"Minas Morgul"</font><font color="#990000">,</font>     <i><font color="#9A1900">// formerly the Gondorian city of Minas Ithil; renamed when Sauron took it over</font></i>
-    <font color="#FF0000">"Cirith Ungol"</font><font color="#990000">,</font>     <i><font color="#9A1900">// the mountianous pass that Sam &amp; Frodo went through; home of Shelob</font></i>
-    <font color="#FF0000">"Gorgoroth"</font><font color="#990000">,</font>        <i><font color="#9A1900">// the plains in Mordor that Frodo &amp; Sam had to cross to reach Mount Doom</font></i>
-    <i><font color="#9A1900">// places that are not cities</font></i>
-    <font color="#FF0000">"Emyn Muil"</font><font color="#990000">,</font>        <i><font color="#9A1900">// the rocky region that Sam &amp; Frodo climb through after leaving the Fellowship</font></i>
-    <font color="#FF0000">"Fangorn Forest"</font><font color="#990000">,</font>   <i><font color="#9A1900">// the forest where Treebeard (and the other Ents) live</font></i>
-    <font color="#FF0000">"Dagorlad"</font><font color="#990000">,</font>         <i><font color="#9A1900">// great plain/swamp between Emyn Muil &amp; Mordor where a great battle was fought long ago</font></i>
-    <font color="#FF0000">"Weathertop"</font><font color="#990000">,</font>       <i><font color="#9A1900">// the tower between Bree and Rivendell where Aragorn and the Hobbits take refuge</font></i>
-    <font color="#FF0000">"Gladden Fields"</font><font color="#990000">,</font>   <i><font color="#9A1900">// this is where the Ring is lost in the River Anduin, after Isildur is ambushed and killed by Orcs</font></i>
-    <font color="#FF0000">"Entwash River"</font><font color="#990000">,</font>    <i><font color="#9A1900">// a river through Rohan, which flows through Fangorn Forest</font></i>
-    <font color="#FF0000">"River Isen"</font><font color="#990000">,</font>       <i><font color="#9A1900">// river through the Gap of Rohan; Theoden's son was slain in a battle here.</font></i>
-    <font color="#FF0000">"The Black Gate"</font><font color="#990000">,</font>   <i><font color="#9A1900">// huge gate to Mordor that Aragorn and company attack as the ring is destroyed</font></i>
-    <font color="#FF0000">"The Old Forest"</font><font color="#990000">,</font>   <i><font color="#9A1900">// a forest to the west of the Shire (adventures there were removed from the movie)</font></i>
-    <font color="#FF0000">"Trollshaws"</font><font color="#990000">,</font>       <i><font color="#9A1900">// area to the west of Rivendell that was home to the trolls that Bilbo met</font></i>
-    <font color="#FF0000">"Pelennor Fields"</font><font color="#990000">,</font>  <i><font color="#9A1900">// great plain between M. Tirith and Osgiliath; site of the Battle of M. Tirith</font></i>
-    <font color="#FF0000">"Hollin"</font><font color="#990000">,</font>           <i><font color="#9A1900">// the empty plains that the Fellowship crosses between Rivendell and Moria</font></i>
-    <font color="#FF0000">"Mirkwood"</font><font color="#990000">,</font>         <i><font color="#9A1900">// Legolas' forest home; Bilbo travels there in 'The Hobbit'.</font></i>
-    <font color="#FF0000">"Misty Mountains"</font><font color="#990000">,</font>  <i><font color="#9A1900">// the north-south moutain range that runs through Middle-earth</font></i>
-    <font color="#FF0000">"Prancing Pony"</font><font color="#990000">,</font>    <i><font color="#9A1900">// an inn in Bree where the hobbits tried to meet Gandalf, but meet Aragorn instead</font></i>
-    <i><font color="#9A1900">// places from the Hobbit book and movies</font></i>
-    <font color="#FF0000">"Laketown"</font><font color="#990000">,</font>         <i><font color="#9A1900">// also called Esgaorth, it is the town of men on the Long Lake near Erebor</font></i>
-    <font color="#FF0000">"Dale"</font><font color="#990000">,</font>             <i><font color="#9A1900">// the town of men outside Erebor, destroyed by Smaug long before the Hobbit story</font></i>
-    <font color="#FF0000">"Erebor"</font><font color="#990000">,</font>           <i><font color="#9A1900">// the Elvish name for the Lonely Mountain, where the dwarves had their fortress</font></i>
-    <font color="#FF0000">"Beorn's House"</font><font color="#990000">,</font>    <i><font color="#9A1900">// Beorn is the shape-shifter who shelters the dwarf party</font></i>
-    <font color="#FF0000">"Dol Guldur"</font><font color="#990000">,</font>       <i><font color="#9A1900">// fortress in Mirkwood where Sauron, as the Necromancer, hid during most of the Hobbit</font></i>
-    <i><font color="#9A1900">// END marker</font></i>
-    <font color="#FF0000">"END"</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// The list of all the place names that we'll be using</span></i>
+<span style="color:#008080">string</span> all_city_names<span style="color:#990000">[]</span> <span style="color:#990000">=</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// human towns, cities and strongholds</span></i>
+    <span style="color:#FF0000">"Bree"</span><span style="color:#990000">,</span>             <i><span style="color:#9A1900">// a human and hobbit town between the Shire and Rivendell</span></i>
+    <span style="color:#FF0000">"Isengard"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// the tower fortress where Saruman resided; Gandalf was imprisoned there.</span></i>
+    <span style="color:#FF0000">"Minas Tirith"</span><span style="color:#990000">,</span>     <i><span style="color:#9A1900">// capital of Gondor, the "white city"; home to Boromir, Denethor, and later, Aragorn</span></i>
+    <span style="color:#FF0000">"Osgiliath"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// city on the river Anduin; is at the other end of Pelennor Fields from M. Tirith</span></i>
+    <span style="color:#FF0000">"Edoras"</span><span style="color:#990000">,</span>           <i><span style="color:#9A1900">// the capital city of Rohan, where King Theoden resides</span></i>
+    <span style="color:#FF0000">"Helm's Deep"</span><span style="color:#990000">,</span>      <i><span style="color:#9A1900">// fortress of Rohan, it is where the people of Edoras fled to from the orc invasion</span></i>
+    <span style="color:#FF0000">"Dunharrow"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// a refuge of Rohan, it is where Elrond presents the sword to Aragorn in the movie</span></i>
+    <i><span style="color:#9A1900">// dwarf cities</span></i>
+    <span style="color:#FF0000">"Moria"</span><span style="color:#990000">,</span>            <i><span style="color:#9A1900">// the enormous dwarven underground complex that the Fellowship traveled through</span></i>
+    <i><span style="color:#9A1900">// elvish cities</span></i>
+    <span style="color:#FF0000">"Lothlorien"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// the elvish tree-city, home of Lady Galadriel and Lord Celeborn</span></i>
+    <span style="color:#FF0000">"Rivendell"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// the elvish city that is home to Lord Elrond</span></i>
+    <span style="color:#FF0000">"The Grey Havens"</span><span style="color:#990000">,</span>  <i><span style="color:#9A1900">// the port city on the western coast from which the elves travel westward</span></i>
+    <i><span style="color:#9A1900">// hobbit villages</span></i>
+    <span style="color:#FF0000">"Bucklebury"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// a Shire village, it has a ferry across the Brandywine River that the Hobbits use</span></i>
+    <span style="color:#FF0000">"Bywater"</span><span style="color:#990000">,</span>          <i><span style="color:#9A1900">// a Shire village, it is the site of the Battle of Bywater (removed from the movie)</span></i>
+    <span style="color:#FF0000">"Hobbiton"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// a Shire village, it is home to Bilbo and, later, Frodo</span></i>
+    <span style="color:#FF0000">"Michel Delving"</span><span style="color:#990000">,</span>   <i><span style="color:#9A1900">// a Shire village, it is the chief town of the Shire</span></i>
+    <i><span style="color:#9A1900">// Mordor places</span></i>
+    <span style="color:#FF0000">"Orodruin"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// Mount Doom in Mordor, it is where the Ring was made, and later, unmade</span></i>
+    <span style="color:#FF0000">"Barad-Dur"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// Sauron's fortress that was part castle, part mountain</span></i>
+    <span style="color:#FF0000">"Minas Morgul"</span><span style="color:#990000">,</span>     <i><span style="color:#9A1900">// formerly the Gondorian city of Minas Ithil; renamed when Sauron took it over</span></i>
+    <span style="color:#FF0000">"Cirith Ungol"</span><span style="color:#990000">,</span>     <i><span style="color:#9A1900">// the mountianous pass that Sam &amp; Frodo went through; home of Shelob</span></i>
+    <span style="color:#FF0000">"Gorgoroth"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// the plains in Mordor that Frodo &amp; Sam had to cross to reach Mount Doom</span></i>
+    <i><span style="color:#9A1900">// places that are not cities</span></i>
+    <span style="color:#FF0000">"Emyn Muil"</span><span style="color:#990000">,</span>        <i><span style="color:#9A1900">// the rocky region that Sam &amp; Frodo climb through after leaving the Fellowship</span></i>
+    <span style="color:#FF0000">"Fangorn Forest"</span><span style="color:#990000">,</span>   <i><span style="color:#9A1900">// the forest where Treebeard (and the other Ents) live</span></i>
+    <span style="color:#FF0000">"Dagorlad"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// great plain/swamp between Emyn Muil &amp; Mordor where a great battle was fought long ago</span></i>
+    <span style="color:#FF0000">"Weathertop"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// the tower between Bree and Rivendell where Aragorn and the Hobbits take refuge</span></i>
+    <span style="color:#FF0000">"Gladden Fields"</span><span style="color:#990000">,</span>   <i><span style="color:#9A1900">// this is where the Ring is lost in the River Anduin, after Isildur is ambushed and killed by Orcs</span></i>
+    <span style="color:#FF0000">"Entwash River"</span><span style="color:#990000">,</span>    <i><span style="color:#9A1900">// a river through Rohan, which flows through Fangorn Forest</span></i>
+    <span style="color:#FF0000">"River Isen"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// river through the Gap of Rohan; Theoden's son was slain in a battle here.</span></i>
+    <span style="color:#FF0000">"The Black Gate"</span><span style="color:#990000">,</span>   <i><span style="color:#9A1900">// huge gate to Mordor that Aragorn and company attack as the ring is destroyed</span></i>
+    <span style="color:#FF0000">"The Old Forest"</span><span style="color:#990000">,</span>   <i><span style="color:#9A1900">// a forest to the west of the Shire (adventures there were removed from the movie)</span></i>
+    <span style="color:#FF0000">"Trollshaws"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// area to the west of Rivendell that was home to the trolls that Bilbo met</span></i>
+    <span style="color:#FF0000">"Pelennor Fields"</span><span style="color:#990000">,</span>  <i><span style="color:#9A1900">// great plain between M. Tirith and Osgiliath; site of the Battle of M. Tirith</span></i>
+    <span style="color:#FF0000">"Hollin"</span><span style="color:#990000">,</span>           <i><span style="color:#9A1900">// the empty plains that the Fellowship crosses between Rivendell and Moria</span></i>
+    <span style="color:#FF0000">"Mirkwood"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// Legolas' forest home; Bilbo travels there in 'The Hobbit'.</span></i>
+    <span style="color:#FF0000">"Misty Mountains"</span><span style="color:#990000">,</span>  <i><span style="color:#9A1900">// the north-south moutain range that runs through Middle-earth</span></i>
+    <span style="color:#FF0000">"Prancing Pony"</span><span style="color:#990000">,</span>    <i><span style="color:#9A1900">// an inn in Bree where the hobbits tried to meet Gandalf, but meet Aragorn instead</span></i>
+    <i><span style="color:#9A1900">// places from the Hobbit book and movies</span></i>
+    <span style="color:#FF0000">"Laketown"</span><span style="color:#990000">,</span>         <i><span style="color:#9A1900">// also called Esgaorth, it is the town of men on the Long Lake near Erebor</span></i>
+    <span style="color:#FF0000">"Dale"</span><span style="color:#990000">,</span>             <i><span style="color:#9A1900">// the town of men outside Erebor, destroyed by Smaug long before the Hobbit story</span></i>
+    <span style="color:#FF0000">"Erebor"</span><span style="color:#990000">,</span>           <i><span style="color:#9A1900">// the Elvish name for the Lonely Mountain, where the dwarves had their fortress</span></i>
+    <span style="color:#FF0000">"Beorn's House"</span><span style="color:#990000">,</span>    <i><span style="color:#9A1900">// Beorn is the shape-shifter who shelters the dwarf party</span></i>
+    <span style="color:#FF0000">"Dol Guldur"</span><span style="color:#990000">,</span>       <i><span style="color:#9A1900">// fortress in Mirkwood where Sauron, as the Necromancer, hid during most of the Hobbit</span></i>
+    <i><span style="color:#9A1900">// END marker</span></i>
+    <span style="color:#FF0000">"END"</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Iluvatar, the creator of Middle-Earth</font></i>
-MiddleEarth<font color="#990000">::</font><b><font color="#000000">MiddleEarth</font></b> <font color="#990000">(</font><font color="#009900">int</font> xsize<font color="#990000">,</font> <font color="#009900">int</font> ysize<font color="#990000">,</font> <font color="#009900">int</font> num_cities<font color="#990000">,</font> <font color="#009900">int</font> seed<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// set up the random number seed</font></i>
-    <b><font color="#000000">srand</font></b><font color="#990000">(</font> <font color="#990000">(</font>seed<font color="#990000">==-</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">?</font> <b><font color="#000000">time</font></b><font color="#990000">(</font>NULL<font color="#990000">)</font> <font color="#990000">:</font> seed <font color="#990000">);</font>
-    <i><font color="#9A1900">// count the number of cities in the array</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> num_city_names <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> all_city_names<font color="#990000">[</font>num_city_names<font color="#990000">]</font> <font color="#990000">!=</font> <font color="#FF0000">"END"</font><font color="#990000">;</font>
-            num_city_names<font color="#990000">++</font> <font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> num_cities <font color="#990000">&gt;</font> num_city_names <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"There are only "</font> <font color="#990000">&lt;&lt;</font> num_city_names <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" city names, so "</font>
-             <font color="#990000">&lt;&lt;</font> num_cities <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" cities cannot be created.</font><font color="#CC33CC">\n</font><font color="#FF0000">Exiting."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> num_cities <font color="#990000">&lt;</font> <font color="#993399">5</font> <font color="#990000">)</font>
-        num_cities <font color="#990000">=</font> <font color="#993399">5</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// select the num_cities names of the cities that we'll be using</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> all_city_names<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">!=</font> <font color="#FF0000">"END"</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        cities<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><b><font color="#000000">string</font></b><font color="#990000">(</font>all_city_names<font color="#990000">[</font>i<font color="#990000">]));</font>
-    <b><font color="#000000">random_shuffle</font></b><font color="#990000">(</font>cities<font color="#990000">.</font><b><font color="#000000">begin</font></b><font color="#990000">(),</font> cities<font color="#990000">.</font><b><font color="#000000">end</font></b><font color="#990000">());</font>
-    cities<font color="#990000">.</font><b><font color="#000000">erase</font></b><font color="#990000">(</font>cities<font color="#990000">.</font><b><font color="#000000">begin</font></b><font color="#990000">()+</font>num_cities<font color="#990000">,</font>cities<font color="#990000">.</font><b><font color="#000000">end</font></b><font color="#990000">());</font>
-    <i><font color="#9A1900">// compute random city positions</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        xpos<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">((</font><b><font color="#000000">rand</font></b><font color="#990000">()/((</font><font color="#009900">float</font><font color="#990000">)</font>RAND_MAX<font color="#990000">))</font> <font color="#990000">*</font> xsize<font color="#990000">);</font>
-        ypos<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">((</font><b><font color="#000000">rand</font></b><font color="#990000">()/((</font><font color="#009900">float</font><font color="#990000">)</font>RAND_MAX<font color="#990000">))</font> <font color="#990000">*</font> ysize<font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// compute the 2-d distance array</font></i>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>xsize <font color="#990000">=</font> xsize<font color="#990000">;</font>
-    <b><font color="#0000FF">this</font></b><font color="#990000">-&gt;</font>ysize <font color="#990000">=</font> ysize<font color="#990000">;</font>
-    <i><font color="#9A1900">// we assume that num_cities &lt; xsize*ysize</font></i>
-    distances <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <font color="#009900">float</font><font color="#990000">[</font>num_cities<font color="#990000">*</font>num_cities<font color="#990000">];</font> <i><font color="#9A1900">// row-major order</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> r <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> r <font color="#990000">&lt;</font> num_cities<font color="#990000">;</font> r<font color="#990000">++</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> c <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> c <font color="#990000">&lt;</font> num_cities<font color="#990000">;</font> c<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            distances<font color="#990000">[</font>r<font color="#990000">*</font>num_cities<font color="#990000">+</font>c<font color="#990000">]</font> <font color="#990000">=</font> <b><font color="#000000">sqrt</font></b><font color="#990000">((</font>xpos<font color="#990000">[</font>c<font color="#990000">]-</font>xpos<font color="#990000">[</font>r<font color="#990000">])*(</font>xpos<font color="#990000">[</font>c<font color="#990000">]-</font>xpos<font color="#990000">[</font>r<font color="#990000">])</font> <font color="#990000">+</font>
-                                             <font color="#990000">(</font>ypos<font color="#990000">[</font>c<font color="#990000">]-</font>ypos<font color="#990000">[</font>r<font color="#990000">])*(</font>ypos<font color="#990000">[</font>c<font color="#990000">]-</font>ypos<font color="#990000">[</font>r<font color="#990000">]));</font>
-        <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// create hash of indices so we don't have to do a linear search</font></i>
-    <i><font color="#9A1900">// each time we want to find a city name to index mapping</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        indices<font color="#990000">[</font>cities<font color="#990000">[</font>i<font color="#990000">]]</font> <font color="#990000">=</font> i<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Iluvatar, the creator of Middle-Earth</span></i>
+MiddleEarth<span style="color:#990000">::</span><b><span style="color:#000000">MiddleEarth</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> xsize<span style="color:#990000">,</span> <span style="color:#009900">int</span> ysize<span style="color:#990000">,</span> <span style="color:#009900">int</span> num_cities<span style="color:#990000">,</span> <span style="color:#009900">int</span> seed<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// set up the random number seed</span></i>
+    <b><span style="color:#000000">srand</span></b><span style="color:#990000">(</span> <span style="color:#990000">(</span>seed<span style="color:#990000">==-</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">?</span> <b><span style="color:#000000">time</span></b><span style="color:#990000">(</span>NULL<span style="color:#990000">)</span> <span style="color:#990000">:</span> seed <span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// count the number of cities in the array</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> num_city_names <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> all_city_names<span style="color:#990000">[</span>num_city_names<span style="color:#990000">]</span> <span style="color:#990000">!=</span> <span style="color:#FF0000">"END"</span><span style="color:#990000">;</span>
+            num_city_names<span style="color:#990000">++</span> <span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> num_cities <span style="color:#990000">&gt;</span> num_city_names <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"There are only "</span> <span style="color:#990000">&lt;&lt;</span> num_city_names <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" city names, so "</span>
+             <span style="color:#990000">&lt;&lt;</span> num_cities <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" cities cannot be created.</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">Exiting."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> num_cities <span style="color:#990000">&lt;</span> <span style="color:#993399">5</span> <span style="color:#990000">)</span>
+        num_cities <span style="color:#990000">=</span> <span style="color:#993399">5</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// select the num_cities names of the cities that we'll be using</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> all_city_names<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">!=</span> <span style="color:#FF0000">"END"</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        cities<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><b><span style="color:#000000">string</span></b><span style="color:#990000">(</span>all_city_names<span style="color:#990000">[</span>i<span style="color:#990000">]));</span>
+    <b><span style="color:#000000">random_shuffle</span></b><span style="color:#990000">(</span>cities<span style="color:#990000">.</span><b><span style="color:#000000">begin</span></b><span style="color:#990000">(),</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">end</span></b><span style="color:#990000">());</span>
+    cities<span style="color:#990000">.</span><b><span style="color:#000000">erase</span></b><span style="color:#990000">(</span>cities<span style="color:#990000">.</span><b><span style="color:#000000">begin</span></b><span style="color:#990000">()+</span>num_cities<span style="color:#990000">,</span>cities<span style="color:#990000">.</span><b><span style="color:#000000">end</span></b><span style="color:#990000">());</span>
+    <i><span style="color:#9A1900">// compute random city positions</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        xpos<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">((</span><b><span style="color:#000000">rand</span></b><span style="color:#990000">()/((</span><span style="color:#009900">float</span><span style="color:#990000">)</span>RAND_MAX<span style="color:#990000">))</span> <span style="color:#990000">*</span> xsize<span style="color:#990000">);</span>
+        ypos<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">((</span><b><span style="color:#000000">rand</span></b><span style="color:#990000">()/((</span><span style="color:#009900">float</span><span style="color:#990000">)</span>RAND_MAX<span style="color:#990000">))</span> <span style="color:#990000">*</span> ysize<span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// compute the 2-d distance array</span></i>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>xsize <span style="color:#990000">=</span> xsize<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">this</span></b><span style="color:#990000">-&gt;</span>ysize <span style="color:#990000">=</span> ysize<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// we assume that num_cities &lt; xsize*ysize</span></i>
+    distances <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">float</span><span style="color:#990000">[</span>num_cities<span style="color:#990000">*</span>num_cities<span style="color:#990000">];</span> <i><span style="color:#9A1900">// row-major order</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> r <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> r <span style="color:#990000">&lt;</span> num_cities<span style="color:#990000">;</span> r<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> c <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> c <span style="color:#990000">&lt;</span> num_cities<span style="color:#990000">;</span> c<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            distances<span style="color:#990000">[</span>r<span style="color:#990000">*</span>num_cities<span style="color:#990000">+</span>c<span style="color:#990000">]</span> <span style="color:#990000">=</span> <b><span style="color:#000000">sqrt</span></b><span style="color:#990000">((</span>xpos<span style="color:#990000">[</span>c<span style="color:#990000">]-</span>xpos<span style="color:#990000">[</span>r<span style="color:#990000">])*(</span>xpos<span style="color:#990000">[</span>c<span style="color:#990000">]-</span>xpos<span style="color:#990000">[</span>r<span style="color:#990000">])</span> <span style="color:#990000">+</span>
+                                             <span style="color:#990000">(</span>ypos<span style="color:#990000">[</span>c<span style="color:#990000">]-</span>ypos<span style="color:#990000">[</span>r<span style="color:#990000">])*(</span>ypos<span style="color:#990000">[</span>c<span style="color:#990000">]-</span>ypos<span style="color:#990000">[</span>r<span style="color:#990000">]));</span>
+        <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// create hash of indices so we don't have to do a linear search</span></i>
+    <i><span style="color:#9A1900">// each time we want to find a city name to index mapping</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        indices<span style="color:#990000">[</span>cities<span style="color:#990000">[</span>i<span style="color:#990000">]]</span> <span style="color:#990000">=</span> i<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Sauron, the destructor of Middle-Earth.</font></i>
-MiddleEarth<font color="#990000">::~</font><b><font color="#000000">MiddleEarth</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">delete</font></b><font color="#990000">[]</font> distances<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// Sauron, the destructor of Middle-Earth.</span></i>
+MiddleEarth<span style="color:#990000">::~</span><b><span style="color:#000000">MiddleEarth</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">delete</span></b><span style="color:#990000">[]</span> distances<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// The Mouth of Sauron!  (prints out info on the created 'world')</font></i>
-<font color="#009900">void</font> MiddleEarth<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"there are "</font> <font color="#990000">&lt;&lt;</font> num_city_names
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" locations to choose from; we are using "</font> <font color="#990000">&lt;&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"they are: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> cities<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" @ ("</font> <font color="#990000">&lt;&lt;</font> xpos<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">", "</font> <font color="#990000">&lt;&lt;</font> ypos<font color="#990000">[</font>i<font color="#990000">]</font>
-             <font color="#990000">&lt;&lt;</font> <font color="#FF0000">")"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// The Mouth of Sauron!  (prints out info on the created 'world')</span></i>
+<span style="color:#009900">void</span> MiddleEarth<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"there are "</span> <span style="color:#990000">&lt;&lt;</span> num_city_names
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" locations to choose from; we are using "</span> <span style="color:#990000">&lt;&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"they are: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> cities<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" @ ("</span> <span style="color:#990000">&lt;&lt;</span> xpos<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">", "</span> <span style="color:#990000">&lt;&lt;</span> ypos<span style="color:#990000">[</span>i<span style="color:#990000">]</span>
+             <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">")"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// prints a tab-separated table of the distances (this can be loaded</font></i>
-<i><font color="#9A1900">// into Excel or similar)</font></i>
-<font color="#009900">void</font> MiddleEarth<font color="#990000">::</font><b><font color="#000000">printTable</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Table: "</font> <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Location</font><font color="#CC33CC">\t</font><font color="#FF0000">xpos</font><font color="#CC33CC">\t</font><font color="#FF0000">ypos</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> r <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> r <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> r<font color="#990000">++</font> <font color="#990000">)</font>
-        cout <font color="#990000">&lt;&lt;</font> cities<font color="#990000">[</font>r<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> r <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> r <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> r<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> cities<font color="#990000">[</font>r<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> xpos<font color="#990000">[</font>r<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> ypos<font color="#990000">[</font>r<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">;</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> c <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> c <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> c<font color="#990000">++</font> <font color="#990000">)</font>
-            cout <font color="#990000">&lt;&lt;</font> distances<font color="#990000">[</font>r<font color="#990000">*</font>cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()+</font>c<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">;</font>
-        cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// prints a tab-separated table of the distances (this can be loaded</span></i>
+<i><span style="color:#9A1900">// into Excel or similar)</span></i>
+<span style="color:#009900">void</span> MiddleEarth<span style="color:#990000">::</span><b><span style="color:#000000">printTable</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Table: "</span> <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Location</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">xpos</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">ypos</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> r <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> r <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> r<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> cities<span style="color:#990000">[</span>r<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> r <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> r <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> r<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> cities<span style="color:#990000">[</span>r<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> xpos<span style="color:#990000">[</span>r<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> ypos<span style="color:#990000">[</span>r<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> c <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> c <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> c<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+            cout <span style="color:#990000">&lt;&lt;</span> distances<span style="color:#990000">[</span>r<span style="color:#990000">*</span>cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()+</span>c<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+        cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// This method returns the distance between the two passed cities.  If</font></i>
-<i><font color="#9A1900">// we assume that the hash table (i.e. the map) is O(1), then this</font></i>
-<i><font color="#9A1900">// method call is also O(1)</font></i>
-<font color="#009900">float</font> MiddleEarth<font color="#990000">::</font><b><font color="#000000">getDistance</font></b> <font color="#990000">(</font><font color="#008080">string</font> city1<font color="#990000">,</font> <font color="#008080">string</font> city2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> distances<font color="#990000">[</font>indices<font color="#990000">[</font>city1<font color="#990000">]*</font>cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()+</font>indices<font color="#990000">[</font>city2<font color="#990000">]];</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// This method returns the distance between the two passed cities.  If</span></i>
+<i><span style="color:#9A1900">// we assume that the hash table (i.e. the map) is O(1), then this</span></i>
+<i><span style="color:#9A1900">// method call is also O(1)</span></i>
+<span style="color:#009900">float</span> MiddleEarth<span style="color:#990000">::</span><b><span style="color:#000000">getDistance</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> city1<span style="color:#990000">,</span> <span style="color:#008080">string</span> city2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> distances<span style="color:#990000">[</span>indices<span style="color:#990000">[</span>city1<span style="color:#990000">]*</span>cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()+</span>indices<span style="color:#990000">[</span>city2<span style="color:#990000">]];</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// Returns the list of cities to travel to.  The first city is the</font></i>
-<i><font color="#9A1900">// original start point as well as the end point.  The number of</font></i>
-<i><font color="#9A1900">// cities passed in does not include this start/end point (so there</font></i>
-<i><font color="#9A1900">// will be length+1 entries in the returned vector).</font></i>
-<font color="#008080">vector&lt;string&gt;</font> MiddleEarth<font color="#990000">::</font><b><font color="#000000">getItinerary</font></b> <font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> length<font color="#990000">)</font> <font color="#FF0000">{</font>
-    length<font color="#990000">++;</font> <i><font color="#9A1900">// to account for the start point</font></i>
-    <i><font color="#9A1900">// check parameter</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> length <font color="#990000">&gt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"You have requested an itinerary of "</font> <font color="#990000">&lt;&lt;</font> length<font color="#990000">-</font><font color="#993399">1</font>
-             <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" cities; you cannot ask for an itinerary of more than length "</font>
-             <font color="#990000">&lt;&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()-</font><font color="#993399">1</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// we need to make a deep copy of the cities vector.  itinerary is a</font></i>
-    <i><font color="#9A1900">// pointer so that it doesn't get deleted when it goes out of scope.</font></i>
-    <font color="#008080">vector&lt;string&gt;</font> itinerary<font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">unsigned</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> cities<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">();</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        itinerary<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font>cities<font color="#990000">[</font>i<font color="#990000">]);</font>
-    <i><font color="#9A1900">// shuffle, erase unneeded ones, and return the itinerary</font></i>
-    <b><font color="#000000">random_shuffle</font></b><font color="#990000">(</font>itinerary<font color="#990000">.</font><b><font color="#000000">begin</font></b><font color="#990000">(),</font> itinerary<font color="#990000">.</font><b><font color="#000000">end</font></b><font color="#990000">());</font>
-    itinerary<font color="#990000">.</font><b><font color="#000000">erase</font></b><font color="#990000">(</font>itinerary<font color="#990000">.</font><b><font color="#000000">begin</font></b><font color="#990000">()+</font>length<font color="#990000">,</font>itinerary<font color="#990000">.</font><b><font color="#000000">end</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">return</font></b> itinerary<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">// Returns the list of cities to travel to.  The first city is the</span></i>
+<i><span style="color:#9A1900">// original start point as well as the end point.  The number of</span></i>
+<i><span style="color:#9A1900">// cities passed in does not include this start/end point (so there</span></i>
+<i><span style="color:#9A1900">// will be length+1 entries in the returned vector).</span></i>
+<span style="color:#008080">vector&lt;string&gt;</span> MiddleEarth<span style="color:#990000">::</span><b><span style="color:#000000">getItinerary</span></b> <span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> length<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    length<span style="color:#990000">++;</span> <i><span style="color:#9A1900">// to account for the start point</span></i>
+    <i><span style="color:#9A1900">// check parameter</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> length <span style="color:#990000">&gt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"You have requested an itinerary of "</span> <span style="color:#990000">&lt;&lt;</span> length<span style="color:#990000">-</span><span style="color:#993399">1</span>
+             <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" cities; you cannot ask for an itinerary of more than length "</span>
+             <span style="color:#990000">&lt;&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()-</span><span style="color:#993399">1</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// we need to make a deep copy of the cities vector.  itinerary is a</span></i>
+    <i><span style="color:#9A1900">// pointer so that it doesn't get deleted when it goes out of scope.</span></i>
+    <span style="color:#008080">vector&lt;string&gt;</span> itinerary<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> cities<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">();</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        itinerary<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span>cities<span style="color:#990000">[</span>i<span style="color:#990000">]);</span>
+    <i><span style="color:#9A1900">// shuffle, erase unneeded ones, and return the itinerary</span></i>
+    <b><span style="color:#000000">random_shuffle</span></b><span style="color:#990000">(</span>itinerary<span style="color:#990000">.</span><b><span style="color:#000000">begin</span></b><span style="color:#990000">(),</span> itinerary<span style="color:#990000">.</span><b><span style="color:#000000">end</span></b><span style="color:#990000">());</span>
+    itinerary<span style="color:#990000">.</span><b><span style="color:#000000">erase</span></b><span style="color:#990000">(</span>itinerary<span style="color:#990000">.</span><b><span style="color:#000000">begin</span></b><span style="color:#990000">()+</span>length<span style="color:#990000">,</span>itinerary<span style="color:#990000">.</span><b><span style="color:#000000">end</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">return</span></b> itinerary<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/labs/lab11/middleearth.cpp.html
+++ b/labs/lab11/middleearth.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab11/middleearth.h.html
+++ b/labs/lab11/middleearth.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab11/middleearth.h.html
+++ b/labs/lab11/middleearth.h.html
@@ -1,44 +1,44 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>middleearth.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;vector&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;map&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;vector&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;map&gt;</span>
 
-<b><font color="#000080">#ifndef</font></b> MIDDLEEARTH_H
-<b><font color="#000080">#define</font></b> MIDDLEEARTH_H
+<b><span style="color:#000080">#ifndef</span></b> MIDDLEEARTH_H
+<b><span style="color:#000080">#define</span></b> MIDDLEEARTH_H
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// see the comments in the lab11 write-up, or in middleearth.cpp</font></i>
+<i><span style="color:#9A1900">// see the comments in the lab11 write-up, or in middleearth.cpp</span></i>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">MiddleEarth</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> num_city_names<font color="#990000">,</font> xsize<font color="#990000">,</font> ysize<font color="#990000">;</font>
-    <font color="#008080">vector&lt;float&gt;</font> xpos<font color="#990000">,</font> ypos<font color="#990000">;</font>
-    <font color="#008080">vector&lt;string&gt;</font> cities<font color="#990000">;</font>
-    <font color="#009900">float</font> <font color="#990000">*</font>distances<font color="#990000">;</font>
-    <font color="#008080">map&lt;string, int&gt;</font> indices<font color="#990000">;</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">MiddleEarth</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> num_city_names<span style="color:#990000">,</span> xsize<span style="color:#990000">,</span> ysize<span style="color:#990000">;</span>
+    <span style="color:#008080">vector&lt;float&gt;</span> xpos<span style="color:#990000">,</span> ypos<span style="color:#990000">;</span>
+    <span style="color:#008080">vector&lt;string&gt;</span> cities<span style="color:#990000">;</span>
+    <span style="color:#009900">float</span> <span style="color:#990000">*</span>distances<span style="color:#990000">;</span>
+    <span style="color:#008080">map&lt;string, int&gt;</span> indices<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">MiddleEarth</font></b> <font color="#990000">(</font><font color="#009900">int</font> xsize<font color="#990000">,</font> <font color="#009900">int</font> ysize<font color="#990000">,</font> <font color="#009900">int</font> numcities<font color="#990000">,</font> <font color="#009900">int</font> seed<font color="#990000">);</font>
-    <font color="#990000">~</font><b><font color="#000000">MiddleEarth</font></b><font color="#990000">();</font>
-    <font color="#009900">void</font> <b><font color="#000000">print</font></b><font color="#990000">();</font>
-    <font color="#009900">void</font> <b><font color="#000000">printTable</font></b><font color="#990000">();</font>
-    <font color="#009900">float</font> <b><font color="#000000">getDistance</font></b> <font color="#990000">(</font><font color="#008080">string</font> city1<font color="#990000">,</font> <font color="#008080">string</font> city2<font color="#990000">);</font>
-    <font color="#008080">vector&lt;string&gt;</font> <b><font color="#000000">getItinerary</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> length<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">MiddleEarth</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> xsize<span style="color:#990000">,</span> <span style="color:#009900">int</span> ysize<span style="color:#990000">,</span> <span style="color:#009900">int</span> numcities<span style="color:#990000">,</span> <span style="color:#009900">int</span> seed<span style="color:#990000">);</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">MiddleEarth</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">printTable</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">float</span> <b><span style="color:#000000">getDistance</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> city1<span style="color:#990000">,</span> <span style="color:#008080">string</span> city2<span style="color:#990000">);</span>
+    <span style="color:#008080">vector&lt;string&gt;</span> <b><span style="color:#000000">getItinerary</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> length<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/labs/lab11/traveling-skeleton.cpp.html
+++ b/labs/lab11/traveling-skeleton.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/labs/lab11/traveling-skeleton.cpp.html
+++ b/labs/lab11/traveling-skeleton.cpp.html
@@ -1,60 +1,60 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>traveling-skeleton.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;algorithm&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;algorithm&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"middleearth.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"middleearth.h"</span>
 
-<font color="#009900">float</font> <b><font color="#000000">computeDistance</font></b> <font color="#990000">(</font><font color="#008080">MiddleEarth</font> <font color="#990000">&amp;</font>me<font color="#990000">,</font> <font color="#008080">string</font> start<font color="#990000">,</font> <font color="#008080">vector&lt;string&gt;</font> dests<font color="#990000">);</font>
-<font color="#009900">void</font> <b><font color="#000000">printRoute</font></b> <font color="#990000">(</font><font color="#008080">string</font> start<font color="#990000">,</font> <font color="#008080">vector&lt;string&gt;</font> dests<font color="#990000">);</font>
+<span style="color:#009900">float</span> <b><span style="color:#000000">computeDistance</span></b> <span style="color:#990000">(</span><span style="color:#008080">MiddleEarth</span> <span style="color:#990000">&amp;</span>me<span style="color:#990000">,</span> <span style="color:#008080">string</span> start<span style="color:#990000">,</span> <span style="color:#008080">vector&lt;string&gt;</span> dests<span style="color:#990000">);</span>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printRoute</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> start<span style="color:#990000">,</span> <span style="color:#008080">vector&lt;string&gt;</span> dests<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// check the number of parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">!=</font> <font color="#993399">6</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Usage: "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" &lt;world_height&gt; &lt;world_width&gt; "</font>
-             <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"&lt;num_cities&gt; &lt;random_seed&gt; &lt;cities_to_visit&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// we'll assume the parameters are all well-formed</font></i>
-    <font color="#009900">int</font> width<font color="#990000">,</font> height<font color="#990000">,</font> num_cities<font color="#990000">,</font> rand_seed<font color="#990000">,</font> cities_to_visit<font color="#990000">;</font>
-    <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>width<font color="#990000">);</font>
-    <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>height<font color="#990000">);</font>
-    <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">3</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>num_cities<font color="#990000">);</font>
-    <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">4</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>rand_seed<font color="#990000">);</font>
-    <b><font color="#000000">sscanf</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">5</font><font color="#990000">],</font> <font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>cities_to_visit<font color="#990000">);</font>
-    <i><font color="#9A1900">// Create the world, and select your itinerary</font></i>
-    <font color="#008080">MiddleEarth</font> <b><font color="#000000">me</font></b><font color="#990000">(</font>width<font color="#990000">,</font> height<font color="#990000">,</font> num_cities<font color="#990000">,</font> rand_seed<font color="#990000">);</font>
-    <font color="#008080">vector&lt;string&gt;</font> dests <font color="#990000">=</font> me<font color="#990000">.</font><b><font color="#000000">getItinerary</font></b><font color="#990000">(</font>cities_to_visit<font color="#990000">);</font>
-    <i><font color="#9A1900">// YOUR CODE HERE</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// check the number of parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">!=</span> <span style="color:#993399">6</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" &lt;world_height&gt; &lt;world_width&gt; "</span>
+             <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"&lt;num_cities&gt; &lt;random_seed&gt; &lt;cities_to_visit&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// we'll assume the parameters are all well-formed</span></i>
+    <span style="color:#009900">int</span> width<span style="color:#990000">,</span> height<span style="color:#990000">,</span> num_cities<span style="color:#990000">,</span> rand_seed<span style="color:#990000">,</span> cities_to_visit<span style="color:#990000">;</span>
+    <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>width<span style="color:#990000">);</span>
+    <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>height<span style="color:#990000">);</span>
+    <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">3</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>num_cities<span style="color:#990000">);</span>
+    <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>rand_seed<span style="color:#990000">);</span>
+    <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">5</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>cities_to_visit<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// Create the world, and select your itinerary</span></i>
+    <span style="color:#008080">MiddleEarth</span> <b><span style="color:#000000">me</span></b><span style="color:#990000">(</span>width<span style="color:#990000">,</span> height<span style="color:#990000">,</span> num_cities<span style="color:#990000">,</span> rand_seed<span style="color:#990000">);</span>
+    <span style="color:#008080">vector&lt;string&gt;</span> dests <span style="color:#990000">=</span> me<span style="color:#990000">.</span><b><span style="color:#000000">getItinerary</span></b><span style="color:#990000">(</span>cities_to_visit<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// YOUR CODE HERE</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// This method will compute the full distance of the cycle that starts</font></i>
-<i><font color="#9A1900">// at the 'start' parameter, goes to each of the cities in the dests</font></i>
-<i><font color="#9A1900">// vector IN ORDER, and ends back at the 'start' parameter.</font></i>
-<font color="#009900">float</font> <b><font color="#000000">computeDistance</font></b> <font color="#990000">(</font><font color="#008080">MiddleEarth</font> <font color="#990000">&amp;</font>me<font color="#990000">,</font> <font color="#008080">string</font> start<font color="#990000">,</font> <font color="#008080">vector&lt;string&gt;</font> dests<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// YOUR CODE HERE</font></i>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// This method will compute the full distance of the cycle that starts</span></i>
+<i><span style="color:#9A1900">// at the 'start' parameter, goes to each of the cities in the dests</span></i>
+<i><span style="color:#9A1900">// vector IN ORDER, and ends back at the 'start' parameter.</span></i>
+<span style="color:#009900">float</span> <b><span style="color:#000000">computeDistance</span></b> <span style="color:#990000">(</span><span style="color:#008080">MiddleEarth</span> <span style="color:#990000">&amp;</span>me<span style="color:#990000">,</span> <span style="color:#008080">string</span> start<span style="color:#990000">,</span> <span style="color:#008080">vector&lt;string&gt;</span> dests<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// YOUR CODE HERE</span></i>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// This method will print the entire route, starting and ending at the</font></i>
-<i><font color="#9A1900">// 'start' parameter.  The output should be of the form:</font></i>
-<i><font color="#9A1900">// Erebor -&gt; Khazad-dum -&gt; Michel Delving -&gt; Bree -&gt; Cirith Ungol -&gt; Erebor</font></i>
-<font color="#009900">void</font> <b><font color="#000000">printRoute</font></b> <font color="#990000">(</font><font color="#008080">string</font> start<font color="#990000">,</font> <font color="#008080">vector&lt;string&gt;</font> dests<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// YOUR CODE HERE</font></i>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">// This method will print the entire route, starting and ending at the</span></i>
+<i><span style="color:#9A1900">// 'start' parameter.  The output should be of the form:</span></i>
+<i><span style="color:#9A1900">// Erebor -&gt; Khazad-dum -&gt; Michel Delving -&gt; Bree -&gt; Cirith Ungol -&gt; Erebor</span></i>
+<span style="color:#009900">void</span> <b><span style="color:#000000">printRoute</span></b> <span style="color:#990000">(</span><span style="color:#008080">string</span> start<span style="color:#990000">,</span> <span style="color:#008080">vector&lt;string&gt;</span> dests<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// YOUR CODE HERE</span></i>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/IntCell.cpp.html
+++ b/slides/code/01-cpp/IntCell.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/IntCell.cpp.html
+++ b/slides/code/01-cpp/IntCell.cpp.html
@@ -1,34 +1,34 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>IntCell.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File IntCell.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File IntCell.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"IntCell.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font> <i><font color="#9A1900">// (not really necessary, but...)</font></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"IntCell.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span> <i><span style="color:#9A1900">// (not really necessary, but...)</span></i>
 
-IntCell<font color="#990000">::</font><b><font color="#000000">IntCell</font></b><font color="#990000">(</font> <font color="#009900">int</font> initialValue <font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">storedValue</font></b><font color="#990000">(</font> initialValue <font color="#990000">)</font> <font color="#FF0000">{</font>
+IntCell<span style="color:#990000">::</span><b><span style="color:#000000">IntCell</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> initialValue <span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">storedValue</span></b><span style="color:#990000">(</span> initialValue <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
 
-<font color="#FF0000">}</font>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> IntCell<font color="#990000">::</font><b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> storedValue<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> IntCell<span style="color:#990000">::</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> storedValue<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> IntCell<font color="#990000">::</font><b><font color="#000000">setValue</font></b><font color="#990000">(</font> <font color="#009900">int</font> val <font color="#990000">)</font> <font color="#FF0000">{</font>
-    storedValue <font color="#990000">=</font> val<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> IntCell<span style="color:#990000">::</span><b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> val <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    storedValue <span style="color:#990000">=</span> val<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> IntCell<font color="#990000">::</font><b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> m<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(</font>m<font color="#990000">&gt;</font>storedValue<font color="#990000">)</font> <font color="#990000">?</font> m <font color="#990000">:</font> storedValue<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> IntCell<span style="color:#990000">::</span><b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> m<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(</span>m<span style="color:#990000">&gt;</span>storedValue<span style="color:#990000">)</span> <span style="color:#990000">?</span> m <span style="color:#990000">:</span> storedValue<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/IntCell.h.html
+++ b/slides/code/01-cpp/IntCell.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/IntCell.h.html
+++ b/slides/code/01-cpp/IntCell.h.html
@@ -1,32 +1,32 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>IntCell.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File IntCell.h</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File IntCell.h</span></i>
 
-<b><font color="#000080">#ifndef</font></b> INTCELL_H
-<b><font color="#000080">#define</font></b> INTCELL_H
+<b><span style="color:#000080">#ifndef</span></b> INTCELL_H
+<b><span style="color:#000080">#define</span></b> INTCELL_H
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">IntCell</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">IntCell</font></b><font color="#990000">(</font> <font color="#009900">int</font> initialValue <font color="#990000">=</font> <font color="#993399">0</font> <font color="#990000">);</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">IntCell</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">IntCell</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> initialValue <span style="color:#990000">=</span> <span style="color:#993399">0</span> <span style="color:#990000">);</span>
 
-    <font color="#009900">int</font> <b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-    <font color="#009900">void</font> <b><font color="#000000">setValue</font></b><font color="#990000">(</font> <font color="#009900">int</font> val <font color="#990000">);</font>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> val <span style="color:#990000">);</span>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> storedValue<font color="#990000">;</font>
-    <font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> m<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> storedValue<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> m<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/Rational.cpp.html
+++ b/slides/code/01-cpp/Rational.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,75 +8,76 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Rational.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File Rational.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File Rational.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"Rational.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"Rational.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// default constructor: initialize to 0/1</font></i>
-Rational<font color="#990000">::</font><b><font color="#000000">Rational</font></b><font color="#990000">()</font> <font color="#990000">:</font> <b><font color="#000000">num</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">),</font> <b><font color="#000000">den</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// default constructor: initialize to 0/1</span></i>
+Rational<span style="color:#990000">::</span><b><span style="color:#000000">Rational</span></b><span style="color:#990000">()</span> <span style="color:#990000">:</span> <b><span style="color:#000000">num</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">),</span> <b><span style="color:#000000">den</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// destructor : more on these later...</font></i>
-Rational<font color="#990000">::~</font><b><font color="#000000">Rational</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// destructor : more on these later...</span></i>
+Rational<span style="color:#990000">::~</span><b><span style="color:#000000">Rational</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// create and initialize a new Rational object</font></i>
-Rational<font color="#990000">::</font><b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#009900">int</font> numerator<font color="#990000">,</font> <font color="#009900">int</font> denominator<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>denominator <font color="#990000">==</font> <font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Denominator is zero"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#009900">int</font> g <font color="#990000">=</font> <b><font color="#000000">gcd</font></b><font color="#990000">(</font>numerator<font color="#990000">,</font> denominator<font color="#990000">);</font>
-    num <font color="#990000">=</font> numerator   <font color="#990000">/</font> g<font color="#990000">;</font>
-    den <font color="#990000">=</font> denominator <font color="#990000">/</font> g<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// create and initialize a new Rational object</span></i>
+Rational<span style="color:#990000">::</span><b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> numerator<span style="color:#990000">,</span> <span style="color:#009900">int</span> denominator<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>denominator <span style="color:#990000">==</span> <span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Denominator is zero"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#009900">int</span> g <span style="color:#990000">=</span> <b><span style="color:#000000">gcd</span></b><span style="color:#990000">(</span>numerator<span style="color:#990000">,</span> denominator<span style="color:#990000">);</span>
+    num <span style="color:#990000">=</span> numerator   <span style="color:#990000">/</span> g<span style="color:#990000">;</span>
+    den <span style="color:#990000">=</span> denominator <span style="color:#990000">/</span> g<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// print string representation of (this) to cout</font></i>
-<font color="#009900">void</font> Rational<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>den <font color="#990000">==</font> <font color="#993399">1</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> num <font color="#990000">&lt;&lt;</font> <font color="#FF0000">""</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> num <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"/"</font> <font color="#990000">&lt;&lt;</font> den <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// print string representation of (this) to cout</span></i>
+<span style="color:#009900">void</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>den <span style="color:#990000">==</span> <span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> num <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">""</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> num <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"/"</span> <span style="color:#990000">&lt;&lt;</span> den <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// return (this * b)</font></i>
-<font color="#008080">Rational</font> Rational<font color="#990000">::</font><b><font color="#000000">times</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">Rational</font></b><font color="#990000">(</font>num <font color="#990000">*</font> b<font color="#990000">.</font>num<font color="#990000">,</font> den <font color="#990000">*</font> b<font color="#990000">.</font>den<font color="#990000">);</font>
-<font color="#FF0000">}</font>
-
-
-<i><font color="#9A1900">// return (this + b)</font></i>
-<font color="#008080">Rational</font> Rational<font color="#990000">::</font><b><font color="#000000">plus</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> numerator   <font color="#990000">=</font> <font color="#990000">(</font>num <font color="#990000">*</font> b<font color="#990000">.</font>den<font color="#990000">)</font> <font color="#990000">+</font> <font color="#990000">(</font>den <font color="#990000">*</font> b<font color="#990000">.</font>num<font color="#990000">);</font>
-    <font color="#009900">int</font> denominator <font color="#990000">=</font> den <font color="#990000">*</font> b<font color="#990000">.</font>den<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">Rational</font></b><font color="#990000">(</font>numerator<font color="#990000">,</font> denominator<font color="#990000">);</font>
-<font color="#FF0000">}</font>
-
-<i><font color="#9A1900">// return (1 / this)</font></i>
-<font color="#008080">Rational</font> Rational<font color="#990000">::</font><b><font color="#000000">reciprocal</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">Rational</font></b><font color="#990000">(</font>den<font color="#990000">,</font> num<font color="#990000">);</font>
-<font color="#FF0000">}</font>
-
-<i><font color="#9A1900">// return (this / b)</font></i>
-<font color="#008080">Rational</font> Rational<font color="#990000">::</font><b><font color="#000000">divides</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">times</font></b><font color="#990000">(</font>b<font color="#990000">.</font><b><font color="#000000">reciprocal</font></b><font color="#990000">());</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// return (this * b)</span></i>
+<span style="color:#008080">Rational</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">times</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span>num <span style="color:#990000">*</span> b<span style="color:#990000">.</span>num<span style="color:#990000">,</span> den <span style="color:#990000">*</span> b<span style="color:#990000">.</span>den<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
 
-<i><font color="#9A1900">/*************************************************************************</font></i>
-<i><font color="#9A1900"> *  Helper functions</font></i>
-<i><font color="#9A1900"> *************************************************************************/</font></i>
+<i><span style="color:#9A1900">// return (this + b)</span></i>
+<span style="color:#008080">Rational</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">plus</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> numerator   <span style="color:#990000">=</span> <span style="color:#990000">(</span>num <span style="color:#990000">*</span> b<span style="color:#990000">.</span>den<span style="color:#990000">)</span> <span style="color:#990000">+</span> <span style="color:#990000">(</span>den <span style="color:#990000">*</span> b<span style="color:#990000">.</span>num<span style="color:#990000">);</span>
+    <span style="color:#009900">int</span> denominator <span style="color:#990000">=</span> den <span style="color:#990000">*</span> b<span style="color:#990000">.</span>den<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span>numerator<span style="color:#990000">,</span> denominator<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// return gcd(m, n)</font></i>
-<font color="#009900">int</font> Rational<font color="#990000">::</font><b><font color="#000000">gcd</font></b><font color="#990000">(</font><font color="#009900">int</font> m<font color="#990000">,</font> <font color="#009900">int</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font><font color="#993399">0</font> <font color="#990000">==</font> n<font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> m<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        <b><font color="#0000FF">return</font></b> <b><font color="#000000">gcd</font></b><font color="#990000">(</font>n<font color="#990000">,</font> m <font color="#990000">%</font> n<font color="#990000">);</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<i><span style="color:#9A1900">// return (1 / this)</span></i>
+<span style="color:#008080">Rational</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">reciprocal</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span>den<span style="color:#990000">,</span> num<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
+
+<i><span style="color:#9A1900">// return (this / b)</span></i>
+<span style="color:#008080">Rational</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">divides</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">times</span></b><span style="color:#990000">(</span>b<span style="color:#990000">.</span><b><span style="color:#000000">reciprocal</span></b><span style="color:#990000">());</span>
+<span style="color:#FF0000">}</span>
+
+
+<i><span style="color:#9A1900">/*************************************************************************</span></i>
+<i><span style="color:#9A1900"> *  Helper functions</span></i>
+<i><span style="color:#9A1900"> *************************************************************************/</span></i>
+
+<i><span style="color:#9A1900">// return gcd(m, n)</span></i>
+<i><span style="color:#9A1900">// not marked as 'static' here because that can only be done in declaration</span></i>
+<span style="color:#009900">int</span> Rational<span style="color:#990000">::</span><b><span style="color:#000000">gcd</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> m<span style="color:#990000">,</span> <span style="color:#009900">int</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span><span style="color:#993399">0</span> <span style="color:#990000">==</span> n<span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> m<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">gcd</span></b><span style="color:#990000">(</span>n<span style="color:#990000">,</span> m <span style="color:#990000">%</span> n<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/Rational.cpp.html
+++ b/slides/code/01-cpp/Rational.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/Rational.h.html
+++ b/slides/code/01-cpp/Rational.h.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,52 +8,52 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Rational.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File Rational.h</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File Rational.h</span></i>
 
-<b><font color="#000080">#ifndef</font></b> RATIONAL_H
-<b><font color="#000080">#define</font></b> RATIONAL_H
+<b><span style="color:#000080">#ifndef</span></b> RATIONAL_H
+<b><span style="color:#000080">#define</span></b> RATIONAL_H
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">Rational</font> <font color="#FF0000">{</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Rational</span> <span style="color:#FF0000">{</span>
 
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <i><font color="#9A1900">// default constructor</font></i>
-    <b><font color="#000000">Rational</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <i><span style="color:#9A1900">// default constructor</span></i>
+    <b><span style="color:#000000">Rational</span></b><span style="color:#990000">();</span>
 
-    <i><font color="#9A1900">// destructor</font></i>
-    <font color="#990000">~</font><b><font color="#000000">Rational</font></b><font color="#990000">();</font>
+    <i><span style="color:#9A1900">// destructor</span></i>
+    <span style="color:#990000">~</span><b><span style="color:#000000">Rational</span></b><span style="color:#990000">();</span>
 
-    <i><font color="#9A1900">// create and initialize a new Rational object</font></i>
-    <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#009900">int</font> numerator<font color="#990000">,</font> <font color="#009900">int</font> denominator<font color="#990000">);</font>
+    <i><span style="color:#9A1900">// create and initialize a new Rational object</span></i>
+    <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> numerator<span style="color:#990000">,</span> <span style="color:#009900">int</span> denominator<span style="color:#990000">);</span>
 
-    <i><font color="#9A1900">// print string representation of (this) to cout</font></i>
-    <font color="#009900">void</font> <b><font color="#000000">print</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print string representation of (this) to cout</span></i>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// return (this * b)</font></i>
-    <font color="#008080">Rational</font> <b><font color="#000000">times</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// return (this * b)</span></i>
+    <span style="color:#008080">Rational</span> <b><span style="color:#000000">times</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// return (this + b)</font></i>
-    <font color="#008080">Rational</font> <b><font color="#000000">plus</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// return (this + b)</span></i>
+    <span style="color:#008080">Rational</span> <b><span style="color:#000000">plus</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// return (1 / this)</font></i>
-    <font color="#008080">Rational</font> <b><font color="#000000">reciprocal</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// return (1 / this)</span></i>
+    <span style="color:#008080">Rational</span> <b><span style="color:#000000">reciprocal</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// return (this / b)</font></i>
-    <font color="#008080">Rational</font> <b><font color="#000000">divides</font></b><font color="#990000">(</font><font color="#008080">Rational</font> b<font color="#990000">)</font> <b><font color="#0000FF">const</font></b><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// return (this / b)</span></i>
+    <span style="color:#008080">Rational</span> <b><span style="color:#000000">divides</span></b><span style="color:#990000">(</span><span style="color:#008080">Rational</span> b<span style="color:#990000">)</span> <b><span style="color:#0000FF">const</span></b><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> num<font color="#990000">;</font>   <i><font color="#9A1900">// the numerator</font></i>
-    <font color="#009900">int</font> den<font color="#990000">;</font>   <i><font color="#9A1900">// the denominator</font></i>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> num<span style="color:#990000">;</span>   <i><span style="color:#9A1900">// the numerator</span></i>
+    <span style="color:#009900">int</span> den<span style="color:#990000">;</span>   <i><span style="color:#9A1900">// the denominator</span></i>
 
-    <i><font color="#9A1900">/*************************************************************************</font></i>
-<i><font color="#9A1900">    *  Helper functions</font></i>
-<i><font color="#9A1900">    *************************************************************************/</font></i>
-    <i><font color="#9A1900">// return gcd(m, n)</font></i>
-    <font color="#009900">int</font> <b><font color="#000000">gcd</font></b><font color="#990000">(</font><font color="#009900">int</font> m<font color="#990000">,</font> <font color="#009900">int</font> n<font color="#990000">);</font>
+    <i><span style="color:#9A1900">/*************************************************************************</span></i>
+<i><span style="color:#9A1900">    *  Helper functions</span></i>
+<i><span style="color:#9A1900">    *************************************************************************/</span></i>
+    <i><span style="color:#9A1900">// return gcd(m, n)</span></i>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">gcd</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> m<span style="color:#990000">,</span> <span style="color:#009900">int</span> n<span style="color:#990000">);</span>
 
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/Rational.h.html
+++ b/slides/code/01-cpp/Rational.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/TestIntCell.cpp.html
+++ b/slides/code/01-cpp/TestIntCell.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/TestIntCell.cpp.html
+++ b/slides/code/01-cpp/TestIntCell.cpp.html
@@ -1,29 +1,29 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TestIntCell.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File TestIntCell.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File TestIntCell.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"IntCell.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">(</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">IntCell</font> m1<font color="#990000">;</font>
-    <font color="#008080">IntCell</font> <b><font color="#000000">m2</font></b><font color="#990000">(</font> <font color="#993399">37</font> <font color="#990000">);</font> <i><font color="#9A1900">//</font></i>
-    <i><font color="#9A1900">//IntCell m2 = 37; // does not work</font></i>
-    cout <font color="#990000">&lt;&lt;</font> m1<font color="#990000">.</font><b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font> <font color="#990000">&lt;&lt;</font> m2<font color="#990000">.</font><b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    m1 <font color="#990000">=</font> m2<font color="#990000">;</font>
-    m2<font color="#990000">.</font><b><font color="#000000">setValue</font></b><font color="#990000">(</font> <font color="#993399">40</font> <font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> m1<font color="#990000">.</font><b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font> <font color="#990000">&lt;&lt;</font> m2<font color="#990000">.</font><b><font color="#000000">getValue</font></b><font color="#990000">(</font> <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"IntCell.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">IntCell</span> m1<span style="color:#990000">;</span>
+    <span style="color:#008080">IntCell</span> <b><span style="color:#000000">m2</span></b><span style="color:#990000">(</span> <span style="color:#993399">37</span> <span style="color:#990000">);</span> <i><span style="color:#9A1900">//</span></i>
+    <i><span style="color:#9A1900">//IntCell m2 = 37; // does not work</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> m1<span style="color:#990000">.</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span> <span style="color:#990000">&lt;&lt;</span> m2<span style="color:#990000">.</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    m1 <span style="color:#990000">=</span> m2<span style="color:#990000">;</span>
+    m2<span style="color:#990000">.</span><b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span> <span style="color:#993399">40</span> <span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> m1<span style="color:#990000">.</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span> <span style="color:#990000">&lt;&lt;</span> m2<span style="color:#990000">.</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">(</span> <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/TestRational.cpp.html
+++ b/slides/code/01-cpp/TestRational.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/TestRational.cpp.html
+++ b/slides/code/01-cpp/TestRational.cpp.html
@@ -1,48 +1,48 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>TestRational.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// File TestRational.cpp</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// File TestRational.cpp</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"Rational.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"Rational.h"</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">Rational</font> x<font color="#990000">,</font> y<font color="#990000">,</font> z<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">Rational</span> x<span style="color:#990000">,</span> y<span style="color:#990000">,</span> z<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// 1/2 + 1/3 = 5/6</font></i>
-    x <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">,</font> <font color="#993399">2</font><font color="#990000">);</font>
-    y <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">,</font> <font color="#993399">3</font><font color="#990000">);</font>
-    z <font color="#990000">=</font> x<font color="#990000">.</font><b><font color="#000000">plus</font></b><font color="#990000">(</font>y<font color="#990000">);</font>
-    z<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
+    <i><span style="color:#9A1900">// 1/2 + 1/3 = 5/6</span></i>
+    x <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">2</span><span style="color:#990000">);</span>
+    y <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">3</span><span style="color:#990000">);</span>
+    z <span style="color:#990000">=</span> x<span style="color:#990000">.</span><b><span style="color:#000000">plus</span></b><span style="color:#990000">(</span>y<span style="color:#990000">);</span>
+    z<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
 
-    <i><font color="#9A1900">// 8/9 + 1/9 = 1</font></i>
-    x <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">8</font><font color="#990000">,</font> <font color="#993399">9</font><font color="#990000">);</font>
-    y <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">,</font> <font color="#993399">9</font><font color="#990000">);</font>
-    z <font color="#990000">=</font> x<font color="#990000">.</font><b><font color="#000000">plus</font></b><font color="#990000">(</font>y<font color="#990000">);</font>
-    z<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
+    <i><span style="color:#9A1900">// 8/9 + 1/9 = 1</span></i>
+    x <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#993399">9</span><span style="color:#990000">);</span>
+    y <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">9</span><span style="color:#990000">);</span>
+    z <span style="color:#990000">=</span> x<span style="color:#990000">.</span><b><span style="color:#000000">plus</span></b><span style="color:#990000">(</span>y<span style="color:#990000">);</span>
+    z<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
 
-    <i><font color="#9A1900">//  4/17 * 7/3 = 28/51</font></i>
-    x <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">4</font><font color="#990000">,</font> <font color="#993399">17</font><font color="#990000">);</font>
-    y <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">7</font><font color="#990000">,</font>  <font color="#993399">3</font><font color="#990000">);</font>
-    z <font color="#990000">=</font> x<font color="#990000">.</font><b><font color="#000000">times</font></b><font color="#990000">(</font>y<font color="#990000">);</font>
-    z<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
+    <i><span style="color:#9A1900">//  4/17 * 7/3 = 28/51</span></i>
+    x <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">17</span><span style="color:#990000">);</span>
+    y <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">7</span><span style="color:#990000">,</span>  <span style="color:#993399">3</span><span style="color:#990000">);</span>
+    z <span style="color:#990000">=</span> x<span style="color:#990000">.</span><b><span style="color:#000000">times</span></b><span style="color:#990000">(</span>y<span style="color:#990000">);</span>
+    z<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
 
-    <i><font color="#9A1900">// 0/6 = 0</font></i>
-    x <font color="#990000">=</font> <b><font color="#000000">Rational</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">,</font> <font color="#993399">6</font><font color="#990000">);</font>
-    x<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
+    <i><span style="color:#9A1900">// 0/6 = 0</span></i>
+    x <span style="color:#990000">=</span> <b><span style="color:#000000">Rational</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#993399">6</span><span style="color:#990000">);</span>
+    x<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/cpptest.cpp.html
+++ b/slides/code/01-cpp/cpptest.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,192 +8,192 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>cpptest.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/*</font></i>
-<i><font color="#9A1900"> * This program is designed to show some nuances of C++ syntax,</font></i>
-<i><font color="#9A1900"> * reference usage, and the various methods in a class (copy</font></i>
-<i><font color="#9A1900"> * constructor, operator=(), etc.).</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The addresses you get when running this program will most likley</font></i>
-<i><font color="#9A1900"> * differ; that is expected.  In fact, the addresses will differ upon</font></i>
-<i><font color="#9A1900"> * successive executions of the program.  If you are compiling this on</font></i>
-<i><font color="#9A1900"> * a 64-bit machine, you may want to use the -m32 flag to g++ to</font></i>
-<i><font color="#9A1900"> * compile it in 32-bit mode -- this keeps the pointers to 32 bits (as</font></i>
-<i><font color="#9A1900"> * opposed to 64 bits).</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Copyright (c) 2012 by Aaron Bloomfield (</font></i><u><font color="#0000FF">aaron@virginia.edu</font></u><i><font color="#9A1900">).  All</font></i>
-<i><font color="#9A1900"> * rights reesrved.</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/*</span></i>
+<i><span style="color:#9A1900"> * This program is designed to show some nuances of C++ syntax,</span></i>
+<i><span style="color:#9A1900"> * reference usage, and the various methods in a class (copy</span></i>
+<i><span style="color:#9A1900"> * constructor, operator=(), etc.).</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The addresses you get when running this program will most likley</span></i>
+<i><span style="color:#9A1900"> * differ; that is expected.  In fact, the addresses will differ upon</span></i>
+<i><span style="color:#9A1900"> * successive executions of the program.  If you are compiling this on</span></i>
+<i><span style="color:#9A1900"> * a 64-bit machine, you may want to use the -m32 flag to g++ to</span></i>
+<i><span style="color:#9A1900"> * compile it in 32-bit mode -- this keeps the pointers to 32 bits (as</span></i>
+<i><span style="color:#9A1900"> * opposed to 64 bits).</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Copyright (c) 2012 by Aaron Bloomfield (</span></i><u><span style="color:#0000FF">aaron@virginia.edu</span></u><i><span style="color:#9A1900">).  All</span></i>
+<i><span style="color:#9A1900"> * rights reesrved.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">//--------------------------------------------------</font></i>
-<i><font color="#9A1900">// this would be in test.h</font></i>
+<i><span style="color:#9A1900">//--------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// this would be in test.h</span></i>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">test</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">static</font></b> <font color="#009900">int</font> idcount<font color="#990000">;</font>
-    <b><font color="#0000FF">const</font></b> <font color="#009900">int</font> id<font color="#990000">;</font>
-    <font color="#009900">int</font> value<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">test</font></b><font color="#990000">();</font>
-    <b><font color="#000000">test</font></b><font color="#990000">(</font><font color="#009900">int</font> v<font color="#990000">);</font>
-    <b><font color="#000000">test</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> x<font color="#990000">);</font>
-    <font color="#990000">~</font><b><font color="#000000">test</font></b><font color="#990000">();</font>
-    test<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">=(</font><b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> other<font color="#990000">);</font>
-    <b><font color="#0000FF">friend</font></b> ostream<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font>ostream<font color="#990000">&amp;</font> out<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> f<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">test</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">static</span></b> <span style="color:#009900">int</span> idcount<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">const</span></b> <span style="color:#009900">int</span> id<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> value<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">test</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> v<span style="color:#990000">);</span>
+    <b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> x<span style="color:#990000">);</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">test</span></b><span style="color:#990000">();</span>
+    test<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">=(</span><b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> other<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">friend</span></b> ostream<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span>ostream<span style="color:#990000">&amp;</span> out<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> f<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">//--------------------------------------------------</font></i>
-<i><font color="#9A1900">// this would be in test.cpp</font></i>
+<i><span style="color:#9A1900">//--------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// this would be in test.cpp</span></i>
 
-<font color="#009900">int</font> test<font color="#990000">::</font>idcount <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
+<span style="color:#009900">int</span> test<span style="color:#990000">::</span>idcount <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
 
-test<font color="#990000">::</font><b><font color="#000000">test</font></b><font color="#990000">()</font> <font color="#990000">:</font> <b><font color="#000000">id</font></b> <font color="#990000">(</font>idcount<font color="#990000">++),</font> <b><font color="#000000">value</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling test(); object created is "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"; address is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+test<span style="color:#990000">::</span><b><span style="color:#000000">test</span></b><span style="color:#990000">()</span> <span style="color:#990000">:</span> <b><span style="color:#000000">id</span></b> <span style="color:#990000">(</span>idcount<span style="color:#990000">++),</span> <b><span style="color:#000000">value</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling test(); object created is "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"; address is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-test<font color="#990000">::</font><b><font color="#000000">test</font></b><font color="#990000">(</font><font color="#009900">int</font> v<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">id</font></b> <font color="#990000">(</font>idcount<font color="#990000">++),</font> <b><font color="#000000">value</font></b><font color="#990000">(</font>v<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling test("</font> <font color="#990000">&lt;&lt;</font> v <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"); object created is "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b>
-         <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"; address is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+test<span style="color:#990000">::</span><b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> v<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">id</span></b> <span style="color:#990000">(</span>idcount<span style="color:#990000">++),</span> <b><span style="color:#000000">value</span></b><span style="color:#990000">(</span>v<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling test("</span> <span style="color:#990000">&lt;&lt;</span> v <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"); object created is "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b>
+         <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"; address is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-test<font color="#990000">::</font><b><font color="#000000">test</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">id</font></b><font color="#990000">(</font>x<font color="#990000">.</font>id<font color="#990000">),</font> <b><font color="#000000">value</font></b><font color="#990000">(</font>x<font color="#990000">.</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling test(const test&amp;) on "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"; address is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+test<span style="color:#990000">::</span><b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> x<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">id</span></b><span style="color:#990000">(</span>x<span style="color:#990000">.</span>id<span style="color:#990000">),</span> <b><span style="color:#000000">value</span></b><span style="color:#990000">(</span>x<span style="color:#990000">.</span>value<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling test(const test&amp;) on "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"; address is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-test<font color="#990000">::~</font><b><font color="#000000">test</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling ~test() on "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+test<span style="color:#990000">::~</span><b><span style="color:#000000">test</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling ~test() on "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span><b><span style="color:#0000FF">this</span></b> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-test<font color="#990000">&amp;</font> test<font color="#990000">::</font><b><font color="#0000FF">operator</font></b><font color="#990000">=(</font><b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> other<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling operator=("</font> <font color="#990000">&lt;&lt;</font> other <font color="#990000">&lt;&lt;</font> <font color="#FF0000">")"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> <font color="#990000">*</font>tmp <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">test</font></b><font color="#990000">(</font>other<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">*</font>tmp<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+test<span style="color:#990000">&amp;</span> test<span style="color:#990000">::</span><b><span style="color:#0000FF">operator</span></b><span style="color:#990000">=(</span><b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> other<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling operator=("</span> <span style="color:#990000">&lt;&lt;</span> other <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">")"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> <span style="color:#990000">*</span>tmp <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">test</span></b><span style="color:#990000">(</span>other<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">*</span>tmp<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-ostream<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</font></b><font color="#990000">&lt;&lt;(</font>ostream<font color="#990000">&amp;</font> out<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> f<font color="#990000">)</font> <font color="#FF0000">{</font>
-    out <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"test[id="</font> <font color="#990000">&lt;&lt;</font> f<font color="#990000">.</font>id <font color="#990000">&lt;&lt;</font> <font color="#FF0000">",v="</font> <font color="#990000">&lt;&lt;</font> f<font color="#990000">.</font>value <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"]"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> out<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+ostream<span style="color:#990000">&amp;</span> <b><span style="color:#0000FF">operator</span></b><span style="color:#990000">&lt;&lt;(</span>ostream<span style="color:#990000">&amp;</span> out<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> test<span style="color:#990000">&amp;</span> f<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    out <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"test[id="</span> <span style="color:#990000">&lt;&lt;</span> f<span style="color:#990000">.</span>id <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">",v="</span> <span style="color:#990000">&lt;&lt;</span> f<span style="color:#990000">.</span>value <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"]"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> out<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
 
-<i><font color="#9A1900">//--------------------------------------------------</font></i>
-<i><font color="#9A1900">// this would be in main.cpp</font></i>
+<i><span style="color:#9A1900">//--------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// this would be in main.cpp</span></i>
 
-<font color="#008080">test</font> <b><font color="#000000">bar</font></b><font color="#990000">(</font><font color="#008080">test</font> param<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">test</font></b><font color="#990000">(</font><font color="#993399">10</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#008080">test</span> <b><span style="color:#000000">bar</span></b><span style="color:#990000">(</span><span style="color:#008080">test</span> param<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><span style="color:#993399">10</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
 
-    <i><font color="#9A1900">// this does NOT create a test object; instead, it creates a function</font></i>
-    <i><font color="#9A1900">// called a() that has no body (and thus C++ defaults it to return</font></i>
-    <i><font color="#9A1900">// 1).  Note that there is no output statement from the default</font></i>
-    <i><font color="#9A1900">// constructor.</font></i>
-    <font color="#008080">test</font> <b><font color="#000000">a</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"attempted to create a: "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// attempted to create a: 1</font></i>
+    <i><span style="color:#9A1900">// this does NOT create a test object; instead, it creates a function</span></i>
+    <i><span style="color:#9A1900">// called a() that has no body (and thus C++ defaults it to return</span></i>
+    <i><span style="color:#9A1900">// 1).  Note that there is no output statement from the default</span></i>
+    <i><span style="color:#9A1900">// constructor.</span></i>
+    <span style="color:#008080">test</span> <b><span style="color:#000000">a</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"attempted to create a: "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// attempted to create a: 1</span></i>
 
-    <i><font color="#9A1900">// this does  create a test object, calling  the default constructor.</font></i>
-    <i><font color="#9A1900">// Since  putting parenthesis in  there for  creating an  object and</font></i>
-    <i><font color="#9A1900">// calling  the  default  constructor  has another  meaning  in  C++</font></i>
-    <i><font color="#9A1900">// (specifically,  creating  a  function),   we  have  to  omit  the</font></i>
-    <i><font color="#9A1900">// parenthesis.</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> aa<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"created aa: "</font> <font color="#990000">&lt;&lt;</font> aa <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// calling test(); object created is test[id=0,v=0]; address is 0xff852a50</font></i>
-    <i><font color="#9A1900">// created aa: test[id=0,v=0]</font></i>
+    <i><span style="color:#9A1900">// this does  create a test object, calling  the default constructor.</span></i>
+    <i><span style="color:#9A1900">// Since  putting parenthesis in  there for  creating an  object and</span></i>
+    <i><span style="color:#9A1900">// calling  the  default  constructor  has another  meaning  in  C++</span></i>
+    <i><span style="color:#9A1900">// (specifically,  creating  a  function),   we  have  to  omit  the</span></i>
+    <i><span style="color:#9A1900">// parenthesis.</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> aa<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"created aa: "</span> <span style="color:#990000">&lt;&lt;</span> aa <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// calling test(); object created is test[id=0,v=0]; address is 0xff852a50</span></i>
+    <i><span style="color:#9A1900">// created aa: test[id=0,v=0]</span></i>
 
-    <i><font color="#9A1900">// this creates a test object, calling the specific constructor that</font></i>
-    <i><font color="#9A1900">// takes in a single int value</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> <b><font color="#000000">b</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"created b: "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// calling test(1); object created is test[id=1,v=1]; address is 0xff852a48</font></i>
-    <i><font color="#9A1900">// created b: test[id=1,v=1]</font></i>
+    <i><span style="color:#9A1900">// this creates a test object, calling the specific constructor that</span></i>
+    <i><span style="color:#9A1900">// takes in a single int value</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> <b><span style="color:#000000">b</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"created b: "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// calling test(1); object created is test[id=1,v=1]; address is 0xff852a48</span></i>
+    <i><span style="color:#9A1900">// created b: test[id=1,v=1]</span></i>
 
-    <i><font color="#9A1900">// this creates two test objects via pointers and new</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> <font color="#990000">*</font>c <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">test</font></b><font color="#990000">(</font><font color="#993399">2</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"created *c: "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>c <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" at "</font> <font color="#990000">&lt;&lt;</font> c <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> <font color="#990000">*</font>d <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> test<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"created *d: "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>d <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" at "</font> <font color="#990000">&lt;&lt;</font> d <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// calling test(2); object created is test[id=2,v=2]; address is 0xa009008</font></i>
-    <i><font color="#9A1900">// created *c: test[id=2,v=2] at 0xa009008</font></i>
-    <i><font color="#9A1900">// calling test(); object created is test[id=3,v=0]; address is 0xa009018</font></i>
-    <i><font color="#9A1900">// created *d: test[id=3,v=0] at 0xa009018</font></i>
+    <i><span style="color:#9A1900">// this creates two test objects via pointers and new</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> <span style="color:#990000">*</span>c <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">test</span></b><span style="color:#990000">(</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"created *c: "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>c <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" at "</span> <span style="color:#990000">&lt;&lt;</span> c <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> <span style="color:#990000">*</span>d <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> test<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"created *d: "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>d <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" at "</span> <span style="color:#990000">&lt;&lt;</span> d <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// calling test(2); object created is test[id=2,v=2]; address is 0xa009008</span></i>
+    <i><span style="color:#9A1900">// created *c: test[id=2,v=2] at 0xa009008</span></i>
+    <i><span style="color:#9A1900">// calling test(); object created is test[id=3,v=0]; address is 0xa009018</span></i>
+    <i><span style="color:#9A1900">// created *d: test[id=3,v=0] at 0xa009018</span></i>
 
-    <i><font color="#9A1900">// subroutine invocation.  The copy constructor is invoked when the</font></i>
-    <i><font color="#9A1900">// actual parameter is copied into the formal parameter.  The</font></i>
-    <i><font color="#9A1900">// subroutine then creates test[id=4,v=10].  The parameter that was</font></i>
-    <i><font color="#9A1900">// copied into the subroutine (via the copy constructor) is then</font></i>
-    <i><font color="#9A1900">// destructed upon termination of the subroutine.</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"about to invoke subroutine..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> e <font color="#990000">=</font> <b><font color="#000000">bar</font></b><font color="#990000">(*</font>c<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"finished invoking subroutine..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// about to invoke subroutine...</font></i>
-    <i><font color="#9A1900">// calling test(const test&amp;) on test[id=2,v=2]; address is 0xff852a38</font></i>
-    <i><font color="#9A1900">// calling test(10); object created is test[id=4,v=10]; address is 0xff852a40</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=2,v=2]</font></i>
-    <i><font color="#9A1900">// finished invoking subroutine...</font></i>
+    <i><span style="color:#9A1900">// subroutine invocation.  The copy constructor is invoked when the</span></i>
+    <i><span style="color:#9A1900">// actual parameter is copied into the formal parameter.  The</span></i>
+    <i><span style="color:#9A1900">// subroutine then creates test[id=4,v=10].  The parameter that was</span></i>
+    <i><span style="color:#9A1900">// copied into the subroutine (via the copy constructor) is then</span></i>
+    <i><span style="color:#9A1900">// destructed upon termination of the subroutine.</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"about to invoke subroutine..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> e <span style="color:#990000">=</span> <b><span style="color:#000000">bar</span></b><span style="color:#990000">(*</span>c<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"finished invoking subroutine..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// about to invoke subroutine...</span></i>
+    <i><span style="color:#9A1900">// calling test(const test&amp;) on test[id=2,v=2]; address is 0xff852a38</span></i>
+    <i><span style="color:#9A1900">// calling test(10); object created is test[id=4,v=10]; address is 0xff852a40</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=2,v=2]</span></i>
+    <i><span style="color:#9A1900">// finished invoking subroutine...</span></i>
 
-    <i><font color="#9A1900">// because this assignment happens in the same statement as the</font></i>
-    <i><font color="#9A1900">// declaration, it invokes the copy constructor</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#008080">test</font> f <font color="#990000">=</font> b<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// calling test(&amp;test) on test[id=1,v=1]; address is 0xff852a30</font></i>
+    <i><span style="color:#9A1900">// because this assignment happens in the same statement as the</span></i>
+    <i><span style="color:#9A1900">// declaration, it invokes the copy constructor</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#008080">test</span> f <span style="color:#990000">=</span> b<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// calling test(&amp;test) on test[id=1,v=1]; address is 0xff852a30</span></i>
 
-    <i><font color="#9A1900">// we are only deleting one of the dynamically created test objects</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"about to delete a test object..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> c<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// about to delete a test object...</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=2,v=2]</font></i>
+    <i><span style="color:#9A1900">// we are only deleting one of the dynamically created test objects</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"about to delete a test object..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> c<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// about to delete a test object...</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=2,v=2]</span></i>
 
-    <i><font color="#9A1900">// because this assignment does NOT happen in the same statement as</font></i>
-    <i><font color="#9A1900">// the declaration, the operator=() subroutine is called.</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"assignment..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    aa <font color="#990000">=</font> b<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// assignment...</font></i>
-    <i><font color="#9A1900">// calling operator=(test[id=1,v=1])</font></i>
-    <i><font color="#9A1900">// calling test(&amp;test) on test[id=1,v=1]; address is 0xa009008</font></i>
+    <i><span style="color:#9A1900">// because this assignment does NOT happen in the same statement as</span></i>
+    <i><span style="color:#9A1900">// the declaration, the operator=() subroutine is called.</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"assignment..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    aa <span style="color:#990000">=</span> b<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// assignment...</span></i>
+    <i><span style="color:#9A1900">// calling operator=(test[id=1,v=1])</span></i>
+    <i><span style="color:#9A1900">// calling test(&amp;test) on test[id=1,v=1]; address is 0xa009008</span></i>
 
-    <i><font color="#9A1900">// upon termination of the main() function, all statically created</font></i>
-    <i><font color="#9A1900">// test objects are deallocated.</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"----------------------------------------"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"about to leave main..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// output:</font></i>
-    <i><font color="#9A1900">// ----------------------------------------</font></i>
-    <i><font color="#9A1900">// about to leave main...</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=1,v=1]</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=4,v=10]</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=1,v=1]</font></i>
-    <i><font color="#9A1900">// calling ~test() on test[id=0,v=0]</font></i>
+    <i><span style="color:#9A1900">// upon termination of the main() function, all statically created</span></i>
+    <i><span style="color:#9A1900">// test objects are deallocated.</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"----------------------------------------"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"about to leave main..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// output:</span></i>
+    <i><span style="color:#9A1900">// ----------------------------------------</span></i>
+    <i><span style="color:#9A1900">// about to leave main...</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=1,v=1]</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=4,v=10]</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=1,v=1]</span></i>
+    <i><span style="color:#9A1900">// calling ~test() on test[id=0,v=0]</span></i>
 
-    <i><font color="#9A1900">// Note that d was created via dynamic memory allocation, so it is</font></i>
-    <i><font color="#9A1900">// not deallcoated by the program.  The operating system will clean</font></i>
-    <i><font color="#9A1900">// up the used memory, but it does not call the destructor on d.</font></i>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <i><span style="color:#9A1900">// Note that d was created via dynamic memory allocation, so it is</span></i>
+    <i><span style="color:#9A1900">// not deallcoated by the program.  The operating system will clean</span></i>
+    <i><span style="color:#9A1900">// up the used memory, but it does not call the destructor on d.</span></i>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/cpptest.cpp.html
+++ b/slides/code/01-cpp/cpptest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/delete.cpp.html
+++ b/slides/code/01-cpp/delete.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/delete.cpp.html
+++ b/slides/code/01-cpp/delete.cpp.html
@@ -1,24 +1,24 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>delete.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    string <font color="#990000">*</font> pointerToString <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">string</font></b><font color="#990000">(</font><font color="#FF0000">"hi"</font><font color="#990000">);</font>
-    <i><font color="#9A1900">// some code that uses pointerToString here</font></i>
-    <b><font color="#0000FF">delete</font></b> pointerToString<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    string <span style="color:#990000">*</span> pointerToString <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">string</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"hi"</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// some code that uses pointerToString here</span></i>
+    <b><span style="color:#0000FF">delete</span></b> pointerToString<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/dynamic_allocation.cpp.html
+++ b/slides/code/01-cpp/dynamic_allocation.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/dynamic_allocation.cpp.html
+++ b/slides/code/01-cpp/dynamic_allocation.cpp.html
@@ -1,47 +1,47 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>dynamic_allocation.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* Author: Michele Co, CS 216, Spring 2007</font></i>
-<i><font color="#9A1900"> * Filename: dynamic_allocation.cpp</font></i>
-<i><font color="#9A1900"> * Description: Demonstrates dynamic allocation and de-allocation</font></i>
-<i><font color="#9A1900"> *			using new and delete</font></i>
-<i><font color="#9A1900"> */</font></i>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* Author: Michele Co, CS 216, Spring 2007</span></i>
+<i><span style="color:#9A1900"> * Filename: dynamic_allocation.cpp</span></i>
+<i><span style="color:#9A1900"> * Description: Demonstrates dynamic allocation and de-allocation</span></i>
+<i><span style="color:#9A1900"> *			using new and delete</span></i>
+<i><span style="color:#9A1900"> */</span></i>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> n<font color="#990000">;</font>
-    <i><font color="#9A1900">// read in a value from the user</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Please enter an integer value: "</font> <font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> n<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> n<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// read in a value from the user</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Please enter an integer value: "</span> <span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> n<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// use the user's input to create an array of int</font></i>
-    <font color="#009900">int</font> <font color="#990000">*</font> ages <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <font color="#009900">int</font> <font color="#990000">[</font>n<font color="#990000">];</font>
+    <i><span style="color:#9A1900">// use the user's input to create an array of int</span></i>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span> ages <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <span style="color:#009900">int</span> <span style="color:#990000">[</span>n<span style="color:#990000">];</span>
 
-    <i><font color="#9A1900">// use a loop to prompt the user to initialize the array</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font><font color="#009900">int</font> i<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> n<font color="#990000">;</font> i<font color="#990000">++)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter a value for ages[ "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" ]: "</font> <font color="#990000">;</font>
-        cin <font color="#990000">&gt;&gt;</font> ages<font color="#990000">[</font>i<font color="#990000">];</font>
-    <font color="#FF0000">}</font>
+    <i><span style="color:#9A1900">// use a loop to prompt the user to initialize the array</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> i<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> n<span style="color:#990000">;</span> i<span style="color:#990000">++)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter a value for ages[ "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" ]: "</span> <span style="color:#990000">;</span>
+        cin <span style="color:#990000">&gt;&gt;</span> ages<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span>
 
-    <i><font color="#9A1900">// print out the contents of the array</font></i>
-    <b><font color="#0000FF">for</font></b><font color="#990000">(</font><font color="#009900">int</font> i<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font> i<font color="#990000">&lt;</font>n<font color="#990000">;</font> i<font color="#990000">++)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"ages[ "</font> <font color="#990000">&lt;&lt;</font> i <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" ]: "</font> <font color="#990000">&lt;&lt;</font> ages<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" , "</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print out the contents of the array</span></i>
+    <b><span style="color:#0000FF">for</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> i<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span> i<span style="color:#990000">&lt;</span>n<span style="color:#990000">;</span> i<span style="color:#990000">++)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"ages[ "</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" ]: "</span> <span style="color:#990000">&lt;&lt;</span> ages<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" , "</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// finished with the array, clean up the memory used by calling delete</font></i>
-    <b><font color="#0000FF">delete</font></b> <font color="#990000">[]</font> ages<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <i><span style="color:#9A1900">// finished with the array, clean up the memory used by calling delete</span></i>
+    <b><span style="color:#0000FF">delete</span></b> <span style="color:#990000">[]</span> ages<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/evenodd.cpp.html
+++ b/slides/code/01-cpp/evenodd.cpp.html
@@ -1,41 +1,41 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>evenodd.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">even</font></b> <font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">even</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">odd</font></b> <font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> x <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        <b><font color="#0000FF">return</font></b> <b><font color="#000000">even</font></b> <font color="#990000">(</font>x<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">odd</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> x <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">even</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">even</font></b> <font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> x <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b>
-        <b><font color="#0000FF">return</font></b> <b><font color="#000000">odd</font></b> <font color="#990000">(</font>x<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">even</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> x <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">odd</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> x<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter a non-zero integer: "</font><font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> x<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"This number is even: "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">even</font></b><font color="#990000">(</font>x<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"This number is odd: "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">odd</font></b><font color="#990000">(</font>x<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> x<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter a non-zero integer: "</span><span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> x<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"This number is even: "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">even</span></b><span style="color:#990000">(</span>x<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"This number is odd: "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">odd</span></b><span style="color:#990000">(</span>x<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/evenodd.cpp.html
+++ b/slides/code/01-cpp/evenodd.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/memory.cpp.html
+++ b/slides/code/01-cpp/memory.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/memory.cpp.html
+++ b/slides/code/01-cpp/memory.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,32 +8,32 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>memory.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">Foo</font> <font color="#FF0000">{</font>
-    <font color="#009900">long</font> x<font color="#990000">,</font> y<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Foo</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">long</span> x<span style="color:#990000">,</span> y<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"sizeof(long): "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">sizeof</font></b><font color="#990000">(</font><font color="#009900">long</font><font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"sizeof(Foo): "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">sizeof</font></b><font color="#990000">(</font>Foo<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"sizeof(long): "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#0000FF">sizeof</span></b><span style="color:#990000">(</span><span style="color:#009900">long</span><span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"sizeof(Foo): "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#0000FF">sizeof</span></b><span style="color:#990000">(</span>Foo<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <font color="#008080">Foo</font> <font color="#990000">*</font>qux <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">Foo</font></b><font color="#990000">();</font>
-    <font color="#008080">Foo</font> <font color="#990000">*</font>bar <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">Foo</font></b><font color="#990000">();</font>
+    <span style="color:#008080">Foo</span> <span style="color:#990000">*</span>qux <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Foo</span></b><span style="color:#990000">();</span>
+    <span style="color:#008080">Foo</span> <span style="color:#990000">*</span>bar <span style="color:#990000">=</span> <b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Foo</span></b><span style="color:#990000">();</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"1st Foo: "</font> <font color="#990000">&lt;&lt;</font> qux <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"2nd Foo: "</font> <font color="#990000">&lt;&lt;</font> bar <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"1st Foo: "</span> <span style="color:#990000">&lt;&lt;</span> qux <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"2nd Foo: "</span> <span style="color:#990000">&lt;&lt;</span> bar <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <font color="#009900">long</font> diff <font color="#990000">=</font> <font color="#990000">((</font><font color="#009900">long</font><font color="#990000">)</font>bar<font color="#990000">)-((</font><font color="#009900">long</font><font color="#990000">)</font>qux<font color="#990000">);</font>
+    <span style="color:#009900">long</span> diff <span style="color:#990000">=</span> <span style="color:#990000">((</span><span style="color:#009900">long</span><span style="color:#990000">)</span>bar<span style="color:#990000">)-((</span><span style="color:#009900">long</span><span style="color:#990000">)</span>qux<span style="color:#990000">);</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Difference: "</font> <font color="#990000">&lt;&lt;</font> diff <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Difference: "</span> <span style="color:#990000">&lt;&lt;</span> diff <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">delete</font></b> qux<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> bar<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">delete</span></b> qux<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> bar<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/pointers.cpp.html
+++ b/slides/code/01-cpp/pointers.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/pointers.cpp.html
+++ b/slides/code/01-cpp/pointers.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,68 +8,68 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pointers.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* Original author: Michele Co, CS 216, Spring 2007</font></i>
-<i><font color="#9A1900"> * Updated by Aaron Bloomfield, CS 2150, Spring 2017</font></i>
-<i><font color="#9A1900"> * Filename: pointers.cpp</font></i>
-<i><font color="#9A1900"> * Description: Examples demonstrating pointers and C++ syntax related to pointers</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * To force 64-bit operation, this file will have to be compiled with</font></i>
-<i><font color="#9A1900"> * the -m64 flag</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* Original author: Michele Co, CS 216, Spring 2007</span></i>
+<i><span style="color:#9A1900"> * Updated by Aaron Bloomfield, CS 2150, Spring 2017</span></i>
+<i><span style="color:#9A1900"> * Filename: pointers.cpp</span></i>
+<i><span style="color:#9A1900"> * Description: Examples demonstrating pointers and C++ syntax related to pointers</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * To force 64-bit operation, this file will have to be compiled with</span></i>
+<i><span style="color:#9A1900"> * the -m64 flag</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// declare and initialize some int variables (we use longs to</font></i>
-    <i><font color="#9A1900">// ensure 64-bit operation)</font></i>
-    <font color="#009900">long</font> y <font color="#990000">=</font> <font color="#993399">5</font><font color="#990000">;</font>
-    <font color="#009900">long</font> x <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// declare and initialize some int variables (we use longs to</span></i>
+    <i><span style="color:#9A1900">// ensure 64-bit operation)</span></i>
+    <span style="color:#009900">long</span> y <span style="color:#990000">=</span> <span style="color:#993399">5</span><span style="color:#990000">;</span>
+    <span style="color:#009900">long</span> x <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// declare a pointer to int and initialize to the address of x</font></i>
-    <font color="#009900">long</font> <font color="#990000">*</font> x_pointer <font color="#990000">=</font> <font color="#990000">&amp;</font>x<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// declare a pointer to int and initialize to the address of x</span></i>
+    <span style="color:#009900">long</span> <span style="color:#990000">*</span> x_pointer <span style="color:#990000">=</span> <span style="color:#990000">&amp;</span>x<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// print the values of each of these variables</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x = "</font> <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"y = "</font> <font color="#990000">&lt;&lt;</font> y <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x_pointer = "</font> <font color="#990000">&lt;&lt;</font> x_pointer <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*x_pointer = "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>x_pointer <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print the values of each of these variables</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x = "</span> <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"y = "</span> <span style="color:#990000">&lt;&lt;</span> y <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> x_pointer <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>x_pointer <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// change the value of the memory pointed to by x_pointer</font></i>
-    <i><font color="#9A1900">// by dereferencing and assigning a new value</font></i>
-    <font color="#990000">*</font>x_pointer <font color="#990000">=</font> <font color="#993399">2</font><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// change the value of the memory pointed to by x_pointer</span></i>
+    <i><span style="color:#9A1900">// by dereferencing and assigning a new value</span></i>
+    <span style="color:#990000">*</span>x_pointer <span style="color:#990000">=</span> <span style="color:#993399">2</span><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// print the values of all variables</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After *x_pointer = 2 "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x = "</font> <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"y = "</font> <font color="#990000">&lt;&lt;</font> y <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x_pointer = "</font> <font color="#990000">&lt;&lt;</font> x_pointer <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*x_pointer = "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>x_pointer <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print the values of all variables</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After *x_pointer = 2 "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x = "</span> <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"y = "</span> <span style="color:#990000">&lt;&lt;</span> y <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> x_pointer <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>x_pointer <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// change the address that x_pointer points to, to y</font></i>
-    x_pointer <font color="#990000">=</font> <font color="#990000">&amp;</font>y<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// change the address that x_pointer points to, to y</span></i>
+    x_pointer <span style="color:#990000">=</span> <span style="color:#990000">&amp;</span>y<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// print the values of all variables</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After x_pointer = &amp;y "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x = "</font> <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"y = "</font> <font color="#990000">&lt;&lt;</font> y <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x_pointer = "</font> <font color="#990000">&lt;&lt;</font> x_pointer <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*x_pointer = "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>x_pointer <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print the values of all variables</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After x_pointer = &amp;y "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x = "</span> <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"y = "</span> <span style="color:#990000">&lt;&lt;</span> y <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> x_pointer <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>x_pointer <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// change the value of the memory pointed to by x_pointer</font></i>
-    <i><font color="#9A1900">// by dereferencing and assigning a new value</font></i>
-    <font color="#990000">*</font>x_pointer <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
+    <i><span style="color:#9A1900">// change the value of the memory pointed to by x_pointer</span></i>
+    <i><span style="color:#9A1900">// by dereferencing and assigning a new value</span></i>
+    <span style="color:#990000">*</span>x_pointer <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
 
-    <i><font color="#9A1900">// print the values of all variables</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After *x_pointer = 3 "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x = "</font> <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"y = "</font> <font color="#990000">&lt;&lt;</font> y <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"x_pointer = "</font> <font color="#990000">&lt;&lt;</font> x_pointer <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"*x_pointer = "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>x_pointer <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    <i><span style="color:#9A1900">// print the values of all variables</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After *x_pointer = 3 "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x = "</span> <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"y = "</span> <span style="color:#990000">&lt;&lt;</span> y <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> x_pointer <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"*x_pointer = "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>x_pointer <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/swap.cpp.html
+++ b/slides/code/01-cpp/swap.cpp.html
@@ -1,37 +1,37 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>swap.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* swap()</font></i>
-<i><font color="#9A1900"> *	common use for pointers</font></i>
-<i><font color="#9A1900"> *  demonstrates use of * to dereference, * to declare pointer, and &amp; to pass an address</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* swap()</span></i>
+<i><span style="color:#9A1900"> *	common use for pointers</span></i>
+<i><span style="color:#9A1900"> *  demonstrates use of * to dereference, * to declare pointer, and &amp; to pass an address</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">swap</font></b><font color="#990000">(</font><font color="#009900">int</font> <font color="#990000">*</font> x<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">*</font> y<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> temp <font color="#990000">=</font> <font color="#990000">*</font>x<font color="#990000">;</font>	<i><font color="#9A1900">//temp = dereference x</font></i>
-    <font color="#990000">*</font>x <font color="#990000">=</font> <font color="#990000">*</font>y<font color="#990000">;</font>
-    <font color="#990000">*</font>y <font color="#990000">=</font> temp<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">swap</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> <span style="color:#990000">*</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">*</span> y<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> temp <span style="color:#990000">=</span> <span style="color:#990000">*</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">//temp = dereference x</span></i>
+    <span style="color:#990000">*</span>x <span style="color:#990000">=</span> <span style="color:#990000">*</span>y<span style="color:#990000">;</span>
+    <span style="color:#990000">*</span>y <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> a<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#009900">int</font> b<font color="#990000">=</font><font color="#993399">3</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Before swap(): a: "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" b: "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">swap</font></b><font color="#990000">(&amp;</font>b<font color="#990000">,&amp;</font>a<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After swap(): a: "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" b: "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> a<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> b<span style="color:#990000">=</span><span style="color:#993399">3</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Before swap(): a: "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" b: "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">swap</span></b><span style="color:#990000">(&amp;</span>b<span style="color:#990000">,&amp;</span>a<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After swap(): a: "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" b: "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/01-cpp/swap.cpp.html
+++ b/slides/code/01-cpp/swap.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/swapref.cpp.html
+++ b/slides/code/01-cpp/swapref.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/01-cpp/swapref.cpp.html
+++ b/slides/code/01-cpp/swapref.cpp.html
@@ -1,35 +1,35 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>swapref.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* swap() with references</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* swap() with references</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">swap</font></b><font color="#990000">(</font><font color="#009900">int</font> <font color="#990000">&amp;</font> x<font color="#990000">,</font> <font color="#009900">int</font> <font color="#990000">&amp;</font> y<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> temp <font color="#990000">=</font> x<font color="#990000">;</font>
-    x <font color="#990000">=</font> y<font color="#990000">;</font>
-    y <font color="#990000">=</font> temp<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">swap</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> <span style="color:#990000">&amp;</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> <span style="color:#990000">&amp;</span> y<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> temp <span style="color:#990000">=</span> x<span style="color:#990000">;</span>
+    x <span style="color:#990000">=</span> y<span style="color:#990000">;</span>
+    y <span style="color:#990000">=</span> temp<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> a<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    <font color="#009900">int</font> b<font color="#990000">=</font><font color="#993399">3</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Before swap(): a: "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"b: "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#000000">swap</font></b><font color="#990000">(</font>b<font color="#990000">,</font>a<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"After swap(): a: "</font> <font color="#990000">&lt;&lt;</font> a <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"b: "</font> <font color="#990000">&lt;&lt;</font> b <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> a<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> b<span style="color:#990000">=</span><span style="color:#993399">3</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Before swap(): a: "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"b: "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#000000">swap</span></b><span style="color:#990000">(</span>b<span style="color:#990000">,</span>a<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"After swap(): a: "</span> <span style="color:#990000">&lt;&lt;</span> a <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"b: "</span> <span style="color:#990000">&lt;&lt;</span> b <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/02-lists/findMax.cpp.html
+++ b/slides/code/02-lists/findMax.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/02-lists/findMax.cpp.html
+++ b/slides/code/02-lists/findMax.cpp.html
@@ -1,61 +1,61 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>findMax.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This code requires the IntCell.h/cpp code from the 02-cpp slide set</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This code requires the IntCell.h/cpp code from the 02-cpp slide set</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;vector&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"IntCell.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;vector&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"IntCell.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">template</font></b> <font color="#990000">&lt;</font><b><font color="#0000FF">typename</font></b> <font color="#008080">Comparable</font><font color="#990000">&gt;</font>
-<b><font color="#0000FF">const</font></b> Comparable <font color="#990000">&amp;</font> <b><font color="#000000">findMax</font></b> <font color="#990000">(</font><b><font color="#0000FF">const</font></b> vector<font color="#990000">&lt;</font>Comparable<font color="#990000">&gt;</font> <font color="#990000">&amp;</font> a<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> maxIndex <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b><font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> a<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">(</font> <font color="#990000">);</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">if</font></b><font color="#990000">(</font> a<font color="#990000">[</font> maxIndex <font color="#990000">]</font> <font color="#990000">&lt;</font> a<font color="#990000">[</font> i <font color="#990000">]</font> <font color="#990000">)</font> <i><font color="#9A1900">// note the use of '&lt;'</font></i>
-            maxIndex <font color="#990000">=</font> i<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> a<font color="#990000">[</font> maxIndex <font color="#990000">];</font>
-<font color="#FF0000">}</font>
+<b><span style="color:#0000FF">template</span></b> <span style="color:#990000">&lt;</span><b><span style="color:#0000FF">typename</span></b> <span style="color:#008080">Comparable</span><span style="color:#990000">&gt;</span>
+<b><span style="color:#0000FF">const</span></b> Comparable <span style="color:#990000">&amp;</span> <b><span style="color:#000000">findMax</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> vector<span style="color:#990000">&lt;</span>Comparable<span style="color:#990000">&gt;</span> <span style="color:#990000">&amp;</span> a<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> maxIndex <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> a<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">(</span> <span style="color:#990000">);</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">if</span></b><span style="color:#990000">(</span> a<span style="color:#990000">[</span> maxIndex <span style="color:#990000">]</span> <span style="color:#990000">&lt;</span> a<span style="color:#990000">[</span> i <span style="color:#990000">]</span> <span style="color:#990000">)</span> <i><span style="color:#9A1900">// note the use of '&lt;'</span></i>
+            maxIndex <span style="color:#990000">=</span> i<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> a<span style="color:#990000">[</span> maxIndex <span style="color:#990000">];</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">vector&lt;int&gt;</font> <b><font color="#000000">v1</font></b><font color="#990000">(</font><font color="#993399">37</font><font color="#990000">);</font>
-    <font color="#008080">vector&lt;double&gt;</font> <b><font color="#000000">v2</font></b><font color="#990000">(</font><font color="#993399">40</font><font color="#990000">);</font>
-    <font color="#008080">vector&lt;string&gt;</font> <b><font color="#000000">v3</font></b><font color="#990000">(</font><font color="#993399">80</font><font color="#990000">);</font>
-    <font color="#008080">vector&lt;IntCell&gt;</font> <b><font color="#000000">v4</font></b><font color="#990000">(</font><font color="#993399">75</font><font color="#990000">);</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">vector&lt;int&gt;</span> <b><span style="color:#000000">v1</span></b><span style="color:#990000">(</span><span style="color:#993399">37</span><span style="color:#990000">);</span>
+    <span style="color:#008080">vector&lt;double&gt;</span> <b><span style="color:#000000">v2</span></b><span style="color:#990000">(</span><span style="color:#993399">40</span><span style="color:#990000">);</span>
+    <span style="color:#008080">vector&lt;string&gt;</span> <b><span style="color:#000000">v3</span></b><span style="color:#990000">(</span><span style="color:#993399">80</span><span style="color:#990000">);</span>
+    <span style="color:#008080">vector&lt;IntCell&gt;</span> <b><span style="color:#000000">v4</span></b><span style="color:#990000">(</span><span style="color:#993399">75</span><span style="color:#990000">);</span>
 
-    v1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">);</font>
-    v1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">7</font><font color="#990000">);</font>
-    v1<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
+    v1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">);</span>
+    v1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">7</span><span style="color:#990000">);</span>
+    v1<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
 
-    v2<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">3.14</font><font color="#990000">);</font>
-    v2<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">2.718</font><font color="#990000">);</font>
-    v2<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(-</font><font color="#993399">1.0</font><font color="#990000">);</font>
+    v2<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">3.14</span><span style="color:#990000">);</span>
+    v2<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">2.718</span><span style="color:#990000">);</span>
+    v2<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(-</span><span style="color:#993399">1.0</span><span style="color:#990000">);</span>
 
-    v3<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"aardvark"</font><font color="#990000">);</font>
-    v3<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"sloth"</font><font color="#990000">);</font>
-    v3<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"platypus"</font><font color="#990000">);</font>
-    v3<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#FF0000">"zebra"</font><font color="#990000">);</font>
+    v3<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"aardvark"</span><span style="color:#990000">);</span>
+    v3<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"sloth"</span><span style="color:#990000">);</span>
+    v3<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"platypus"</span><span style="color:#990000">);</span>
+    v3<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"zebra"</span><span style="color:#990000">);</span>
 
-    v4<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><b><font color="#000000">IntCell</font></b><font color="#990000">(</font><font color="#993399">3</font><font color="#990000">));</font>
-    v4<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><b><font color="#000000">IntCell</font></b><font color="#990000">(</font><font color="#993399">7</font><font color="#990000">));</font>
-    v4<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><b><font color="#000000">IntCell</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">));</font>
+    v4<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><b><span style="color:#000000">IntCell</span></b><span style="color:#990000">(</span><span style="color:#993399">3</span><span style="color:#990000">));</span>
+    v4<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><b><span style="color:#000000">IntCell</span></b><span style="color:#990000">(</span><span style="color:#993399">7</span><span style="color:#990000">));</span>
+    v4<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><b><span style="color:#000000">IntCell</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">));</span>
 
-    cout <font color="#990000">&lt;&lt;</font> <b><font color="#000000">findMax</font></b><font color="#990000">(</font>v1<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>  <i><font color="#9A1900">// ok: Comparable = int</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <b><font color="#000000">findMax</font></b><font color="#990000">(</font>v2<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>  <i><font color="#9A1900">// ok: Comparable = double</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <b><font color="#000000">findMax</font></b><font color="#990000">(</font>v3<font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>  <i><font color="#9A1900">// ok: Comparable = string</font></i>
-    <i><font color="#9A1900">//cout &lt;&lt; findMax(v4) &lt;&lt; endl;  // Illegal: no operator&lt;</font></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">findMax</span></b><span style="color:#990000">(</span>v1<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>  <i><span style="color:#9A1900">// ok: Comparable = int</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">findMax</span></b><span style="color:#990000">(</span>v2<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>  <i><span style="color:#9A1900">// ok: Comparable = double</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">findMax</span></b><span style="color:#990000">(</span>v3<span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>  <i><span style="color:#9A1900">// ok: Comparable = string</span></i>
+    <i><span style="color:#9A1900">//cout &lt;&lt; findMax(v4) &lt;&lt; endl;  // Illegal: no operator&lt;</span></i>
 
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/02-lists/objectCell.h.html
+++ b/slides/code/02-lists/objectCell.h.html
@@ -1,36 +1,36 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>objectCell.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> OBJECTCELL_H
-<b><font color="#000080">#define</font></b> OBJECTCELL_H
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> OBJECTCELL_H
+<b><span style="color:#000080">#define</span></b> OBJECTCELL_H
 
-<b><font color="#0000FF">template</font></b> <font color="#990000">&lt;</font><b><font color="#0000FF">typename</font></b> <font color="#008080">Object</font><font color="#990000">&gt;</font>
-<b><font color="#0000FF">class</font></b> <font color="#008080">ObjectCell</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">ObjectCell</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> Object <font color="#990000">&amp;</font> initValue <font color="#990000">=</font> <b><font color="#000000">Object</font></b><font color="#990000">())</font> <font color="#990000">:</font> <b><font color="#000000">storedValue</font></b><font color="#990000">(</font>initValue<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#FF0000">}</font>
+<b><span style="color:#0000FF">template</span></b> <span style="color:#990000">&lt;</span><b><span style="color:#0000FF">typename</span></b> <span style="color:#008080">Object</span><span style="color:#990000">&gt;</span>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">ObjectCell</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">ObjectCell</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> Object <span style="color:#990000">&amp;</span> initValue <span style="color:#990000">=</span> <b><span style="color:#000000">Object</span></b><span style="color:#990000">())</span> <span style="color:#990000">:</span> <b><span style="color:#000000">storedValue</span></b><span style="color:#990000">(</span>initValue<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#FF0000">}</span>
 
-    <b><font color="#0000FF">const</font></b> Object <font color="#990000">&amp;</font> <b><font color="#000000">getValue</font></b><font color="#990000">()</font> <b><font color="#0000FF">const</font></b> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">return</font></b> storedValue<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <b><span style="color:#0000FF">const</span></b> Object <span style="color:#990000">&amp;</span> <b><span style="color:#000000">getValue</span></b><span style="color:#990000">()</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">return</span></b> storedValue<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">setValue</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> Object <font color="#990000">&amp;</font> val<font color="#990000">)</font> <font color="#FF0000">{</font>
-        storedValue <font color="#990000">=</font> val<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> Object <span style="color:#990000">&amp;</span> val<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        storedValue <span style="color:#990000">=</span> val<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">Object</font> storedValue<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">Object</span> storedValue<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/slides/code/02-lists/objectCell.h.html
+++ b/slides/code/02-lists/objectCell.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/02-lists/objectCellMain.cpp.html
+++ b/slides/code/02-lists/objectCellMain.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/02-lists/objectCellMain.cpp.html
+++ b/slides/code/02-lists/objectCellMain.cpp.html
@@ -1,26 +1,26 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>objectCellMain.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"objectCell.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"objectCell.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">ObjectCell&lt;int&gt;</font> m1<font color="#990000">;</font>
-    <font color="#008080">ObjectCell&lt;double&gt;</font> <b><font color="#000000">m2</font></b><font color="#990000">(</font><font color="#993399">3.14</font><font color="#990000">);</font>
-    m1<font color="#990000">.</font><b><font color="#000000">setValue</font></b><font color="#990000">(</font><font color="#993399">37</font><font color="#990000">);</font>
-    m2<font color="#990000">.</font><b><font color="#000000">setValue</font></b><font color="#990000">(</font>m2<font color="#990000">.</font><b><font color="#000000">getValue</font></b><font color="#990000">()</font> <font color="#990000">*</font><font color="#993399">2</font><font color="#990000">);</font>
-    <i><font color="#9A1900">// ...</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">ObjectCell&lt;int&gt;</span> m1<span style="color:#990000">;</span>
+    <span style="color:#008080">ObjectCell&lt;double&gt;</span> <b><span style="color:#000000">m2</span></b><span style="color:#990000">(</span><span style="color:#993399">3.14</span><span style="color:#990000">);</span>
+    m1<span style="color:#990000">.</span><b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span><span style="color:#993399">37</span><span style="color:#990000">);</span>
+    m2<span style="color:#990000">.</span><b><span style="color:#000000">setValue</span></b><span style="color:#990000">(</span>m2<span style="color:#990000">.</span><b><span style="color:#000000">getValue</span></b><span style="color:#990000">()</span> <span style="color:#990000">*</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// ...</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/03-numbers/float_to_hex.cpp.html
+++ b/slides/code/03-numbers/float_to_hex.cpp.html
@@ -1,30 +1,30 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>float_to_hex.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// This should be compiled with the -m32 flag, so as to make the</font></i>
-<i><font color="#9A1900">// pointer a 32-bit memory address.</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// This should be compiled with the -m32 flag, so as to make the</span></i>
+<i><span style="color:#9A1900">// pointer a 32-bit memory address.</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">union</font></b> foo <font color="#FF0000">{</font>
-    <font color="#009900">float</font> f<font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>x<font color="#990000">;</font>
-<font color="#FF0000">}</font> bar<font color="#990000">;</font>
+<b><span style="color:#0000FF">union</span></b> foo <span style="color:#FF0000">{</span>
+    <span style="color:#009900">float</span> f<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>x<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span> bar<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    bar<font color="#990000">.</font>f <font color="#990000">=</font> <font color="#993399">42.125</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> bar<font color="#990000">.</font>x <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font> <i><font color="#9A1900">// prints in big-endian</font></i>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    bar<span style="color:#990000">.</span>f <span style="color:#990000">=</span> <span style="color:#993399">42.125</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> bar<span style="color:#990000">.</span>x <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span> <i><span style="color:#9A1900">// prints in big-endian</span></i>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/03-numbers/float_to_hex.cpp.html
+++ b/slides/code/03-numbers/float_to_hex.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/04-arrays-bigoh/cmdlineparams.cpp.html
+++ b/slides/code/04-arrays-bigoh/cmdlineparams.cpp.html
@@ -1,36 +1,36 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>cmdlineparams.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// handling command-line parameters</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// handling command-line parameters</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font><font color="#990000">*</font> argv<font color="#990000">[])</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// the command-line parameters are stored as C-style strings in the</font></i>
-    <i><font color="#9A1900">// argv[] array. argc contains 1 more than the number of command</font></i>
-    <i><font color="#9A1900">// line parmaeters specified.</font></i>
-    <i><font color="#9A1900">// the 0th command line parameter is always the program name.</font></i>
-    <i><font color="#9A1900">// we can print a C-style string directly through cout:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"This program is called '"</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"'"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The following are the command line parameters you specified: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <i><font color="#9A1900">// this for loop starts at 1 to avoid printing the name of the program</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> argc<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <i><font color="#9A1900">// we can convert the C-style strings into C++-style strings:</font></i>
-        <font color="#008080">string</font> <b><font color="#000000">s</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">]);</font>
-        <i><font color="#9A1900">// and then print them out:</font></i>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> s <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span><span style="color:#990000">*</span> argv<span style="color:#990000">[])</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// the command-line parameters are stored as C-style strings in the</span></i>
+    <i><span style="color:#9A1900">// argv[] array. argc contains 1 more than the number of command</span></i>
+    <i><span style="color:#9A1900">// line parmaeters specified.</span></i>
+    <i><span style="color:#9A1900">// the 0th command line parameter is always the program name.</span></i>
+    <i><span style="color:#9A1900">// we can print a C-style string directly through cout:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"This program is called '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The following are the command line parameters you specified: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// this for loop starts at 1 to avoid printing the name of the program</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> argc<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <i><span style="color:#9A1900">// we can convert the C-style strings into C++-style strings:</span></i>
+        <span style="color:#008080">string</span> <b><span style="color:#000000">s</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">]);</span>
+        <i><span style="color:#9A1900">// and then print them out:</span></i>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> s <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/04-arrays-bigoh/cmdlineparams.cpp.html
+++ b/slides/code/04-arrays-bigoh/cmdlineparams.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/Makefile.html
+++ b/slides/code/08-assembly-32bit/Makefile.html
@@ -1,54 +1,46 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Makefile</title>
 </head>
-<body bgcolor="white">
-<pre><tt><font color="#990000">main:</font>
-	@echo You should <b><font color="#0000FF">read</font></b> the readme.txt file<font color="#990000">!</font>
+<body style="background-color:white">
+<pre><span style="color:#990000">main:</span>
+	@echo You should <b><span style="color:#0000FF">read</span></b> the readme.txt file<span style="color:#990000">!</span>
 
-<font color="#990000">compile:</font>
+<span style="color:#990000">compile:</span>
 	gcc -o test_abs_c test_abs_c.c
-	g<font color="#990000">++</font> -o test_abs test_abs.cpp
-	g<font color="#990000">++</font> -o test_fib test_fib.cpp
-	g<font color="#990000">++</font> -o test_max test_max.cpp
-	g<font color="#990000">++</font> -o test_string_compare test_string_compare.cpp
+	g<span style="color:#990000">++</span> -o test_abs test_abs.cpp
+	g<span style="color:#990000">++</span> -o test_fib test_fib.cpp
+	g<span style="color:#990000">++</span> -o test_max test_max.cpp
+	g<span style="color:#990000">++</span> -o test_string_compare test_string_compare.cpp
 
-<font color="#990000">asm:</font>
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_abs_c.c -o test_abs_c.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_abs.cpp -o test_abs.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_fib.cpp -o test_fib.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_string_compare.cpp -o test_string_compare.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_max.cpp -o test_max.s
-	g<font color="#990000">++</font> -O<font color="#993399">2</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_max.cpp -o test_max-O2.s
-	grep -v extern test_max.cpp <font color="#990000">&gt;</font> foo.cpp
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S foo.cpp -o test_max-noextern.s
+<span style="color:#990000">asm:</span>
+	gcc -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_abs_c.c -o test_abs_c.s
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -S test_abs.cpp -o test_abs-non-intel.s
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_abs.cpp -o test_abs.s
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_fib.cpp -o test_fib.s
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_string_compare.cpp -o test_string_compare.s
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_max.cpp -o test_max.s
+	g<span style="color:#990000">++</span> -O<span style="color:#993399">2</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S test_max.cpp -o test_max-O2.s
+	grep -v extern test_max.cpp <span style="color:#990000">&gt;</span> foo.cpp
+	g<span style="color:#990000">++</span> -m<span style="color:#993399">32</span> -masm<span style="color:#990000">=</span>intel -S foo.cpp -o test_max-noextern.s
 	/bin/rm -rf foo.cpp
 
-<font color="#990000">asmclang:</font>
-	clang -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_abs_c.c -o test_abs_c.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -S test_abs.cpp -o test_abs-non-intel.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_abs.cpp -o test_abs.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_fib.cpp -o test_fib.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_string_compare.cpp -o test_string_compare.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_max.cpp -o test_max.s
-	clang<font color="#990000">++</font> -O<font color="#993399">2</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_max.cpp -o test_max-O2.s
-	grep -v extern test_max.cpp <font color="#990000">&gt;</font> foo.cpp
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S foo.cpp -o test_max-noextern.s
-	/bin/rm -rf foo.cpp
-
-<font color="#990000">clean:</font>
-	/bin/rm -f test_abs_c test_abs_c.exe test_fib test_fib.exe test_max <font color="#990000">\</font>
-		test_max.exe test_string_compare test_string_compare.exe <font color="#990000">\</font>
+<span style="color:#990000">clean:</span>
+	/bin/rm -f test_abs_c test_abs_c.exe test_fib test_fib.exe test_max <span style="color:#990000">\</span>
+		test_max.exe test_string_compare test_string_compare.exe <span style="color:#990000">\</span>
 		test_abs test_abs.exe
 
-<font color="#990000">asmclean:</font>
-	/bin/rm -f <font color="#990000">*</font>.s
-</tt></pre>
+<span style="color:#990000">asmclean:</span>
+	/bin/rm -f <span style="color:#990000">*</span>.s
+
+<span style="color:#990000">source-highlight:</span>
+	source-highlight -d <span style="color:#990000">*</span>.s <span style="color:#990000">*</span>.c <span style="color:#990000">*</span>.cpp
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/Makefile.html
+++ b/slides/code/08-assembly-32bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_abs-non-intel.s.html
+++ b/slides/code/08-assembly-32bit/test_abs-non-intel.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_abs-non-intel.s.html
+++ b/slides/code/08-assembly-32bit/test_abs-non-intel.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,172 +8,172 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs-non-intel.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_abs.cpp"</font>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	absolute_value
-	.type	absolute_value, @function
-absolute_value:
-.LFB1021:
-	.cfi_startproc
-	pushl	%ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	movl	<font color="#990000">%esp, %</font>ebp
-	.cfi_def_cfa_register 5
-	cmpl	$0, 8(%ebp)
-	jns	.L2
-	negl	8(%ebp)
-.L2:
-	movl	8(<font color="#990000">%ebp), %</font>eax
-	popl	%ebp
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	absolute_value, .-absolute_value
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter a value: "</font>
-.LC1:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	leal	4(<font color="#990000">%esp), %</font>ecx
-	.cfi_def_cfa 1, 0
-	andl	$-16, %esp
-	pushl	-4(%ecx)
-	pushl	%ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	movl	<font color="#990000">%esp, %</font>ebp
-	pushl	%ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	subl	$20, %esp
-	movl	<font color="#990000">%gs:20, %</font>eax
-	movl	<font color="#990000">%eax, -12(%</font>ebp)
-	xorl	<font color="#990000">%eax, %</font>eax
-	movl	$0, -20(%ebp)
-	subl	$8, %esp
-	pushl	$.LC0
-	pushl	$_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	addl	$16, %esp
-	subl	$8, %esp
-	pushl	$_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	pushl	%eax
-	call	_ZNSolsEPFRSoS_E
-	addl	$16, %esp
-	subl	$8, %esp
-	leal	-20(<font color="#990000">%ebp), %</font>eax
-	pushl	%eax
-	pushl	$_ZSt3cin
-	call	_ZNSirsERi
-	addl	$16, %esp
-	movl	-20(<font color="#990000">%ebp), %</font>eax
-	subl	$12, %esp
-	pushl	%eax
-	call	absolute_value
-	addl	$16, %esp
-	movl	<font color="#990000">%eax, -16(%</font>ebp)
-	subl	$8, %esp
-	pushl	$.LC1
-	pushl	$_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	addl	$16, %esp
-	subl	$8, %esp
-	pushl	-16(%ebp)
-	pushl	%eax
-	call	_ZNSolsEi
-	addl	$16, %esp
-	subl	$8, %esp
-	pushl	$_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	pushl	%eax
-	call	_ZNSolsEPFRSoS_E
-	addl	$16, %esp
-	movl	$0, %eax
-	movl	-12(<font color="#990000">%ebp), %</font>edx
-	xorl	<font color="#990000">%gs:20, %</font>edx
-	je	.L6
-	call	__stack_chk_fail
-.L6:
-	movl	-4(<font color="#990000">%ebp), %</font>ecx
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	leal	-4(<font color="#990000">%ecx), %</font>esp
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1031:
-	.cfi_startproc
-	pushl	%ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	movl	<font color="#990000">%esp, %</font>ebp
-	.cfi_def_cfa_register 5
-	subl	$8, %esp
-	cmpl	$1, 8(%ebp)
-	jne	.L9
-	cmpl	$65535, 12(%ebp)
-	jne	.L9
-	subl	$12, %esp
-	pushl	$_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	addl	$16, %esp
-	subl	$4, %esp
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs.cpp"</span>
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span> @function
+absolute_value<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	cmpl	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#993399">8</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	<b><span style="color:#0000FF">jns</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	negl	<span style="color:#993399">8</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	movl	<span style="color:#993399">8</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	popl	<span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.-</span>absolute_value
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	leal	<span style="color:#993399">4</span><span style="color:#990000">(%</span><span style="color:#009900">esp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	andl	$<span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	<span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">(%</span><span style="color:#009900">ecx</span><span style="color:#990000">)</span>
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	subl	$<span style="color:#993399">20</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	xorl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	movl	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$<span style="color:#990000">.</span>LC<span style="color:#993399">0</span>
+	pushl	$_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	leal	<span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	pushl	$_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	movl	<span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	subl	$<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$<span style="color:#990000">.</span>LC<span style="color:#993399">1</span>
+	pushl	$_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	<span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	movl	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	movl	<span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">edx</span>
+	xorl	<span style="color:#990000">%</span><span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">6</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L6</span></b><span style="color:#990000">:</span>
+	movl	<span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	leal	<span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">(%</span><span style="color:#009900">ecx</span><span style="color:#990000">),</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	cmpl	$<span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">8</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">9</span>
+	cmpl	$<span style="color:#993399">65535</span><span style="color:#990000">,</span> <span style="color:#993399">12</span><span style="color:#990000">(%</span><span style="color:#009900">ebp</span><span style="color:#990000">)</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">9</span>
+	subl	$<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
 	pushl	$__dso_handle
-	pushl	$_ZStL8__ioinit
-	pushl	$_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	addl	$16, %esp
-.L9:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1031:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I_absolute_value, @function
-_GLOBAL__sub_I_absolute_value:
-.LFB1032:
-	.cfi_startproc
-	pushl	%ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	movl	<font color="#990000">%esp, %</font>ebp
-	.cfi_def_cfa_register 5
-	subl	$8, %esp
-	subl	$8, %esp
-	pushl	$65535
-	pushl	$1
-	call	_Z41__static_initialization_and_destruction_0ii
-	addl	$16, %esp
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1032:
-	.size	_GLOBAL__sub_I_absolute_value, .-_GLOBAL__sub_I_absolute_value
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_absolute_value
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+	pushl	$_ZStL<span style="color:#993399">8</span>__ioinit
+	pushl	$_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+<b><span style="color:#000080">.L9</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_absolute_value<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_absolute_value<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	pushl	<span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	subl	$<span style="color:#993399">8</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	pushl	$<span style="color:#993399">65535</span>
+	pushl	$<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	addl	$<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_absolute_value
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_absolute_value
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_abs.cpp.html
+++ b/slides/code/08-assembly-32bit/test_abs.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_abs.cpp.html
+++ b/slides/code/08-assembly-32bit/test_abs.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,25 +8,25 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x<font color="#990000">&lt;</font><font color="#993399">0</font><font color="#990000">)</font>	<i><font color="#9A1900">// if x is negative</font></i>
-        x <font color="#990000">=</font> <font color="#990000">-</font>x<font color="#990000">;</font>	<i><font color="#9A1900">// negate x</font></i>
-    <b><font color="#0000FF">return</font></b> x<font color="#990000">;</font>	<i><font color="#9A1900">// return x</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">&lt;</span><span style="color:#993399">0</span><span style="color:#990000">)</span>	<i><span style="color:#9A1900">// if x is negative</span></i>
+        x <span style="color:#990000">=</span> <span style="color:#990000">-</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// negate x</span></i>
+    <b><span style="color:#0000FF">return</span></b> x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return x</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter a value: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue<font color="#990000">;</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter a value: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_abs.s.html
+++ b/slides/code/08-assembly-32bit/test_abs.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,173 +8,173 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_abs.cpp"</font>
-	.intel_syntax noprefix
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	absolute_value
-	.type	absolute_value, @function
-absolute_value:
-.LFB1021:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	cmp	DWORD PTR [ebp+8], 0
-	jns	.L2
-	neg	DWORD PTR [ebp+8]
-.L2:
-	mov	eax, DWORD PTR [ebp+8]
-	pop	ebp
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	absolute_value, .-absolute_value
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter a value: "</font>
-.LC1:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	sub	esp, 20
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	mov	DWORD PTR [ebp-20], 0
-	sub	esp, 8
-	push	OFFSET FLAT:.LC0
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-20]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	mov	eax, DWORD PTR [ebp-20]
-	sub	esp, 12
-	push	eax
-	call	absolute_value
-	add	esp, 16
-	mov	DWORD PTR [ebp-16], eax
-	sub	esp, 8
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	DWORD PTR [ebp-16]
-	push	eax
-	call	_ZNSolsEi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	mov	eax, 0
-	mov	edx, DWORD PTR [ebp-12]
-	xor	edx, DWORD PTR gs:20
-	je	.L6
-	call	__stack_chk_fail
-.L6:
-	mov	ecx, DWORD PTR [ebp-4]
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1031:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L9
-	cmp	DWORD PTR [ebp+12], 65535
-	jne	.L9
-	sub	esp, 12
-	push	OFFSET FLAT:_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 16
-	sub	esp, 4
-	push	OFFSET FLAT:__dso_handle
-	push	OFFSET FLAT:_ZStL8__ioinit
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	add	esp, 16
-.L9:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1031:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I_absolute_value, @function
-_GLOBAL__sub_I_absolute_value:
-.LFB1032:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	sub	esp, 8
-	push	65535
-	push	1
-	call	_Z41__static_initialization_and_destruction_0ii
-	add	esp, 16
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1032:
-	.size	_GLOBAL__sub_I_absolute_value, .-_GLOBAL__sub_I_absolute_value
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_absolute_value
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span> @function
+absolute_value<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jns</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">neg</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.-</span>absolute_value
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">6</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L6</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">9</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">9</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+<b><span style="color:#000080">.L9</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_absolute_value<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_absolute_value<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_absolute_value
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_absolute_value
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_abs.s.html
+++ b/slides/code/08-assembly-32bit/test_abs.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_abs_c.c.html
+++ b/slides/code/08-assembly-32bit/test_abs_c.c.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_abs_c.c.html
+++ b/slides/code/08-assembly-32bit/test_abs_c.c.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,23 +8,23 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_c.c</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x<font color="#990000">&lt;</font><font color="#993399">0</font><font color="#990000">)</font>	<i><font color="#9A1900">// if x is negative</font></i>
-        x <font color="#990000">=</font> <font color="#990000">-</font>x<font color="#990000">;</font>	<i><font color="#9A1900">// negate x</font></i>
-    <b><font color="#0000FF">return</font></b> x<font color="#990000">;</font>	<i><font color="#9A1900">// return x</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">&lt;</span><span style="color:#993399">0</span><span style="color:#990000">)</span>	<i><span style="color:#9A1900">// if x is negative</span></i>
+        x <span style="color:#990000">=</span> <span style="color:#990000">-</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// negate x</span></i>
+    <b><span style="color:#0000FF">return</span></b> x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return x</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Enter a value: </font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">scanf</font></b> <font color="#990000">(</font><font color="#FF0000">"%d"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>theValue<font color="#990000">);</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"The result is: %d</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> theResult<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Enter a value: </span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">scanf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>theValue<span style="color:#990000">);</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"The result is: %d</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> theResult<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_abs_c.s.html
+++ b/slides/code/08-assembly-32bit/test_abs_c.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,98 +8,98 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_c.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_abs_c.c"</font>
-	.intel_syntax noprefix
-	.text
-	.globl	absolute_value
-	.type	absolute_value, @function
-absolute_value:
-.LFB0:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	cmp	DWORD PTR [ebp+8], 0
-	jns	.L2
-	neg	DWORD PTR [ebp+8]
-.L2:
-	mov	eax, DWORD PTR [ebp+8]
-	pop	ebp
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE0:
-	.size	absolute_value, .-absolute_value
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter a value: "</font>
-.LC1:
-	.string	<font color="#FF0000">"%d"</font>
-.LC2:
-	.string	<font color="#FF0000">"The result is: %d</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	sub	esp, 20
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	mov	DWORD PTR [ebp-20], 0
-	sub	esp, 12
-	push	OFFSET FLAT:.LC0
-	call	puts
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-20]
-	push	eax
-	push	OFFSET FLAT:.LC1
-	call	__isoc99_scanf
-	add	esp, 16
-	mov	eax, DWORD PTR [ebp-20]
-	sub	esp, 12
-	push	eax
-	call	absolute_value
-	add	esp, 16
-	mov	DWORD PTR [ebp-16], eax
-	sub	esp, 8
-	push	DWORD PTR [ebp-16]
-	push	OFFSET FLAT:.LC2
-	call	printf
-	add	esp, 16
-	mov	eax, 0
-	mov	edx, DWORD PTR [ebp-12]
-	xor	edx, DWORD PTR gs:20
-	je	.L6
-	call	__stack_chk_fail
-.L6:
-	mov	ecx, DWORD PTR [ebp-4]
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1:
-	.size	main, .-main
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs_c.c"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span> @function
+absolute_value<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jns</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">neg</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.-</span>absolute_value
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"%d"</span>
+<b><span style="color:#000080">.LC2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: %d</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	puts
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	__isoc<span style="color:#993399">99</span>_scanf
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">call</span></b>	printf
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">6</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L6</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_abs_c.s.html
+++ b/slides/code/08-assembly-32bit/test_abs_c.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_fib.cpp.html
+++ b/slides/code/08-assembly-32bit/test_fib.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_fib.cpp.html
+++ b/slides/code/08-assembly-32bit/test_fib.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,26 +8,26 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_fib.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">fib</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> n<font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">fib</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> n<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">fib</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">((</font>n<font color="#990000">==</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(</font>n<font color="#990000">==</font><font color="#993399">1</font><font color="#990000">))</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <b><font color="#000000">fib</font></b><font color="#990000">(</font>n<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">+</font> <b><font color="#000000">fib</font></b><font color="#990000">(</font>n<font color="#990000">-</font><font color="#993399">2</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">fib</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">((</span>n<span style="color:#990000">==</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(</span>n<span style="color:#990000">==</span><span style="color:#993399">1</span><span style="color:#990000">))</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <b><span style="color:#000000">fib</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">+</span> <b><span style="color:#000000">fib</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-</span><span style="color:#993399">2</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value for fib(): "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue<font color="#990000">;</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">fib</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value for fib(): "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">fib</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_fib.s.html
+++ b/slides/code/08-assembly-32bit/test_fib.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,196 +8,196 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_fib.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_fib.cpp"</font>
-	.intel_syntax noprefix
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	fib
-	.type	fib, @function
-fib:
-.LFB1021:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	push	ebx
-	sub	esp, 4
-	.cfi_offset 3, -12
-	cmp	DWORD PTR [ebp+8], 0
-	je	.L2
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L3
-.L2:
-	mov	eax, 1
-	jmp	.L4
-.L3:
-	mov	eax, DWORD PTR [ebp+8]
-	sub	eax, 1
-	sub	esp, 12
-	push	eax
-	call	fib
-	add	esp, 16
-	mov	ebx, eax
-	mov	eax, DWORD PTR [ebp+8]
-	sub	eax, 2
-	sub	esp, 12
-	push	eax
-	call	fib
-	add	esp, 16
-	add	eax, ebx
-.L4:
-	mov	ebx, DWORD PTR [ebp-4]
-	leave
-	.cfi_restore 5
-	.cfi_restore 3
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	fib, .-fib
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter value for fib(): "</font>
-.LC1:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	sub	esp, 20
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	mov	DWORD PTR [ebp-20], 0
-	sub	esp, 8
-	push	OFFSET FLAT:.LC0
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-20]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	mov	eax, DWORD PTR [ebp-20]
-	sub	esp, 12
-	push	eax
-	call	fib
-	add	esp, 16
-	mov	DWORD PTR [ebp-16], eax
-	sub	esp, 8
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	DWORD PTR [ebp-16]
-	push	eax
-	call	_ZNSolsEi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	mov	eax, 0
-	mov	edx, DWORD PTR [ebp-12]
-	xor	edx, DWORD PTR gs:20
-	je	.L7
-	call	__stack_chk_fail
-.L7:
-	mov	ecx, DWORD PTR [ebp-4]
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1031:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L10
-	cmp	DWORD PTR [ebp+12], 65535
-	jne	.L10
-	sub	esp, 12
-	push	OFFSET FLAT:_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 16
-	sub	esp, 4
-	push	OFFSET FLAT:__dso_handle
-	push	OFFSET FLAT:_ZStL8__ioinit
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	add	esp, 16
-.L10:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1031:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I_fib, @function
-_GLOBAL__sub_I_fib:
-.LFB1032:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	sub	esp, 8
-	push	65535
-	push	1
-	call	_Z41__static_initialization_and_destruction_0ii
-	add	esp, 16
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1032:
-	.size	_GLOBAL__sub_I_fib, .-_GLOBAL__sub_I_fib
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_fib
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_fib.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	fib
+<b><span style="color:#000080">	.type</span></b>	fib<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">fib:</span></b>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">3</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">3</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">4</span>
+<b><span style="color:#000080">.L3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	fib
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	fib
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+<b><span style="color:#000080">.L4</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">3</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	fib<span style="color:#990000">,</span> <span style="color:#990000">.-</span>fib
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value for fib(): "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	fib
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">7</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L7</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+<b><span style="color:#000080">.L10</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_fib<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_fib<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_fib<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_fib
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_fib
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_fib.s.html
+++ b/slides/code/08-assembly-32bit/test_fib.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_max-O2.s.html
+++ b/slides/code/08-assembly-32bit/test_max-O2.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,174 +8,174 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max-O2.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_max.cpp"</font>
-	.intel_syntax noprefix
-	.section	.text.unlikely,<font color="#FF0000">"ax"</font>,@progbits
-.LCOLDB0:
-	.text
-.LHOTB0:
-	.p2align 4,,15
-	.globl	max
-	.type	max, @function
-max:
-.LFB1048:
-	.cfi_startproc
-	mov	eax, DWORD PTR [esp+4]
-	mov	edx, DWORD PTR [esp+8]
-	cmp	eax, edx
-	cmovl	eax, edx
-	ret
-	.cfi_endproc
-.LFE1048:
-	.size	max, .-max
-	.section	.text.unlikely
-.LCOLDE0:
-	.text
-.LHOTE0:
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.LC1:
-	.string	<font color="#FF0000">"Enter value 1: "</font>
-.LC2:
-	.string	<font color="#FF0000">"Enter value 2: "</font>
-.LC3:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.section	.text.unlikely
-.LCOLDB4:
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-.LHOTB4:
-	.p2align 4,,15
-	.globl	main
-	.type	main, @function
-main:
-.LFB1049:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ebx
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x78,0x6
-	.cfi_escape 0x10,0x3,0x2,0x75,0x7c
-	sub	esp, 20
-	mov	DWORD PTR [ebp-20], 0
-	mov	DWORD PTR [ebp-16], 0
-	push	15
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_i
-	mov	DWORD PTR [esp], OFFSET FLAT:_ZSt4cout
-	call	_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	pop	eax
-	lea	eax, [ebp-20]
-	pop	edx
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 12
-	push	15
-	push	OFFSET FLAT:.LC2
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_i
-	mov	DWORD PTR [esp], OFFSET FLAT:_ZSt4cout
-	call	_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	pop	ecx
-	lea	eax, [ebp-16]
-	pop	ebx
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	mov	eax, DWORD PTR [ebp-16]
-	mov	ebx, DWORD PTR [ebp-20]
-	add	esp, 12
-	push	15
-	push	OFFSET FLAT:.LC3
-	push	OFFSET FLAT:_ZSt4cout
-	cmp	eax, ebx
-	cmovge	ebx, eax
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_i
-	pop	eax
-	pop	edx
-	push	ebx
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZNSolsEi
-	mov	DWORD PTR [esp], eax
-	call	_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	add	esp, 16
-	mov	edx, DWORD PTR [ebp-12]
-	xor	edx, DWORD PTR gs:20
-	jne	.L6
-	lea	esp, [ebp-8]
-	xor	eax, eax
-	pop	ecx
-	.cfi_remember_state
-	.cfi_restore 1
-	.cfi_def_cfa 1, 0
-	pop	ebx
-	.cfi_restore 3
-	pop	ebp
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-.L6:
-	.cfi_restore_state
-	call	__stack_chk_fail
-	.cfi_endproc
-.LFE1049:
-	.size	main, .-main
-	.section	.text.unlikely
-.LCOLDE4:
-	.section	.text.startup
-.LHOTE4:
-	.section	.text.unlikely
-.LCOLDB5:
-	.section	.text.startup
-.LHOTB5:
-	.p2align 4,,15
-	.type	_GLOBAL__sub_I_max, @function
-_GLOBAL__sub_I_max:
-.LFB1059:
-	.cfi_startproc
-	sub	esp, 24
-	.cfi_def_cfa_offset 28
-	push	OFFSET FLAT:_ZStL8__ioinit
-	.cfi_def_cfa_offset 32
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 12
-	.cfi_def_cfa_offset 20
-	push	OFFSET FLAT:__dso_handle
-	.cfi_def_cfa_offset 24
-	push	OFFSET FLAT:_ZStL8__ioinit
-	.cfi_def_cfa_offset 28
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	.cfi_def_cfa_offset 32
-	call	__cxa_atexit
-	add	esp, 28
-	.cfi_def_cfa_offset 4
-	ret
-	.cfi_endproc
-.LFE1059:
-	.size	_GLOBAL__sub_I_max, .-_GLOBAL__sub_I_max
-	.section	.text.unlikely
-.LCOLDE5:
-	.section	.text.startup
-.LHOTE5:
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_max
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_max.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">.LCOLDB0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">.LHOTB0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.p2align</span></b> <span style="color:#993399">4</span><span style="color:#990000">,,</span><span style="color:#993399">15</span>
+<b><span style="color:#000080">	.globl</span></b>	max
+<b><span style="color:#000080">	.type</span></b>	max<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">max:</span></b>
+<b><span style="color:#000080">.LFB1048</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">edx</span>
+	cmovl	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1048</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	max<span style="color:#990000">,</span> <span style="color:#990000">.-</span>max
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely
+<b><span style="color:#000080">.LCOLDE0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">.LHOTE0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">.LC2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">.LC3</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely
+<b><span style="color:#000080">.LCOLDB4</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">.LHOTB4</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.p2align</span></b> <span style="color:#993399">4</span><span style="color:#990000">,,</span><span style="color:#993399">15</span>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1049</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x78</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_i
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">],</span> <b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_i
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">],</span> <b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">3</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+	cmovge	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_i
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">6</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_remember_state
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">1</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebx</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">3</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.L6</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore_state
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1049</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely
+<b><span style="color:#000080">.LCOLDE4</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup
+<b><span style="color:#000080">.LHOTE4</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely
+<b><span style="color:#000080">.LCOLDB5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup
+<b><span style="color:#000080">.LHOTB5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.p2align</span></b> <span style="color:#993399">4</span><span style="color:#990000">,,</span><span style="color:#993399">15</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_max<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_max<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1059</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">24</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">28</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">32</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">24</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">28</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">32</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">28</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1059</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_max<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_max
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>unlikely
+<b><span style="color:#000080">.LCOLDE5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup
+<b><span style="color:#000080">.LHOTE5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_max
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_max-O2.s.html
+++ b/slides/code/08-assembly-32bit/test_max-O2.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_max-noextern.s.html
+++ b/slides/code/08-assembly-32bit/test_max-noextern.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,201 +8,201 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max-noextern.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"foo.cpp"</font>
-	.intel_syntax noprefix
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	_Z3maxii
-	.type	_Z3maxii, @function
-_Z3maxii:
-.LFB1021:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 16
-	mov	eax, DWORD PTR [ebp+8]
-	cmp	eax, DWORD PTR [ebp+12]
-	jle	.L2
-	mov	eax, DWORD PTR [ebp+8]
-	mov	DWORD PTR [ebp-4], eax
-	jmp	.L3
-.L2:
-	mov	eax, DWORD PTR [ebp+12]
-	mov	DWORD PTR [ebp-4], eax
-.L3:
-	mov	eax, DWORD PTR [ebp-4]
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	_Z3maxii, .-_Z3maxii
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter value 1: "</font>
-.LC1:
-	.string	<font color="#FF0000">"Enter value 2: "</font>
-.LC2:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	sub	esp, 20
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	mov	DWORD PTR [ebp-24], 0
-	mov	DWORD PTR [ebp-20], 0
-	sub	esp, 8
-	push	OFFSET FLAT:.LC0
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-24]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-20]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	mov	edx, DWORD PTR [ebp-20]
-	mov	eax, DWORD PTR [ebp-24]
-	sub	esp, 8
-	push	edx
-	push	eax
-	call	_Z3maxii
-	add	esp, 16
-	mov	DWORD PTR [ebp-16], eax
-	sub	esp, 8
-	push	OFFSET FLAT:.LC2
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	DWORD PTR [ebp-16]
-	push	eax
-	call	_ZNSolsEi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	mov	eax, 0
-	mov	ecx, DWORD PTR [ebp-12]
-	xor	ecx, DWORD PTR gs:20
-	je	.L7
-	call	__stack_chk_fail
-.L7:
-	mov	ecx, DWORD PTR [ebp-4]
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1031:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L10
-	cmp	DWORD PTR [ebp+12], 65535
-	jne	.L10
-	sub	esp, 12
-	push	OFFSET FLAT:_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 16
-	sub	esp, 4
-	push	OFFSET FLAT:__dso_handle
-	push	OFFSET FLAT:_ZStL8__ioinit
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	add	esp, 16
-.L10:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1031:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I__Z3maxii, @function
-_GLOBAL__sub_I__Z3maxii:
-.LFB1032:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	sub	esp, 8
-	push	65535
-	push	1
-	call	_Z41__static_initialization_and_destruction_0ii
-	add	esp, 16
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1032:
-	.size	_GLOBAL__sub_I__Z3maxii, .-_GLOBAL__sub_I__Z3maxii
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I__Z3maxii
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"foo.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	_Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jle</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">3</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.L3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">.LC2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">3</span>maxii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">7</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L7</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+<b><span style="color:#000080">.L10</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I__Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I__Z<span style="color:#993399">3</span>maxii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I__Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I__Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I__Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_max-noextern.s.html
+++ b/slides/code/08-assembly-32bit/test_max-noextern.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_max.cpp.html
+++ b/slides/code/08-assembly-32bit/test_max.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,30 +8,30 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#009900">int</font> y<font color="#990000">);</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> y<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#009900">int</font> y<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theMax<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">&gt;</font> y<font color="#990000">)</font> 		<i><font color="#9A1900">// if x &gt; y then x is max</font></i>
-        theMax <font color="#990000">=</font> x<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> 		<i><font color="#9A1900">// else y is the max</font></i>
-        theMax <font color="#990000">=</font> y<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> theMax<font color="#990000">;</font>	<i><font color="#9A1900">// return the max</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> y<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theMax<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">&gt;</span> y<span style="color:#990000">)</span> 		<i><span style="color:#9A1900">// if x &gt; y then x is max</span></i>
+        theMax <span style="color:#990000">=</span> x<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> 		<i><span style="color:#9A1900">// else y is the max</span></i>
+        theMax <span style="color:#990000">=</span> y<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> theMax<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return the max</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue1<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">,</font> theValue2<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value 1: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue1<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value 2: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue2<font color="#990000">;</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">max</font></b><font color="#990000">(</font>theValue1<font color="#990000">,</font> theValue2<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue1<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">,</span> theValue2<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value 1: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue1<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value 2: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue2<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span>theValue1<span style="color:#990000">,</span> theValue2<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_max.cpp.html
+++ b/slides/code/08-assembly-32bit/test_max.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_max.s.html
+++ b/slides/code/08-assembly-32bit/test_max.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_max.s.html
+++ b/slides/code/08-assembly-32bit/test_max.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,201 +8,201 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_max.cpp"</font>
-	.intel_syntax noprefix
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	max
-	.type	max, @function
-max:
-.LFB1021:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 16
-	mov	eax, DWORD PTR [ebp+8]
-	cmp	eax, DWORD PTR [ebp+12]
-	jle	.L2
-	mov	eax, DWORD PTR [ebp+8]
-	mov	DWORD PTR [ebp-4], eax
-	jmp	.L3
-.L2:
-	mov	eax, DWORD PTR [ebp+12]
-	mov	DWORD PTR [ebp-4], eax
-.L3:
-	mov	eax, DWORD PTR [ebp-4]
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	max, .-max
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter value 1: "</font>
-.LC1:
-	.string	<font color="#FF0000">"Enter value 2: "</font>
-.LC2:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x7c,0x6
-	sub	esp, 20
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	mov	DWORD PTR [ebp-24], 0
-	mov	DWORD PTR [ebp-20], 0
-	sub	esp, 8
-	push	OFFSET FLAT:.LC0
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-24]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-20]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZNSirsERi
-	add	esp, 16
-	mov	edx, DWORD PTR [ebp-20]
-	mov	eax, DWORD PTR [ebp-24]
-	sub	esp, 8
-	push	edx
-	push	eax
-	call	max
-	add	esp, 16
-	mov	DWORD PTR [ebp-16], eax
-	sub	esp, 8
-	push	OFFSET FLAT:.LC2
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	DWORD PTR [ebp-16]
-	push	eax
-	call	_ZNSolsEi
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	mov	eax, 0
-	mov	ecx, DWORD PTR [ebp-12]
-	xor	ecx, DWORD PTR gs:20
-	je	.L7
-	call	__stack_chk_fail
-.L7:
-	mov	ecx, DWORD PTR [ebp-4]
-	.cfi_def_cfa 1, 0
-	leave
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1031:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L10
-	cmp	DWORD PTR [ebp+12], 65535
-	jne	.L10
-	sub	esp, 12
-	push	OFFSET FLAT:_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 16
-	sub	esp, 4
-	push	OFFSET FLAT:__dso_handle
-	push	OFFSET FLAT:_ZStL8__ioinit
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	add	esp, 16
-.L10:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1031:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I_max, @function
-_GLOBAL__sub_I_max:
-.LFB1032:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	sub	esp, 8
-	push	65535
-	push	1
-	call	_Z41__static_initialization_and_destruction_0ii
-	add	esp, 16
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1032:
-	.size	_GLOBAL__sub_I_max, .-_GLOBAL__sub_I_max
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_max
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_max.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	max
+<b><span style="color:#000080">	.type</span></b>	max<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">max:</span></b>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jle</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">3</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.L3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	max<span style="color:#990000">,</span> <span style="color:#990000">.-</span>max
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">.LC2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">20</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	max
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">7</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L7</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+<b><span style="color:#000080">.L10</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1031</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_max<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_max<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1032</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_max<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_max
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_max
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_string_compare.cpp.html
+++ b/slides/code/08-assembly-32bit/test_string_compare.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-32bit/test_string_compare.cpp.html
+++ b/slides/code/08-assembly-32bit/test_string_compare.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,34 +8,34 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_string_compare.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">bool</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font><font color="#990000">*</font> theStr1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#009900">char</font><font color="#990000">*</font> theStr2<font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">bool</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span><span style="color:#990000">*</span> theStr1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span><span style="color:#990000">*</span> theStr2<span style="color:#990000">);</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>theStr1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>theStr2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// while *theStr1 is not NULL terminator</font></i>
-    <i><font color="#9A1900">// and the current corresponding bytes are equal</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <font color="#990000">(*</font>theStr1 <font color="#990000">!=</font> <font color="#993399">0</font><font color="#990000">)</font>
-            <font color="#990000">&amp;&amp;</font> <font color="#990000">(*</font>theStr1 <font color="#990000">==</font> <font color="#990000">*</font>theStr2<font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        theStr1<font color="#990000">++;</font>		<i><font color="#9A1900">// increment the pointers to</font></i>
-        theStr2<font color="#990000">++;</font>		<i><font color="#9A1900">// the next char / byte</font></i>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(*</font>theStr1<font color="#990000">==*</font>theStr2<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>theStr1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>theStr2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// while *theStr1 is not NULL terminator</span></i>
+    <i><span style="color:#9A1900">// and the current corresponding bytes are equal</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(*</span>theStr1 <span style="color:#990000">!=</span> <span style="color:#993399">0</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(*</span>theStr1 <span style="color:#990000">==</span> <span style="color:#990000">*</span>theStr2<span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        theStr1<span style="color:#990000">++;</span>		<i><span style="color:#9A1900">// increment the pointers to</span></i>
+        theStr2<span style="color:#990000">++;</span>		<i><span style="color:#9A1900">// the next char / byte</span></i>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(*</span>theStr1<span style="color:#990000">==*</span>theStr2<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> theValue1<font color="#990000">,</font> theValue2<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter string 1: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue1<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter string 2: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue2<font color="#990000">;</font>
-    <font color="#009900">bool</font> theResult <font color="#990000">=</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font>theValue1<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">(),</font> 					     theValue2<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> theValue1<span style="color:#990000">,</span> theValue2<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter string 1: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue1<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter string 2: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue2<span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span>theValue1<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">(),</span> 					     theValue2<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_string_compare.s.html
+++ b/slides/code/08-assembly-32bit/test_string_compare.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,316 +8,316 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_string_compare.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.file	<font color="#FF0000">"test_string_compare.cpp"</font>
-	.intel_syntax noprefix
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.text
-	.globl	compare_string
-	.type	compare_string, @function
-compare_string:
-.LFB1021:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-.L3:
-	mov	eax, DWORD PTR [ebp+8]
-	movzx	eax, BYTE PTR [eax]
-	test	al, al
-	je	.L2
-	mov	eax, DWORD PTR [ebp+8]
-	movzx	edx, BYTE PTR [eax]
-	mov	eax, DWORD PTR [ebp+12]
-	movzx	eax, BYTE PTR [eax]
-	cmp	dl, al
-	jne	.L2
-	add	DWORD PTR [ebp+8], 1
-	add	DWORD PTR [ebp+12], 1
-	jmp	.L3
-.L2:
-	mov	eax, DWORD PTR [ebp+8]
-	movzx	edx, BYTE PTR [eax]
-	mov	eax, DWORD PTR [ebp+12]
-	movzx	eax, BYTE PTR [eax]
-	cmp	dl, al
-	sete	al
-	pop	ebp
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1021:
-	.size	compare_string, .-compare_string
-	.section	.rodata
-.LC0:
-	.string	<font color="#FF0000">"Enter string 1: "</font>
-.LC1:
-	.string	<font color="#FF0000">"Enter string 2: "</font>
-.LC2:
-	.string	<font color="#FF0000">"The result is: "</font>
-	.text
-	.globl	main
-	.type	main, @function
-main:
-.LFB1022:
-	.cfi_startproc
-	.cfi_personality 0,__gxx_personality_v0
-	.cfi_lsda 0,.LLSDA1022
-	lea	ecx, [esp+4]
-	.cfi_def_cfa 1, 0
-	and	esp, -16
-	push	DWORD PTR [ecx-4]
-	push	ebp
-	.cfi_escape 0x10,0x5,0x2,0x75,0
-	mov	ebp, esp
-	push	ebx
-	push	ecx
-	.cfi_escape 0xf,0x3,0x75,0x78,0x6
-	.cfi_escape 0x10,0x3,0x2,0x75,0x7c
-	sub	esp, 64
-	mov	eax, DWORD PTR gs:20
-	mov	DWORD PTR [ebp-12], eax
-	xor	eax, eax
-	sub	esp, 12
-	lea	eax, [ebp-60]
-	push	eax
-.LEHB0:
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1Ev
-.LEHE0:
-	add	esp, 16
-	sub	esp, 12
-	lea	eax, [ebp-36]
-	push	eax
-.LEHB1:
-	.cfi_escape 0x2e,0x10
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1Ev
-.LEHE1:
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:.LC0
-	push	OFFSET FLAT:_ZSt4cout
-.LEHB2:
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-60]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:.LC1
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-	add	esp, 16
-	sub	esp, 8
-	lea	eax, [ebp-36]
-	push	eax
-	push	OFFSET FLAT:_ZSt3cin
-	call	_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
-	add	esp, 16
-	sub	esp, 12
-	lea	eax, [ebp-36]
-	push	eax
-	call	_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5c_strEv
-	add	esp, 16
-	mov	ebx, eax
-	sub	esp, 12
-	lea	eax, [ebp-60]
-	push	eax
-	call	_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE5c_strEv
-	add	esp, 16
-	sub	esp, 8
-	push	ebx
-	push	eax
-	call	compare_string
-	add	esp, 16
-	mov	BYTE PTR [ebp-61], al
-	movzx	ebx, BYTE PTR [ebp-61]
-	sub	esp, 8
-	push	OFFSET FLAT:.LC2
-	push	OFFSET FLAT:_ZSt4cout
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	add	esp, 16
-	sub	esp, 8
-	push	ebx
-	push	eax
-	call	_ZNSolsEb
-	add	esp, 16
-	sub	esp, 8
-	push	OFFSET FLAT:_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	push	eax
-	call	_ZNSolsEPFRSoS_E
-.LEHE2:
-	add	esp, 16
-	mov	ebx, 0
-	sub	esp, 12
-	lea	eax, [ebp-36]
-	push	eax
-.LEHB3:
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-.LEHE3:
-	add	esp, 16
-	sub	esp, 12
-	lea	eax, [ebp-60]
-	push	eax
-.LEHB4:
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-.LEHE4:
-	add	esp, 16
-	mov	eax, ebx
-	mov	edx, DWORD PTR [ebp-12]
-	xor	edx, DWORD PTR gs:20
-	je	.L9
-	jmp	.L12
-.L11:
-	mov	ebx, eax
-	sub	esp, 12
-	lea	eax, [ebp-36]
-	push	eax
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-	add	esp, 16
-	jmp	.L8
-.L10:
-	mov	ebx, eax
-.L8:
-	sub	esp, 12
-	lea	eax, [ebp-60]
-	push	eax
-	call	_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
-	add	esp, 16
-	mov	eax, ebx
-	sub	esp, 12
-	push	eax
-.LEHB5:
-	call	_Unwind_Resume
-.LEHE5:
-.L12:
-	call	__stack_chk_fail
-.L9:
-	lea	esp, [ebp-8]
-	pop	ecx
-	.cfi_restore 1
-	.cfi_def_cfa 1, 0
-	pop	ebx
-	.cfi_restore 3
-	pop	ebp
-	.cfi_restore 5
-	lea	esp, [ecx-4]
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1022:
-	.globl	__gxx_personality_v0
-	.section	.gcc_except_table,<font color="#FF0000">"a"</font>,@progbits
-.LLSDA1022:
-	.byte	0xff
-	.byte	0xff
-	.byte	0x1
-	.uleb128 .LLSDACSE1022-.LLSDACSB1022
-.LLSDACSB1022:
-	.uleb128 .LEHB0-.LFB1022
-	.uleb128 .LEHE0-.LEHB0
-	.uleb128 0
-	.uleb128 0
-	.uleb128 .LEHB1-.LFB1022
-	.uleb128 .LEHE1-.LEHB1
-	.uleb128 .L10-.LFB1022
-	.uleb128 0
-	.uleb128 .LEHB2-.LFB1022
-	.uleb128 .LEHE2-.LEHB2
-	.uleb128 .L11-.LFB1022
-	.uleb128 0
-	.uleb128 .LEHB3-.LFB1022
-	.uleb128 .LEHE3-.LEHB3
-	.uleb128 .L10-.LFB1022
-	.uleb128 0
-	.uleb128 .LEHB4-.LFB1022
-	.uleb128 .LEHE4-.LEHB4
-	.uleb128 0
-	.uleb128 0
-	.uleb128 .LEHB5-.LFB1022
-	.uleb128 .LEHE5-.LEHB5
-	.uleb128 0
-	.uleb128 0
-.LLSDACSE1022:
-	.text
-	.size	main, .-main
-	.type	_Z41__static_initialization_and_destruction_0ii, @function
-_Z41__static_initialization_and_destruction_0ii:
-.LFB1074:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	cmp	DWORD PTR [ebp+8], 1
-	jne	.L15
-	cmp	DWORD PTR [ebp+12], 65535
-	jne	.L15
-	sub	esp, 12
-	push	OFFSET FLAT:_ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	add	esp, 16
-	sub	esp, 4
-	push	OFFSET FLAT:__dso_handle
-	push	OFFSET FLAT:_ZStL8__ioinit
-	push	OFFSET FLAT:_ZNSt8ios_base4InitD1Ev
-	call	__cxa_atexit
-	add	esp, 16
-.L15:
-	nop
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1074:
-	.size	_Z41__static_initialization_and_destruction_0ii, .-_Z41__static_initialization_and_destruction_0ii
-	.type	_GLOBAL__sub_I_compare_string, @function
-_GLOBAL__sub_I_compare_string:
-.LFB1075:
-	.cfi_startproc
-	push	ebp
-	.cfi_def_cfa_offset 8
-	.cfi_offset 5, -8
-	mov	ebp, esp
-	.cfi_def_cfa_register 5
-	sub	esp, 8
-	sub	esp, 8
-	push	65535
-	push	1
-	call	_Z41__static_initialization_and_destruction_0ii
-	add	esp, 16
-	leave
-	.cfi_restore 5
-	.cfi_def_cfa 4, 4
-	ret
-	.cfi_endproc
-.LFE1075:
-	.size	_GLOBAL__sub_I_compare_string, .-_GLOBAL__sub_I_compare_string
-	.section	.init_array,<font color="#FF0000">"aw"</font>
-	.align 4
-	.long	_GLOBAL__sub_I_compare_string
-	.hidden	__dso_handle
-	.ident	<font color="#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</font>
-	.section	.note.GNU-stack,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_string_compare.cpp"</span>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	compare_string
+<b><span style="color:#000080">	.type</span></b>	compare_string<span style="color:#990000">,</span> @function
+compare_string<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+<b><span style="color:#000080">.L3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">eax</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">eax</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">eax</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">dl</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">add</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">add</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">3</span>
+<b><span style="color:#000080">.L2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">eax</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">eax</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">dl</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">sete</span></b>	<span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1021</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	compare_string<span style="color:#990000">,</span> <span style="color:#990000">.-</span>compare_string
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata
+<b><span style="color:#000080">.LC0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter string 1: "</span>
+<b><span style="color:#000080">.LC1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"Enter string 2: "</span>
+<b><span style="color:#000080">.LC2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.string</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span> @function
+<b><span style="color:#000080">main:</span></b>
+<b><span style="color:#000080">.LFB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+<b><span style="color:#000080">	.cfi</span></b>_personality <span style="color:#993399">0</span><span style="color:#990000">,</span>__gxx_personality_v<span style="color:#993399">0</span>
+<b><span style="color:#000080">	.cfi</span></b>_lsda <span style="color:#993399">0</span><span style="color:#990000">,.</span>LLSDA<span style="color:#993399">1022</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">esp</span><span style="color:#990000">+</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">and</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x5</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0xf</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x78</span><span style="color:#990000">,</span><span style="color:#993399">0x6</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x10</span><span style="color:#990000">,</span><span style="color:#993399">0x3</span><span style="color:#990000">,</span><span style="color:#993399">0x2</span><span style="color:#990000">,</span><span style="color:#993399">0x75</span><span style="color:#990000">,</span><span style="color:#993399">0x7c</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">64</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">mov</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">60</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LEHB0</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEEC<span style="color:#993399">1</span>Ev
+<b><span style="color:#000080">.LEHE0</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">36</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LEHB1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_escape <span style="color:#993399">0x2e</span><span style="color:#990000">,</span><span style="color:#993399">0x10</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEEC<span style="color:#993399">1</span>Ev
+<b><span style="color:#000080">.LEHE1</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+<b><span style="color:#000080">.LEHB2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">60</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZStrsIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEERSt<span style="color:#993399">13</span>basic_istreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">7</span>_RNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIS<span style="color:#993399">4</span>_S<span style="color:#993399">5</span>_T<span style="color:#993399">1</span>_EE
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">36</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZStrsIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEERSt<span style="color:#993399">13</span>basic_istreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">7</span>_RNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIS<span style="color:#993399">4</span>_S<span style="color:#993399">5</span>_T<span style="color:#993399">1</span>_EE
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">36</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEE<span style="color:#993399">5</span>c_strEv
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">60</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEE<span style="color:#993399">5</span>c_strEv
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	compare_string
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">61</span><span style="color:#990000">],</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> BYTE <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">61</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:.</span>LC<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEb
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+<b><span style="color:#000080">.LEHE2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">36</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LEHB3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">1</span>Ev
+<b><span style="color:#000080">.LEHE3</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">60</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LEHB4</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">1</span>Ev
+<b><span style="color:#000080">.LEHE4</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#009900">gs</span><span style="color:#990000">:</span><span style="color:#993399">20</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">9</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">12</span>
+<b><span style="color:#000080">.L11</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">36</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">8</span>
+<b><span style="color:#000080">.L10</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.L8</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">60</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LEHB5</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_Unwind_Resume
+<b><span style="color:#000080">.LEHE5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">.L12</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	__stack_chk_fail
+<b><span style="color:#000080">.L9</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ecx</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">1</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">1</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebx</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">3</span>
+	<b><span style="color:#0000FF">pop</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">lea</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#990000">[</span><span style="color:#009900">ecx</span><span style="color:#990000">-</span><span style="color:#993399">4</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.globl</span></b>	__gxx_personality_v<span style="color:#993399">0</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>gcc_except_table<span style="color:#990000">,</span><span style="color:#FF0000">"a"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">.LLSDA1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">0xff</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">0xff</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">0x1</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LLSDACSE<span style="color:#993399">1022</span><span style="color:#990000">-.</span>LLSDACSB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">.LLSDACSB1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">0</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">0</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">1</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">1</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">1</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>L<span style="color:#993399">10</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">2</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">2</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">2</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>L<span style="color:#993399">11</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">3</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">3</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">3</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>L<span style="color:#993399">10</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">4</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">4</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">4</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHB<span style="color:#993399">5</span><span style="color:#990000">-.</span>LFB<span style="color:#993399">1022</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#990000">.</span>LEHE<span style="color:#993399">5</span><span style="color:#990000">-.</span>LEHB<span style="color:#993399">5</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">	.uleb128</span></b> <span style="color:#993399">0</span>
+<b><span style="color:#000080">.LLSDACSE1022</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.-</span>main
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> @function
+_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1074</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">cmp</span></b>	DWORD <b><span style="color:#0000FF">PTR</span></b> <span style="color:#990000">[</span><span style="color:#009900">ebp</span><span style="color:#990000">+</span><span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>L<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>__dso_handle
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">push</span></b>	<b><span style="color:#0000FF">OFFSET</span></b> FLAT<span style="color:#990000">:</span>_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+<b><span style="color:#000080">.L15</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">nop</span></b>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1074</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_compare_string<span style="color:#990000">,</span> @function
+_GLOBAL__sub_I_compare_string<span style="color:#990000">:</span>
+<b><span style="color:#000080">.LFB1075</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#009900">ebp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">8</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset <span style="color:#993399">5</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebp</span><span style="color:#990000">,</span> <span style="color:#009900">esp</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_register <span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">65535</span>
+	<b><span style="color:#0000FF">push</span></b>	<span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">41</span>__static_initialization_and_destruction<span style="color:#993399">_0</span>ii
+	<b><span style="color:#0000FF">add</span></b>	<span style="color:#009900">esp</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">leave</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_restore <span style="color:#993399">5</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa <span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">.LFE1075</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_compare_string<span style="color:#990000">,</span> <span style="color:#990000">.-</span>_GLOBAL__sub_I_compare_string
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span>
+<b><span style="color:#000080">	.align</span></b> <span style="color:#993399">4</span>
+<b><span style="color:#000080">	.long</span></b>	_GLOBAL__sub_I_compare_string
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"GCC: (Ubuntu 5.4.0-6ubuntu1~16.04.2) 5.4.0 20160609"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>note<span style="color:#990000">.</span>GNU<span style="color:#990000">-</span>stack<span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-32bit/test_string_compare.s.html
+++ b/slides/code/08-assembly-32bit/test_string_compare.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/Makefile.html
+++ b/slides/code/08-assembly-64bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/Makefile.html
+++ b/slides/code/08-assembly-64bit/Makefile.html
@@ -1,54 +1,48 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Makefile</title>
 </head>
-<body bgcolor="white">
-<pre><tt><font color="#990000">main:</font>
-	@echo You should <b><font color="#0000FF">read</font></b> the readme.txt file<font color="#990000">!</font>
+<body style="background-color:white">
+<pre><span style="color:#009900">CXXASMFLAGS	=</span> -m<span style="color:#993399">64</span> -mllvm --x<span style="color:#993399">86</span>-asm-syntax<span style="color:#990000">=</span>intel -S -fomit-frame-pointer
+<span style="color:#990000">main:</span>
+	@echo You should <b><span style="color:#0000FF">read</span></b> the readme.txt file<span style="color:#990000">!</span>
 
-<font color="#990000">compile:</font>
+<span style="color:#990000">compile:</span>
 	gcc -o test_abs_c test_abs_c.c
-	g<font color="#990000">++</font> -o test_abs test_abs.cpp
-	g<font color="#990000">++</font> -o test_fib test_fib.cpp
-	g<font color="#990000">++</font> -o test_max test_max.cpp
-	g<font color="#990000">++</font> -o test_string_compare test_string_compare.cpp
+	g<span style="color:#990000">++</span> -o test_abs test_abs.cpp
+	g<span style="color:#990000">++</span> -o test_fib test_fib.cpp
+	g<span style="color:#990000">++</span> -o test_max test_max.cpp
+	g<span style="color:#990000">++</span> -o test_string_compare test_string_compare.cpp
 
-<font color="#990000">asm:</font>
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_abs_c.c -o test_abs_c.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_abs.cpp -o test_abs.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_fib.cpp -o test_fib.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_string_compare.cpp -o test_string_compare.s
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_max.cpp -o test_max.s
-	g<font color="#990000">++</font> -O<font color="#993399">2</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S test_max.cpp -o test_max-O2.s
-	grep -v extern test_max.cpp <font color="#990000">&gt;</font> foo.cpp
-	g<font color="#990000">++</font> -m<font color="#993399">32</font> -masm<font color="#990000">=</font>intel -S foo.cpp -o test_max-noextern.s
+<span style="color:#990000">asm:</span>
+	clang   <span style="color:#009900">$(CXXASMFLAGS)</span> test_abs_c.c -o test_abs_c.s
+	clang<span style="color:#990000">++</span> -m<span style="color:#993399">64</span> -S -fomit-frame-pointer test_abs.cpp -o test_abs-non-intel.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> test_abs.cpp -o test_abs.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> test_abs_int.cpp -o test_abs_int.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> -O<span style="color:#993399">2</span> test_fib.cpp -o test_fib.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> -O<span style="color:#993399">2</span> test_string_compare.cpp -o test_string_compare.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> test_max.cpp -o test_max.s
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> -O<span style="color:#993399">2</span> test_max.cpp -o test_max-O2.s
+	grep -v extern test_max.cpp <span style="color:#990000">&gt;</span> foo.cpp
+	clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXASMFLAGS)</span> foo.cpp -o test_max-noextern.s
 	/bin/rm -rf foo.cpp
 
-<font color="#990000">asmclang:</font>
-	clang -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_abs_c.c -o test_abs_c.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -S test_abs.cpp -o test_abs-non-intel.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_abs.cpp -o test_abs.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_fib.cpp -o test_fib.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_string_compare.cpp -o test_string_compare.s
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_max.cpp -o test_max.s
-	clang<font color="#990000">++</font> -O<font color="#993399">2</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S test_max.cpp -o test_max-O2.s
-	grep -v extern test_max.cpp <font color="#990000">&gt;</font> foo.cpp
-	clang<font color="#990000">++</font> -m<font color="#993399">32</font> -mllvm --x<font color="#993399">86</font>-asm-syntax<font color="#990000">=</font>intel -S foo.cpp -o test_max-noextern.s
-	/bin/rm -rf foo.cpp
-
-<font color="#990000">clean:</font>
-	/bin/rm -f test_abs_c test_abs_c.exe test_fib test_fib.exe test_max <font color="#990000">\</font>
-		test_max.exe test_string_compare test_string_compare.exe <font color="#990000">\</font>
+<span style="color:#990000">clean:</span>
+	/bin/rm -f test_abs_c test_abs_c.exe test_fib test_fib.exe test_max <span style="color:#990000">\</span>
+		test_max.exe test_string_compare test_string_compare.exe <span style="color:#990000">\</span>
 		test_abs test_abs.exe
 
-<font color="#990000">asmclean:</font>
-	/bin/rm -f <font color="#990000">*</font>.s
-</tt></pre>
+<span style="color:#990000">asmclean:</span>
+	/bin/rm -f <span style="color:#990000">*</span>.s
+
+<span style="color:#990000">source-highlight:</span>
+	source-highlight -d <span style="color:#990000">*</span>.s <span style="color:#990000">*</span>.c <span style="color:#990000">*</span>.cpp
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs-non-intel.s.html
+++ b/slides/code/08-assembly-64bit/test_abs-non-intel.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,132 +8,132 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs-non-intel.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.file	<font color="#FF0000">"test_abs.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	pushq	%rax
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	movabsq	$_ZStL8__ioinit, %rdi
-	callq	_ZNSt8ios_base4InitC1Ev
-	movabsq	$_ZNSt8ios_base4InitD1Ev, %rdi
-	movabsq	$_ZStL8__ioinit, %rsi
-	movabsq	$__dso_handle, %rdx
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	pushq	<span style="color:#990000">%</span>rax
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabsq	$_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
+	callq	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabsq	$_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
+	movabsq	$_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span> <span style="color:#990000">%</span>rsi
+	movabsq	$__dso_handle<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdx
 	callq	__cxa_atexit
-	movl	<font color="#990000">%eax, 4(%</font>rsp)           <i><font color="#9A1900"># 4-byte Spill</font></i>
-	popq	%rax
+	movl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">4</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>           # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	popq	<span style="color:#990000">%</span>rax
 	retq
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.text
-	.globl	absolute_value
-	.align	16, 0x90
-	.type	absolute_value,@function
-absolute_value:                         <i><font color="#9A1900"># @absolute_value</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	movq	<font color="#990000">%rdi, -8(%</font>rsp)
-	cmpq	$0, -8(%rsp)
-	jge	.LBB1_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	xorl	<font color="#990000">%eax, %</font>eax
-	movl	<font color="#990000">%eax, %</font>ecx
-	subq	-8(<font color="#990000">%rsp), %</font>rcx
-	movq	<font color="#990000">%rcx, -8(%</font>rsp)
-.LBB1_2:
-	movq	-8(<font color="#990000">%rsp), %</font>rax
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span>@function
+absolute_value<span style="color:#990000">:</span>                         # @absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	movq	<span style="color:#990000">%</span>rdi<span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+	cmpq	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+	<b><span style="color:#0000FF">jge</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	xorl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	movl	<span style="color:#990000">%</span><span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ecx</span>
+	subq	<span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">),</span> <span style="color:#990000">%</span>rcx
+	movq	<span style="color:#990000">%</span>rcx<span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	movq	<span style="color:#990000">-</span><span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">),</span> <span style="color:#990000">%</span>rax
 	retq
-.Lfunc_end1:
-	.size	absolute_value, .Lfunc_end1-absolute_value
-	.cfi_endproc
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	subq	$56, %rsp
-.Ltmp1:
-	.cfi_def_cfa_offset 64
-	movabsq	$_ZSt4cout, %rdi
-	movabsq	$.L.str, %rsi
-	movl	$0, 52(%rsp)
-	movq	$0, 40(%rsp)
-	callq	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabsq	$_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_, %rsi
-	movq	<font color="#990000">%rax, %</font>rdi
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	subq	$<span style="color:#993399">56</span><span style="color:#990000">,</span> <span style="color:#990000">%</span>rsp
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">64</span>
+	movabsq	$_ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
+	movabsq	$<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#990000">%</span>rsi
+	movl	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#993399">52</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+	movq	$<span style="color:#993399">0</span><span style="color:#990000">,</span> <span style="color:#993399">40</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+	callq	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabsq	$_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_<span style="color:#990000">,</span> <span style="color:#990000">%</span>rsi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
 	callq	_ZNSolsEPFRSoS_E
-	movabsq	$_ZSt3cin, %rdi
-	leaq	40(<font color="#990000">%rsp), %</font>rsi
-	movq	<font color="#990000">%rax, 24(%</font>rsp)          <i><font color="#9A1900"># 8-byte Spill</font></i>
+	movabsq	$_ZSt<span style="color:#993399">3</span>cin<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
+	leaq	<span style="color:#993399">40</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">),</span> <span style="color:#990000">%</span>rsi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#993399">24</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>          # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
 	callq	_ZNSirsERl
-	movq	40(<font color="#990000">%rsp), %</font>rdi
-	movq	<font color="#990000">%rax, 16(%</font>rsp)          <i><font color="#9A1900"># 8-byte Spill</font></i>
+	movq	<span style="color:#993399">40</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">),</span> <span style="color:#990000">%</span>rdi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#993399">16</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>          # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
 	callq	absolute_value
-	movabsq	$_ZSt4cout, %rdi
-	movabsq	$.L.str.1, %rsi
-	movq	<font color="#990000">%rax, 32(%</font>rsp)
-	callq	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movq	32(<font color="#990000">%rsp), %</font>rsi
-	movq	<font color="#990000">%rax, %</font>rdi
+	movabsq	$_ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
+	movabsq	$<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#990000">%</span>rsi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#993399">32</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>
+	callq	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movq	<span style="color:#993399">32</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">),</span> <span style="color:#990000">%</span>rsi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
 	callq	_ZNSolsEl
-	movabsq	$_ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_, %rsi
-	movq	<font color="#990000">%rax, %</font>rdi
+	movabsq	$_ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_<span style="color:#990000">,</span> <span style="color:#990000">%</span>rsi
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#990000">%</span>rdi
 	callq	_ZNSolsEPFRSoS_E
-	xorl	<font color="#990000">%ecx, %</font>ecx
-	movq	<font color="#990000">%rax, 8(%</font>rsp)           <i><font color="#9A1900"># 8-byte Spill</font></i>
-	movl	<font color="#990000">%ecx, %</font>eax
-	addq	$56, %rsp
+	xorl	<span style="color:#990000">%</span><span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">ecx</span>
+	movq	<span style="color:#990000">%</span>rax<span style="color:#990000">,</span> <span style="color:#993399">8</span><span style="color:#990000">(%</span>rsp<span style="color:#990000">)</span>           # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	movl	<span style="color:#990000">%</span><span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#990000">%</span><span style="color:#009900">eax</span>
+	addq	$<span style="color:#993399">56</span><span style="color:#990000">,</span> <span style="color:#990000">%</span>rsp
 	retq
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_abs.cpp,@function
-_GLOBAL__sub_I_test_abs.cpp:            <i><font color="#9A1900"># @_GLOBAL__sub_I_test_abs.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	pushq	%rax
-.Ltmp2:
-	.cfi_def_cfa_offset 16
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>            # @_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	pushq	<span style="color:#990000">%</span>rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
 	callq	__cxx_global_var_init
-	popq	%rax
+	popq	<span style="color:#990000">%</span>rax
 	retq
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_test_abs.cpp, .Lfunc_end3-_GLOBAL__sub_I_test_abs.cpp
-	.cfi_endproc
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter a value: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_abs.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs-non-intel.s.html
+++ b/slides/code/08-assembly-64bit/test_abs-non-intel.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs.cpp.html
+++ b/slides/code/08-assembly-64bit/test_abs.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs.cpp.html
+++ b/slides/code/08-assembly-64bit/test_abs.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,25 +8,25 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">long</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">long</font> x<font color="#990000">);</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">long</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">long</span> x<span style="color:#990000">);</span>
 
-<font color="#009900">long</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">long</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x<font color="#990000">&lt;</font><font color="#993399">0</font><font color="#990000">)</font>	<i><font color="#9A1900">// if x is negative</font></i>
-        x <font color="#990000">=</font> <font color="#990000">-</font>x<font color="#990000">;</font>	<i><font color="#9A1900">// negate x</font></i>
-    <b><font color="#0000FF">return</font></b> x<font color="#990000">;</font>	<i><font color="#9A1900">// return x</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">long</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">long</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">&lt;</span><span style="color:#993399">0</span><span style="color:#990000">)</span>	<i><span style="color:#9A1900">// if x is negative</span></i>
+        x <span style="color:#990000">=</span> <span style="color:#990000">-</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// negate x</span></i>
+    <b><span style="color:#0000FF">return</span></b> x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return x</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">long</font> theValue<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter a value: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue<font color="#990000">;</font>
-    <font color="#009900">long</font> theResult <font color="#990000">=</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">long</span> theValue<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter a value: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue<span style="color:#990000">;</span>
+    <span style="color:#009900">long</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs.s.html
+++ b/slides/code/08-assembly-64bit/test_abs.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs.s.html
+++ b/slides/code/08-assembly-64bit/test_abs.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,133 +8,133 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_abs.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	movabs	rdi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	movabs	rdi, _ZNSt8ios_base4InitD1Ev
-	movabs	rsi, _ZStL8__ioinit
-	movabs	rdx, __dso_handle
-	call	__cxa_atexit
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	pop	rax
-	ret
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabs	rdi<span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	movabs	rsi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	movabs	rdx<span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.text
-	.globl	absolute_value
-	.align	16, 0x90
-	.type	absolute_value,@function
-absolute_value:                         <i><font color="#9A1900"># @absolute_value</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	qword ptr [rsp - 8], rdi
-	cmp	qword ptr [rsp - 8], 0
-	jge	.LBB1_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	xor	eax, eax
-	mov	ecx, eax
-	sub	rcx, qword ptr [rsp - 8]
-	mov	qword ptr [rsp - 8], rcx
-.LBB1_2:
-	mov	rax, qword ptr [rsp - 8]
-	ret
-.Lfunc_end1:
-	.size	absolute_value, .Lfunc_end1-absolute_value
-	.cfi_endproc
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span>@function
+absolute_value<span style="color:#990000">:</span>                         # @absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rdi
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jge</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	rcx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rcx
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	sub	rsp, 56
-.Ltmp1:
-	.cfi_def_cfa_offset 64
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str
-	mov	dword ptr [rsp + 52], 0
-	mov	qword ptr [rsp + 40], 0
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 40]
-	mov	qword ptr [rsp + 24], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERl
-	mov	rdi, qword ptr [rsp + 40]
-	mov	qword ptr [rsp + 16], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	absolute_value
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.1
-	mov	qword ptr [rsp + 32], rax
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	mov	rsi, qword ptr [rsp + 32]
-	mov	rdi, rax
-	call	_ZNSolsEl
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	xor	ecx, ecx
-	mov	qword ptr [rsp + 8], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 56
-	ret
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">64</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">52</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERl
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">mov</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEl
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_abs.cpp,@function
-_GLOBAL__sub_I_test_abs.cpp:            <i><font color="#9A1900"># @_GLOBAL__sub_I_test_abs.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp2:
-	.cfi_def_cfa_offset 16
-	call	__cxx_global_var_init
-	pop	rax
-	ret
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_test_abs.cpp, .Lfunc_end3-_GLOBAL__sub_I_test_abs.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>            # @_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxx_global_var_init
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter a value: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_abs.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_abs<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs_c.c.html
+++ b/slides/code/08-assembly-64bit/test_abs_c.c.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs_c.c.html
+++ b/slides/code/08-assembly-64bit/test_abs_c.c.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,23 +8,23 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_c.c</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
 
-<font color="#009900">long</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">long</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x<font color="#990000">&lt;</font><font color="#993399">0</font><font color="#990000">)</font>	<i><font color="#9A1900">// if x is negative</font></i>
-        x <font color="#990000">=</font> <font color="#990000">-</font>x<font color="#990000">;</font>	<i><font color="#9A1900">// negate x</font></i>
-    <b><font color="#0000FF">return</font></b> x<font color="#990000">;</font>	<i><font color="#9A1900">// return x</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">long</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">long</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">&lt;</span><span style="color:#993399">0</span><span style="color:#990000">)</span>	<i><span style="color:#9A1900">// if x is negative</span></i>
+        x <span style="color:#990000">=</span> <span style="color:#990000">-</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// negate x</span></i>
+    <b><span style="color:#0000FF">return</span></b> x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return x</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">long</font> theValue<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Enter a value: </font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">scanf</font></b> <font color="#990000">(</font><font color="#FF0000">"%ld"</font><font color="#990000">,</font> <font color="#990000">&amp;</font>theValue<font color="#990000">);</font>
-    <font color="#009900">long</font> theResult <font color="#990000">=</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"The result is: %ld</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> theResult<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">long</span> theValue<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Enter a value: </span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">scanf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"%ld"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>theValue<span style="color:#990000">);</span>
+    <span style="color:#009900">long</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"The result is: %ld</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> theResult<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs_c.s.html
+++ b/slides/code/08-assembly-64bit/test_abs_c.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,86 +8,86 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_c.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_abs_c.c"</font>
-	.globl	absolute_value
-	.align	16, 0x90
-	.type	absolute_value,@function
-absolute_value:                         <i><font color="#9A1900"># @absolute_value</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	qword ptr [rsp - 8], rdi
-	cmp	qword ptr [rsp - 8], 0
-	jge	.LBB0_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	xor	eax, eax
-	mov	ecx, eax
-	sub	rcx, qword ptr [rsp - 8]
-	mov	qword ptr [rsp - 8], rcx
-.LBB0_2:
-	mov	rax, qword ptr [rsp - 8]
-	ret
-.Lfunc_end0:
-	.size	absolute_value, .Lfunc_end0-absolute_value
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs_c.c"</span>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span>@function
+absolute_value<span style="color:#990000">:</span>                         # @absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rdi
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jge</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">0_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	rcx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rcx
+<b><span style="color:#000080">.LBB0</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	sub	rsp, 40
-.Ltmp0:
-	.cfi_def_cfa_offset 48
-	movabs	rdi, .L.str
-	mov	dword ptr [rsp + 36], 0
-	mov	qword ptr [rsp + 24], 0
-	mov	al, 0
-	call	printf
-	movabs	rdi, .L.str.1
-	lea	rsi, [rsp + 24]
-	mov	dword ptr [rsp + 12], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	mov	al, 0
-	call	__isoc99_scanf
-	mov	rdi, qword ptr [rsp + 24]
-	mov	dword ptr [rsp + 8], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	call	absolute_value
-	movabs	rdi, .L.str.2
-	mov	qword ptr [rsp + 16], rax
-	mov	rsi, qword ptr [rsp + 16]
-	mov	al, 0
-	call	printf
-	xor	ecx, ecx
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 40
-	ret
-.Lfunc_end1:
-	.size	main, .Lfunc_end1-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">48</span>
+	movabs	rdi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">36</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	printf
+	movabs	rdi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	__isoc<span style="color:#993399">99</span>_scanf
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	movabs	rdi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax
+	<b><span style="color:#0000FF">mov</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	printf
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter a value: </font><font color="#CC33CC">\n</font><font color="#FF0000">"</font>
-	.size	.L.str, 17
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter a value: </span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">17</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"%ld"</font>
-	.size	.L.str.1, 4
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"%ld"</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">4</span>
 
-	.type	.L.str.2,@object        <i><font color="#9A1900"># @.str.2</font></i>
-.L.str.2:
-	.asciz	<font color="#FF0000">"The result is: %ld</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font>
-	.size	.L.str.2, 20
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: %ld</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span> <span style="color:#993399">20</span>
 
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs_c.s.html
+++ b/slides/code/08-assembly-64bit/test_abs_c.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs_int.cpp.html
+++ b/slides/code/08-assembly-64bit/test_abs_int.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,25 +8,25 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_int.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x<font color="#990000">&lt;</font><font color="#993399">0</font><font color="#990000">)</font>	<i><font color="#9A1900">// if x is negative</font></i>
-        x <font color="#990000">=</font> <font color="#990000">-</font>x<font color="#990000">;</font>	<i><font color="#9A1900">// negate x</font></i>
-    <b><font color="#0000FF">return</font></b> x<font color="#990000">;</font>	<i><font color="#9A1900">// return x</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">&lt;</span><span style="color:#993399">0</span><span style="color:#990000">)</span>	<i><span style="color:#9A1900">// if x is negative</span></i>
+        x <span style="color:#990000">=</span> <span style="color:#990000">-</span>x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// negate x</span></i>
+    <b><span style="color:#0000FF">return</span></b> x<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return x</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter a value: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue<font color="#990000">;</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">absolute_value</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter a value: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">absolute_value</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_abs_int.cpp.html
+++ b/slides/code/08-assembly-64bit/test_abs_int.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs_int.s.html
+++ b/slides/code/08-assembly-64bit/test_abs_int.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_abs_int.s.html
+++ b/slides/code/08-assembly-64bit/test_abs_int.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,132 +8,132 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_abs_int.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_abs_int.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	movabs	rdi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	movabs	rdi, _ZNSt8ios_base4InitD1Ev
-	movabs	rsi, _ZStL8__ioinit
-	movabs	rdx, __dso_handle
-	call	__cxa_atexit
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	pop	rax
-	ret
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_abs_int.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabs	rdi<span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	movabs	rsi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	movabs	rdx<span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.text
-	.globl	absolute_value
-	.align	16, 0x90
-	.type	absolute_value,@function
-absolute_value:                         <i><font color="#9A1900"># @absolute_value</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	dword ptr [rsp - 4], edi
-	cmp	dword ptr [rsp - 4], 0
-	jge	.LBB1_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	xor	eax, eax
-	sub	eax, dword ptr [rsp - 4]
-	mov	dword ptr [rsp - 4], eax
-.LBB1_2:
-	mov	eax, dword ptr [rsp - 4]
-	ret
-.Lfunc_end1:
-	.size	absolute_value, .Lfunc_end1-absolute_value
-	.cfi_endproc
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	absolute_value
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	absolute_value<span style="color:#990000">,</span>@function
+absolute_value<span style="color:#990000">:</span>                         # @absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">edi</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jge</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	absolute_value<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>absolute_value
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	sub	rsp, 40
-.Ltmp1:
-	.cfi_def_cfa_offset 48
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str
-	mov	dword ptr [rsp + 36], 0
-	mov	dword ptr [rsp + 32], 0
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 32]
-	mov	qword ptr [rsp + 16], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERi
-	mov	edi, dword ptr [rsp + 32]
-	mov	qword ptr [rsp + 8], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	absolute_value
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.1
-	mov	dword ptr [rsp + 28], eax
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	mov	esi, dword ptr [rsp + 28]
-	mov	rdi, rax
-	call	_ZNSolsEi
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	xor	ecx, ecx
-	mov	qword ptr [rsp], rax    <i><font color="#9A1900"># 8-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 40
-	ret
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">48</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">36</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	absolute_value
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">28</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">28</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> rax    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_abs_int.cpp,@function
-_GLOBAL__sub_I_test_abs_int.cpp:        <i><font color="#9A1900"># @_GLOBAL__sub_I_test_abs_int.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp2:
-	.cfi_def_cfa_offset 16
-	call	__cxx_global_var_init
-	pop	rax
-	ret
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_test_abs_int.cpp, .Lfunc_end3-_GLOBAL__sub_I_test_abs_int.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>        # @_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxx_global_var_init
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter a value: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter a value: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_abs_int.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_abs_int<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_fact.cpp.html
+++ b/slides/code/08-assembly-64bit/test_fact.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,26 +8,26 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_fact.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">long</font> <b><font color="#000000">fact</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> n<font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">long</span> <b><span style="color:#000000">fact</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> n<span style="color:#990000">);</span>
 
-<font color="#009900">long</font> <b><font color="#000000">fact</font></b><font color="#990000">(</font><font color="#009900">unsigned</font> <font color="#009900">int</font> n<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> n<font color="#990000">==</font><font color="#993399">0</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">return</font></b> <font color="#993399">1</font><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> n <font color="#990000">*</font> <b><font color="#000000">fact</font></b><font color="#990000">(</font>n<font color="#990000">-</font><font color="#993399">1</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">long</span> <b><span style="color:#000000">fact</span></b><span style="color:#990000">(</span><span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> n<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> n<span style="color:#990000">==</span><span style="color:#993399">0</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> n <span style="color:#990000">*</span> <b><span style="color:#000000">fact</span></b><span style="color:#990000">(</span>n<span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">unsigned</font> <font color="#009900">int</font> theValue <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value for fact(): "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue<font color="#990000">;</font>
-    <font color="#009900">long</font> theResult <font color="#990000">=</font> <b><font color="#000000">fact</font></b><font color="#990000">(</font>theValue<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> theValue <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value for fact(): "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue<span style="color:#990000">;</span>
+    <span style="color:#009900">long</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">fact</span></b><span style="color:#990000">(</span>theValue<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_fact.cpp.html
+++ b/slides/code/08-assembly-64bit/test_fact.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_fact.s.html
+++ b/slides/code/08-assembly-64bit/test_fact.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,143 +8,143 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_fact.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_fact.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.p2align	4, 0x90         <i><font color="#9A1900"># -- Begin function __cxx_global_var_init</font></i>
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># %bb.0:</font></i>
-	push	rax
-	.cfi_def_cfa_offset 16
-	movabs	rdi, offset _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	movabs	rdi, offset _ZNSt8ios_base4InitD1Ev
-	movabs	rsi, offset _ZStL8__ioinit
-	movabs	rdx, offset __dso_handle
-	call	__cxa_atexit
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	pop	rax
-	ret
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
-                                        <i><font color="#9A1900"># -- End function</font></i>
-	.text
-	.globl	fact                    <i><font color="#9A1900"># -- Begin function fact</font></i>
-	.p2align	4, 0x90
-	.type	fact,@function
-fact:                                   <i><font color="#9A1900"># @fact</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># %bb.0:</font></i>
-	sub	rsp, 24
-	.cfi_def_cfa_offset 32
-	mov	dword ptr [rsp + 12], edi
-	cmp	dword ptr [rsp + 12], 0
-	jne	.LBB1_2
-<i><font color="#9A1900"># %bb.1:</font></i>
-	mov	qword ptr [rsp + 16], 1
-	jmp	.LBB1_3
-.LBB1_2:
-	mov	eax, dword ptr [rsp + 12]
-	mov	ecx, eax
-	mov	eax, dword ptr [rsp + 12]
-	sub	eax, 1
-	mov	edi, eax
-	mov	qword ptr [rsp], rcx    <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	fact
-	mov	rcx, qword ptr [rsp]    <i><font color="#9A1900"># 8-byte Reload</font></i>
-	imul	rcx, rax
-	mov	qword ptr [rsp + 16], rcx
-.LBB1_3:
-	mov	rax, qword ptr [rsp + 16]
-	add	rsp, 24
-	ret
-.Lfunc_end1:
-	.size	fact, .Lfunc_end1-fact
-	.cfi_endproc
-                                        <i><font color="#9A1900"># -- End function</font></i>
-	.globl	main                    <i><font color="#9A1900"># -- Begin function main</font></i>
-	.p2align	4, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># %bb.0:</font></i>
-	sub	rsp, 40
-	.cfi_def_cfa_offset 48
-	movabs	rdi, offset _ZSt4cout
-	movabs	rsi, offset .L.str
-	mov	dword ptr [rsp + 36], 0
-	mov	dword ptr [rsp + 32], 0
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, offset _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, offset _ZSt3cin
-	lea	rsi, [rsp + 32]
-	mov	qword ptr [rsp + 16], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERj
-	mov	edi, dword ptr [rsp + 32]
-	mov	qword ptr [rsp + 8], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	fact
-	movabs	rdi, offset _ZSt4cout
-	movabs	rsi, offset .L.str.1
-	mov	qword ptr [rsp + 24], rax
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	mov	rsi, qword ptr [rsp + 24]
-	mov	rdi, rax
-	call	_ZNSolsEl
-	movabs	rsi, offset _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	xor	ecx, ecx
-	mov	qword ptr [rsp], rax    <i><font color="#9A1900"># 8-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 40
-	ret
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
-                                        <i><font color="#9A1900"># -- End function</font></i>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.p2align	4, 0x90         <i><font color="#9A1900"># -- Begin function _GLOBAL__sub_I_test_fact.cpp</font></i>
-	.type	_GLOBAL__sub_I_test_fact.cpp,@function
-_GLOBAL__sub_I_test_fact.cpp:           <i><font color="#9A1900"># @_GLOBAL__sub_I_test_fact.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># %bb.0:</font></i>
-	push	rax
-	.cfi_def_cfa_offset 16
-	call	__cxx_global_var_init
-	pop	rax
-	ret
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_test_fact.cpp, .Lfunc_end3-_GLOBAL__sub_I_test_fact.cpp
-	.cfi_endproc
-                                        <i><font color="#9A1900"># -- End function</font></i>
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.hidden	__dso_handle
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter value for fact(): "</font>
-	.size	.L.str, 25
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_fact.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.p2align</span></b>	<span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>         # <span style="color:#990000">--</span> Begin function __cxx_global_var_init
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# <span style="color:#990000">%</span>bb<span style="color:#993399">.0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabs	rdi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabs	rdi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	movabs	rsi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZStL<span style="color:#993399">8</span>__ioinit
+	movabs	rdx<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> __dso_handle
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+                                        # <span style="color:#990000">--</span> <b><span style="color:#0000FF">End</span></b> function
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	fact                    # <span style="color:#990000">--</span> Begin function fact
+<b><span style="color:#000080">	.p2align</span></b>	<span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	fact<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">fact:</span></b>                                   # @fact
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# <span style="color:#990000">%</span>bb<span style="color:#993399">.0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">24</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">32</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">edi</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# <span style="color:#990000">%</span>bb<span style="color:#993399">.1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_3</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">sub</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> rcx    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	fact
+	<b><span style="color:#0000FF">mov</span></b>	rcx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Reload
+	<b><span style="color:#0000FF">imul</span></b>	rcx<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rcx
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_3</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">24</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	fact<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>fact
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+                                        # <span style="color:#990000">--</span> <b><span style="color:#0000FF">End</span></b> function
+<b><span style="color:#000080">	.globl</span></b>	main                    # <span style="color:#990000">--</span> Begin function main
+<b><span style="color:#000080">	.p2align</span></b>	<span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# <span style="color:#990000">%</span>bb<span style="color:#993399">.0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">48</span>
+	movabs	rdi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">36</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERj
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	fact
+	movabs	rdi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">],</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">mov</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEl
+	movabs	rsi<span style="color:#990000">,</span> <b><span style="color:#0000FF">offset</span></b> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> rax    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">40</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+                                        # <span style="color:#990000">--</span> <b><span style="color:#0000FF">End</span></b> function
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.p2align</span></b>	<span style="color:#993399">4</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>         # <span style="color:#990000">--</span> Begin function _GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>           # @_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# <span style="color:#990000">%</span>bb<span style="color:#993399">.0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxx_global_var_init
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+                                        # <span style="color:#990000">--</span> <b><span style="color:#0000FF">End</span></b> function
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.hidden</span></b>	__dso_handle
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value for fact(): "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">25</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.p2align	3
-	.quad	_GLOBAL__sub_I_test_fact.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.p2align</span></b>	<span style="color:#993399">3</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_fact<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_fact.s.html
+++ b/slides/code/08-assembly-64bit/test_fact.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_max-O2.s.html
+++ b/slides/code/08-assembly-64bit/test_max-O2.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,199 +8,199 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max-O2.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_max.cpp"</font>
-	.globl	max
-	.align	16, 0x90
-	.type	max,@function
-max:                                    <i><font color="#9A1900"># @max</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	cmp	edi, esi
-	cmovge	esi, edi
-	mov	eax, esi
-	ret
-.Lfunc_end0:
-	.size	max, .Lfunc_end0-max
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_max.cpp"</span>
+<b><span style="color:#000080">	.globl</span></b>	max
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	max<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">max:</span></b>                                    # @max
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">esi</span>
+	cmovge	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">edi</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">esi</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	max<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>max
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	r14
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	push	rbx
-.Ltmp1:
-	.cfi_def_cfa_offset 24
-	push	rax
-.Ltmp2:
-	.cfi_def_cfa_offset 32
-.Ltmp3:
-	.cfi_offset rbx, -24
-.Ltmp4:
-	.cfi_offset r14, -16
-	mov	dword ptr [rsp + 4], 0
-	mov	dword ptr [rsp], 0
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str
-	mov	edx, 15
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-	mov	rax, qword ptr [rip + _ZSt4cout]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [rax + _ZSt4cout+240]
-	test	rbx, rbx
-	je	.LBB1_13
-<i><font color="#9A1900"># BB#1:                                 # %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_3
-<i><font color="#9A1900"># BB#2:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_4
-.LBB1_3:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-	mov	rax, qword ptr [rbx]
-	mov	esi, 10
-	mov	rdi, rbx
-	call	qword ptr [rax + 48]
-.LBB1_4:                                <i><font color="#9A1900"># %_ZNKSt5ctypeIcE5widenEc.exit</font></i>
-	movsx	esi, al
-	mov	edi, _ZSt4cout
-	call	_ZNSo3putEc
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-	lea	rsi, [rsp + 4]
-	mov	edi, _ZSt3cin
-	call	_ZNSirsERi
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str.1
-	mov	edx, 15
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-	mov	rax, qword ptr [rip + _ZSt4cout]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [rax + _ZSt4cout+240]
-	test	rbx, rbx
-	je	.LBB1_13
-<i><font color="#9A1900"># BB#5:                                 # %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit5</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_7
-<i><font color="#9A1900"># BB#6:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_8
-.LBB1_7:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-	mov	rax, qword ptr [rbx]
-	mov	esi, 10
-	mov	rdi, rbx
-	call	qword ptr [rax + 48]
-.LBB1_8:                                <i><font color="#9A1900"># %_ZNKSt5ctypeIcE5widenEc.exit2</font></i>
-	movsx	esi, al
-	mov	edi, _ZSt4cout
-	call	_ZNSo3putEc
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-	lea	rsi, [rsp]
-	mov	edi, _ZSt3cin
-	call	_ZNSirsERi
-	mov	eax, dword ptr [rsp + 4]
-	mov	ebx, dword ptr [rsp]
-	cmp	eax, ebx
-	cmovge	ebx, eax
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str.2
-	mov	edx, 15
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-	mov	edi, _ZSt4cout
-	mov	esi, ebx
-	call	_ZNSolsEi
-	mov	r14, rax
-	mov	rax, qword ptr [r14]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [r14 + rax + 240]
-	test	rbx, rbx
-	je	.LBB1_13
-<i><font color="#9A1900"># BB#9:                                 # %_ZSt13__check_facetISt5ctypeIcEERKT_PS3_.exit6</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_11
-<i><font color="#9A1900"># BB#10:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_12
-.LBB1_11:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-	mov	rax, qword ptr [rbx]
-	mov	esi, 10
-	mov	rdi, rbx
-	call	qword ptr [rax + 48]
-.LBB1_12:                               <i><font color="#9A1900"># %_ZNKSt5ctypeIcE5widenEc.exit4</font></i>
-	movsx	esi, al
-	mov	rdi, r14
-	call	_ZNSo3putEc
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-	xor	eax, eax
-	add	rsp, 8
-	pop	rbx
-	pop	r14
-	ret
-.LBB1_13:
-	call	_ZSt16__throw_bad_castv
-.Lfunc_end1:
-	.size	main, .Lfunc_end1-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	r<span style="color:#993399">14</span>
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	rbx
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">24</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">32</span>
+<b><span style="color:#000080">.Ltmp3</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset rbx<span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">24</span>
+<b><span style="color:#000080">.Ltmp4</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset r<span style="color:#993399">14</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rip <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">+</span><span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_13</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%</span>_ZSt<span style="color:#993399">13</span>__check_facetISt<span style="color:#993399">5</span>ctypeIcEERKT_PS<span style="color:#993399">3</span>_<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_3</span>
+# BB#<span style="color:#993399">2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_4</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_3</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_4</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">5</span>widenEc<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rip <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">+</span><span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_13</span>
+# BB#<span style="color:#993399">5</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%</span>_ZSt<span style="color:#993399">13</span>__check_facetISt<span style="color:#993399">5</span>ctypeIcEERKT_PS<span style="color:#993399">3</span>_<span style="color:#990000">.</span>exit<span style="color:#993399">5</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_7</span>
+# BB#<span style="color:#993399">6</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_8</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_7</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_8</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">5</span>widenEc<span style="color:#990000">.</span>exit<span style="color:#993399">2</span>
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+	cmovge	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	<b><span style="color:#0000FF">mov</span></b>	r<span style="color:#993399">14</span><span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>r<span style="color:#993399">14</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>r<span style="color:#993399">14</span> <span style="color:#990000">+</span> rax <span style="color:#990000">+</span> <span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_13</span>
+# BB#<span style="color:#993399">9</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%</span>_ZSt<span style="color:#993399">13</span>__check_facetISt<span style="color:#993399">5</span>ctypeIcEERKT_PS<span style="color:#993399">3</span>_<span style="color:#990000">.</span>exit<span style="color:#993399">6</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_11</span>
+# BB#<span style="color:#993399">10</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_12</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_11</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_12</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">5</span>widenEc<span style="color:#990000">.</span>exit<span style="color:#993399">4</span>
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">14</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">pop</span></b>	rbx
+	<b><span style="color:#0000FF">pop</span></b>	r<span style="color:#993399">14</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_13</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__throw_bad_castv
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_max.cpp,@function
-_GLOBAL__sub_I_test_max.cpp:            <i><font color="#9A1900"># @_GLOBAL__sub_I_test_max.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp5:
-	.cfi_def_cfa_offset 16
-	mov	edi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	mov	edi, _ZNSt8ios_base4InitD1Ev
-	mov	esi, _ZStL8__ioinit
-	mov	edx, __dso_handle
-	pop	rax
-	jmp	__cxa_atexit            <i><font color="#9A1900"># TAILCALL</font></i>
-.Lfunc_end2:
-	.size	_GLOBAL__sub_I_test_max.cpp, .Lfunc_end2-_GLOBAL__sub_I_test_max.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>            # @_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">jmp</span></b>	__cxa_atexit            # TAILCALL
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter value 1: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"Enter value 2: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.2,@object        <i><font color="#9A1900"># @.str.2</font></i>
-.L.str.2:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.2, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_max.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_max-O2.s.html
+++ b/slides/code/08-assembly-64bit/test_max-O2.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_max-noextern.s.html
+++ b/slides/code/08-assembly-64bit/test_max-noextern.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_max-noextern.s.html
+++ b/slides/code/08-assembly-64bit/test_max-noextern.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,155 +8,155 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max-noextern.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"foo.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	movabs	rdi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	movabs	rdi, _ZNSt8ios_base4InitD1Ev
-	movabs	rsi, _ZStL8__ioinit
-	movabs	rdx, __dso_handle
-	call	__cxa_atexit
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	pop	rax
-	ret
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"foo.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabs	rdi<span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	movabs	rsi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	movabs	rdx<span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.text
-	.globl	_Z3maxii
-	.align	16, 0x90
-	.type	_Z3maxii,@function
-_Z3maxii:                               <i><font color="#9A1900"># @_Z3maxii</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	dword ptr [rsp - 4], edi
-	mov	dword ptr [rsp - 8], esi
-	mov	esi, dword ptr [rsp - 4]
-	cmp	esi, dword ptr [rsp - 8]
-	jle	.LBB1_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	mov	eax, dword ptr [rsp - 4]
-	mov	dword ptr [rsp - 12], eax
-	jmp	.LBB1_3
-.LBB1_2:
-	mov	eax, dword ptr [rsp - 8]
-	mov	dword ptr [rsp - 12], eax
-.LBB1_3:
-	mov	eax, dword ptr [rsp - 12]
-	ret
-.Lfunc_end1:
-	.size	_Z3maxii, .Lfunc_end1-_Z3maxii
-	.cfi_endproc
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	_Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span>@function
+_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">:</span>                               # @_Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">edi</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#009900">esi</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jle</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_3</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_3</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_Z<span style="color:#993399">3</span>maxii<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>_Z<span style="color:#993399">3</span>maxii
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	sub	rsp, 56
-.Ltmp1:
-	.cfi_def_cfa_offset 64
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str
-	mov	dword ptr [rsp + 52], 0
-	mov	dword ptr [rsp + 48], 0
-	mov	dword ptr [rsp + 44], 0
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 48]
-	mov	qword ptr [rsp + 32], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERi
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.1
-	mov	qword ptr [rsp + 24], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 44]
-	mov	qword ptr [rsp + 16], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERi
-	mov	edi, dword ptr [rsp + 48]
-	mov	esi, dword ptr [rsp + 44]
-	mov	qword ptr [rsp + 8], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_Z3maxii
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.2
-	mov	dword ptr [rsp + 40], eax
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	mov	esi, dword ptr [rsp + 40]
-	mov	rdi, rax
-	call	_ZNSolsEi
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	xor	ecx, ecx
-	mov	qword ptr [rsp], rax    <i><font color="#9A1900"># 8-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 56
-	ret
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">64</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">52</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_Z<span style="color:#993399">3</span>maxii
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> rax    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_foo.cpp,@function
-_GLOBAL__sub_I_foo.cpp:                 <i><font color="#9A1900"># @_GLOBAL__sub_I_foo.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp2:
-	.cfi_def_cfa_offset 16
-	call	__cxx_global_var_init
-	pop	rax
-	ret
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_foo.cpp, .Lfunc_end3-_GLOBAL__sub_I_foo.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>                 # @_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxx_global_var_init
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter value 1: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"Enter value 2: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.2,@object        <i><font color="#9A1900"># @.str.2</font></i>
-.L.str.2:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.2, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_foo.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_foo<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_max.cpp.html
+++ b/slides/code/08-assembly-64bit/test_max.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,30 +8,30 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#009900">int</font> y<font color="#990000">);</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> y<span style="color:#990000">);</span>
 
-<font color="#009900">int</font> <b><font color="#000000">max</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">,</font> <font color="#009900">int</font> y<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theMax<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>x <font color="#990000">&gt;</font> y<font color="#990000">)</font> 		<i><font color="#9A1900">// if x &gt; y then x is max</font></i>
-        theMax <font color="#990000">=</font> x<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> 		<i><font color="#9A1900">// else y is the max</font></i>
-        theMax <font color="#990000">=</font> y<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> theMax<font color="#990000">;</font>	<i><font color="#9A1900">// return the max</font></i>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">,</span> <span style="color:#009900">int</span> y<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theMax<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>x <span style="color:#990000">&gt;</span> y<span style="color:#990000">)</span> 		<i><span style="color:#9A1900">// if x &gt; y then x is max</span></i>
+        theMax <span style="color:#990000">=</span> x<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> 		<i><span style="color:#9A1900">// else y is the max</span></i>
+        theMax <span style="color:#990000">=</span> y<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> theMax<span style="color:#990000">;</span>	<i><span style="color:#9A1900">// return the max</span></i>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> theValue1<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">,</font> theValue2<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value 1: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue1<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter value 2: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue2<font color="#990000">;</font>
-    <font color="#009900">int</font> theResult <font color="#990000">=</font> <b><font color="#000000">max</font></b><font color="#990000">(</font>theValue1<font color="#990000">,</font> theValue2<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> theValue1<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">,</span> theValue2<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value 1: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue1<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter value 2: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue2<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">max</span></b><span style="color:#990000">(</span>theValue1<span style="color:#990000">,</span> theValue2<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_max.cpp.html
+++ b/slides/code/08-assembly-64bit/test_max.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_max.s.html
+++ b/slides/code/08-assembly-64bit/test_max.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_max.s.html
+++ b/slides/code/08-assembly-64bit/test_max.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,155 +8,155 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_max.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_max.cpp"</font>
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	__cxx_global_var_init,@function
-__cxx_global_var_init:                  <i><font color="#9A1900"># @__cxx_global_var_init</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp0:
-	.cfi_def_cfa_offset 16
-	movabs	rdi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	movabs	rdi, _ZNSt8ios_base4InitD1Ev
-	movabs	rsi, _ZStL8__ioinit
-	movabs	rdx, __dso_handle
-	call	__cxa_atexit
-	mov	dword ptr [rsp + 4], eax <i><font color="#9A1900"># 4-byte Spill</font></i>
-	pop	rax
-	ret
-.Lfunc_end0:
-	.size	__cxx_global_var_init, .Lfunc_end0-__cxx_global_var_init
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_max.cpp"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	__cxx_global_var_init<span style="color:#990000">,</span>@function
+__cxx_global_var_init<span style="color:#990000">:</span>                  # @__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	movabs	rdi<span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	movabs	rsi<span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	movabs	rdx<span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">call</span></b>	__cxa_atexit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span> # <span style="color:#993399">4</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	__cxx_global_var_init<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>__cxx_global_var_init
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.text
-	.globl	max
-	.align	16, 0x90
-	.type	max,@function
-max:                                    <i><font color="#9A1900"># @max</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	dword ptr [rsp - 4], edi
-	mov	dword ptr [rsp - 8], esi
-	mov	esi, dword ptr [rsp - 4]
-	cmp	esi, dword ptr [rsp - 8]
-	jle	.LBB1_2
-<i><font color="#9A1900"># BB#1:</font></i>
-	mov	eax, dword ptr [rsp - 4]
-	mov	dword ptr [rsp - 12], eax
-	jmp	.LBB1_3
-.LBB1_2:
-	mov	eax, dword ptr [rsp - 8]
-	mov	dword ptr [rsp - 12], eax
-.LBB1_3:
-	mov	eax, dword ptr [rsp - 12]
-	ret
-.Lfunc_end1:
-	.size	max, .Lfunc_end1-max
-	.cfi_endproc
+<b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.globl</span></b>	max
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	max<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">max:</span></b>                                    # @max
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">],</span> <span style="color:#009900">edi</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#009900">esi</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jle</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">4</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_3</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">8</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_3</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">-</span> <span style="color:#993399">12</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	max<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>max
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	sub	rsp, 56
-.Ltmp1:
-	.cfi_def_cfa_offset 64
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str
-	mov	dword ptr [rsp + 52], 0
-	mov	dword ptr [rsp + 48], 0
-	mov	dword ptr [rsp + 44], 0
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 48]
-	mov	qword ptr [rsp + 32], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERi
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.1
-	mov	qword ptr [rsp + 24], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	movabs	rdi, _ZSt3cin
-	lea	rsi, [rsp + 44]
-	mov	qword ptr [rsp + 16], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	_ZNSirsERi
-	mov	edi, dword ptr [rsp + 48]
-	mov	esi, dword ptr [rsp + 44]
-	mov	qword ptr [rsp + 8], rax <i><font color="#9A1900"># 8-byte Spill</font></i>
-	call	max
-	movabs	rdi, _ZSt4cout
-	movabs	rsi, .L.str.2
-	mov	dword ptr [rsp + 40], eax
-	call	_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc
-	mov	esi, dword ptr [rsp + 40]
-	mov	rdi, rax
-	call	_ZNSolsEi
-	movabs	rsi, _ZSt4endlIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_
-	mov	rdi, rax
-	call	_ZNSolsEPFRSoS_E
-	xor	ecx, ecx
-	mov	qword ptr [rsp], rax    <i><font color="#9A1900"># 8-byte Spill</font></i>
-	mov	eax, ecx
-	add	rsp, 56
-	ret
-.Lfunc_end2:
-	.size	main, .Lfunc_end2-main
-	.cfi_endproc
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">64</span>
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">52</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">24</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	_ZNSirsERi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">44</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> rax # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">call</span></b>	max
+	movabs	rdi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	movabs	rsi<span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">],</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">dword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEi
+	movabs	rsi<span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>endlIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSolsEPFRSoS_E
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> rax    # <span style="color:#993399">8</span><span style="color:#990000">-</span><span style="color:#009900">byte</span> Spill
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">56</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_max.cpp,@function
-_GLOBAL__sub_I_test_max.cpp:            <i><font color="#9A1900"># @_GLOBAL__sub_I_test_max.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp2:
-	.cfi_def_cfa_offset 16
-	call	__cxx_global_var_init
-	pop	rax
-	ret
-.Lfunc_end3:
-	.size	_GLOBAL__sub_I_test_max.cpp, .Lfunc_end3-_GLOBAL__sub_I_test_max.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span>            # @_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	__cxx_global_var_init
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">3</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">3</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter value 1: "</font>
-	.size	.L.str, 16
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 1: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"Enter value 2: "</font>
-	.size	.L.str.1, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter value 2: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.type	.L.str.2,@object        <i><font color="#9A1900"># @.str.2</font></i>
-.L.str.2:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.2, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_max.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_max<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_string_compare.cpp.html
+++ b/slides/code/08-assembly-64bit/test_string_compare.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/08-assembly-64bit/test_string_compare.cpp.html
+++ b/slides/code/08-assembly-64bit/test_string_compare.cpp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,34 +8,34 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_string_compare.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#009900">bool</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font><font color="#990000">*</font> theStr1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#009900">char</font><font color="#990000">*</font> theStr2<font color="#990000">);</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#009900">bool</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span><span style="color:#990000">*</span> theStr1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span><span style="color:#990000">*</span> theStr2<span style="color:#990000">);</span>
 
-<font color="#009900">bool</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>theStr1<font color="#990000">,</font> <b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>theStr2<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// while *theStr1 is not NULL terminator</font></i>
-    <i><font color="#9A1900">// and the current corresponding bytes are equal</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <font color="#990000">(*</font>theStr1 <font color="#990000">!=</font> <font color="#993399">0</font><font color="#990000">)</font>
-            <font color="#990000">&amp;&amp;</font> <font color="#990000">(*</font>theStr1 <font color="#990000">==</font> <font color="#990000">*</font>theStr2<font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        theStr1<font color="#990000">++;</font>		<i><font color="#9A1900">// increment the pointers to</font></i>
-        theStr2<font color="#990000">++;</font>		<i><font color="#9A1900">// the next char / byte</font></i>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(*</font>theStr1<font color="#990000">==*</font>theStr2<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>theStr1<span style="color:#990000">,</span> <b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>theStr2<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// while *theStr1 is not NULL terminator</span></i>
+    <i><span style="color:#9A1900">// and the current corresponding bytes are equal</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(*</span>theStr1 <span style="color:#990000">!=</span> <span style="color:#993399">0</span><span style="color:#990000">)</span>
+            <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(*</span>theStr1 <span style="color:#990000">==</span> <span style="color:#990000">*</span>theStr2<span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        theStr1<span style="color:#990000">++;</span>		<i><span style="color:#9A1900">// increment the pointers to</span></i>
+        theStr2<span style="color:#990000">++;</span>		<i><span style="color:#9A1900">// the next char / byte</span></i>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(*</span>theStr1<span style="color:#990000">==*</span>theStr2<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#008080">string</font> theValue1<font color="#990000">,</font> theValue2<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter string 1: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue1<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter string 2: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> theValue2<font color="#990000">;</font>
-    <font color="#009900">bool</font> theResult <font color="#990000">=</font> <b><font color="#000000">compare_string</font></b><font color="#990000">(</font>theValue1<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">(),</font> 					     theValue2<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The result is: "</font> <font color="#990000">&lt;&lt;</font> theResult <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">string</span> theValue1<span style="color:#990000">,</span> theValue2<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter string 1: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue1<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter string 2: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> theValue2<span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> theResult <span style="color:#990000">=</span> <b><span style="color:#000000">compare_string</span></b><span style="color:#990000">(</span>theValue1<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">(),</span> 					     theValue2<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The result is: "</span> <span style="color:#990000">&lt;&lt;</span> theResult <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_string_compare.s.html
+++ b/slides/code/08-assembly-64bit/test_string_compare.s.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,386 +8,386 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>test_string_compare.s</title>
 </head>
-<body bgcolor="white">
-<pre><tt>	.text
-	.intel_syntax noprefix
-	.file	<font color="#FF0000">"test_string_compare.cpp"</font>
-	.globl	compare_string
-	.align	16, 0x90
-	.type	compare_string,@function
-compare_string:                         <i><font color="#9A1900"># @compare_string</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	mov	al, byte ptr [rdi]
-	test	al, al
-	je	.LBB0_4
-<i><font color="#9A1900"># BB#1:                                 # %.lr.ph.preheader</font></i>
-	inc	rdi
-	.align	16, 0x90
-.LBB0_2:                                <i><font color="#9A1900"># %.lr.ph</font></i>
-                                        <i><font color="#9A1900"># =&gt;This Inner Loop Header: Depth=1</font></i>
-	movzx	ecx, byte ptr [rsi]
-	movzx	edx, al
-	cmp	edx, ecx
-	jne	.LBB0_5
-<i><font color="#9A1900"># BB#3:                                 #   in Loop: Header=BB0_2 Depth=1</font></i>
-	inc	rsi
-	mov	al, byte ptr [rdi]
-	inc	rdi
-	test	al, al
-	jne	.LBB0_2
-.LBB0_4:
-	xor	eax, eax
-.LBB0_5:                                <i><font color="#9A1900"># %.critedge</font></i>
-	movzx	ecx, byte ptr [rsi]
-	movzx	eax, al
-	cmp	eax, ecx
-	sete	al
-	ret
-.Lfunc_end0:
-	.size	compare_string, .Lfunc_end0-compare_string
-	.cfi_endproc
+<body style="background-color:white">
+<pre><b><span style="color:#000080">	.text</span></b>
+<b><span style="color:#000080">	.intel</span></b>_syntax noprefix
+<b><span style="color:#000080">	.file</span></b>	<span style="color:#FF0000">"test_string_compare.cpp"</span>
+<b><span style="color:#000080">	.globl</span></b>	compare_string
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	compare_string<span style="color:#990000">,</span>@function
+compare_string<span style="color:#990000">:</span>                         # @compare_string
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rdi<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">0_4</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%.</span>lr<span style="color:#990000">.</span>ph<span style="color:#990000">.</span>preheader
+	<b><span style="color:#0000FF">inc</span></b>	rdi
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">.LBB0</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>lr<span style="color:#990000">.</span>ph
+                                        # <span style="color:#990000">=&gt;</span><b><span style="color:#0000FF">This</span></b> Inner <b><span style="color:#0000FF">Loop</span></b> Header<span style="color:#990000">:</span> Depth<span style="color:#990000">=</span><span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsi<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">0_5</span>
+# BB#<span style="color:#993399">3</span><span style="color:#990000">:</span>                                 #   <b><span style="color:#0000FF">in</span></b> <b><span style="color:#0000FF">Loop</span></b><span style="color:#990000">:</span> Header<span style="color:#990000">=</span>BB<span style="color:#993399">0_2</span> Depth<span style="color:#990000">=</span><span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">inc</span></b>	rsi
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rdi<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">inc</span></b>	rdi
+	<b><span style="color:#0000FF">test</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">0_2</span>
+<b><span style="color:#000080">.LBB0</span></b><span style="color:#993399">_4</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+<b><span style="color:#000080">.LBB0</span></b><span style="color:#993399">_5</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>critedge
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsi<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">ecx</span>
+	<b><span style="color:#0000FF">sete</span></b>	<span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	compare_string<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">0</span><span style="color:#990000">-</span>compare_string
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.globl	main
-	.align	16, 0x90
-	.type	main,@function
-main:                                   <i><font color="#9A1900"># @main</font></i>
-.Lfunc_begin0:
-	.cfi_startproc
-	.cfi_personality 3, __gxx_personality_v0
-	.cfi_lsda 3, .Lexception0
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rbp
-.Ltmp43:
-	.cfi_def_cfa_offset 16
-	push	r15
-.Ltmp44:
-	.cfi_def_cfa_offset 24
-	push	r14
-.Ltmp45:
-	.cfi_def_cfa_offset 32
-	push	r12
-.Ltmp46:
-	.cfi_def_cfa_offset 40
-	push	rbx
-.Ltmp47:
-	.cfi_def_cfa_offset 48
-	sub	rsp, 64
-.Ltmp48:
-	.cfi_def_cfa_offset 112
-.Ltmp49:
-	.cfi_offset rbx, -48
-.Ltmp50:
-	.cfi_offset r12, -40
-.Ltmp51:
-	.cfi_offset r14, -32
-.Ltmp52:
-	.cfi_offset r15, -24
-.Ltmp53:
-	.cfi_offset rbp, -16
-	lea	r15, [rsp + 48]
-	mov	qword ptr [rsp + 32], r15
-	mov	qword ptr [rsp + 40], 0
-	mov	byte ptr [rsp + 48], 0
-	lea	r12, [rsp + 16]
-	mov	qword ptr [rsp], r12
-	mov	qword ptr [rsp + 8], 0
-	mov	byte ptr [rsp + 16], 0
-.Ltmp0:
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str
-	mov	edx, 16
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-.Ltmp1:
-<i><font color="#9A1900"># BB#1:                                 # %_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc.exit</font></i>
-	mov	rax, qword ptr [rip + _ZSt4cout]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [rax + _ZSt4cout+240]
-	test	rbx, rbx
-	je	.LBB1_2
-.LBB1_3:                                <i><font color="#9A1900"># %.noexc34</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_5
-<i><font color="#9A1900"># BB#4:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_7
-.LBB1_5:
-.Ltmp2:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-.Ltmp3:
-<i><font color="#9A1900"># BB#6:                                 # %.noexc38</font></i>
-	mov	rax, qword ptr [rbx]
-	mov	rax, qword ptr [rax + 48]
-.Ltmp4:
-	mov	esi, 10
-	mov	rdi, rbx
-	call	rax
-.Ltmp5:
-.LBB1_7:                                <i><font color="#9A1900"># %.noexc</font></i>
-.Ltmp6:
-	movsx	esi, al
-	mov	edi, _ZSt4cout
-	call	_ZNSo3putEc
-.Ltmp7:
-<i><font color="#9A1900"># BB#8:                                 # %.noexc4</font></i>
-.Ltmp8:
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-.Ltmp9:
-<i><font color="#9A1900"># BB#9:                                 # %_ZNSolsEPFRSoS_E.exit</font></i>
-.Ltmp10:
-	lea	rsi, [rsp + 32]
-	mov	edi, _ZSt3cin
-	call	_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
-.Ltmp11:
-<i><font color="#9A1900"># BB#10:</font></i>
-.Ltmp12:
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str.1
-	mov	edx, 16
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-.Ltmp13:
-<i><font color="#9A1900"># BB#11:                                # %_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc.exit8</font></i>
-	mov	rax, qword ptr [rip + _ZSt4cout]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [rax + _ZSt4cout+240]
-	test	rbx, rbx
-	je	.LBB1_12
-.LBB1_13:                               <i><font color="#9A1900"># %.noexc17</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_15
-<i><font color="#9A1900"># BB#14:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_17
-.LBB1_15:
-.Ltmp14:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-.Ltmp15:
-<i><font color="#9A1900"># BB#16:                                # %.noexc19</font></i>
-	mov	rax, qword ptr [rbx]
-	mov	rax, qword ptr [rax + 48]
-.Ltmp16:
-	mov	esi, 10
-	mov	rdi, rbx
-	call	rax
-.Ltmp17:
-.LBB1_17:                               <i><font color="#9A1900"># %.noexc11</font></i>
-.Ltmp18:
-	movsx	esi, al
-	mov	edi, _ZSt4cout
-	call	_ZNSo3putEc
-.Ltmp19:
-<i><font color="#9A1900"># BB#18:                                # %.noexc12</font></i>
-.Ltmp20:
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-.Ltmp21:
-<i><font color="#9A1900"># BB#19:                                # %_ZNSolsEPFRSoS_E.exit10</font></i>
-.Ltmp22:
-	lea	rsi, [rsp]
-	mov	edi, _ZSt3cin
-	call	_ZStrsIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EE
-.Ltmp23:
-<i><font color="#9A1900"># BB#20:</font></i>
-	mov	rcx, qword ptr [rsp + 32]
-	mov	rax, qword ptr [rsp]
-	mov	bl, byte ptr [rcx]
-	test	bl, bl
-	je	.LBB1_24
-<i><font color="#9A1900"># BB#21:                                # %.lr.ph.i.preheader</font></i>
-	inc	rcx
-	.align	16, 0x90
-.LBB1_22:                               <i><font color="#9A1900"># %.lr.ph.i</font></i>
-                                        <i><font color="#9A1900"># =&gt;This Inner Loop Header: Depth=1</font></i>
-	movzx	edx, byte ptr [rax]
-	movzx	esi, bl
-	cmp	esi, edx
-	jne	.LBB1_25
-<i><font color="#9A1900"># BB#23:                                #   in Loop: Header=BB1_22 Depth=1</font></i>
-	inc	rax
-	mov	bl, byte ptr [rcx]
-	inc	rcx
-	test	bl, bl
-	jne	.LBB1_22
-.LBB1_24:
-	xor	ebx, ebx
-.LBB1_25:                               <i><font color="#9A1900"># %compare_string.exit</font></i>
-	mov	bpl, byte ptr [rax]
-.Ltmp24:
-	mov	edi, _ZSt4cout
-	mov	esi, .L.str.2
-	mov	edx, 15
-	call	_ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l
-.Ltmp25:
-<i><font color="#9A1900"># BB#26:                                # %_ZStlsISt11char_traitsIcEERSt13basic_ostreamIcT_ES5_PKc.exit22</font></i>
-	movzx	eax, bpl
-	movzx	ecx, bl
-	cmp	ecx, eax
-	sete	al
-	movzx	esi, al
-.Ltmp26:
-	mov	edi, _ZSt4cout
-	call	_ZNSo9_M_insertIbEERSoT_
-	mov	r14, rax
-.Ltmp27:
-<i><font color="#9A1900"># BB#27:                                # %_ZNSolsEb.exit</font></i>
-	mov	rax, qword ptr [r14]
-	mov	rax, qword ptr [rax - 24]
-	mov	rbx, qword ptr [r14 + rax + 240]
-	test	rbx, rbx
-	je	.LBB1_28
-.LBB1_29:                               <i><font color="#9A1900"># %.noexc42</font></i>
-	cmp	byte ptr [rbx + 56], 0
-	je	.LBB1_31
-<i><font color="#9A1900"># BB#30:</font></i>
-	mov	al, byte ptr [rbx + 67]
-	jmp	.LBB1_33
-.LBB1_31:
-.Ltmp28:
-	mov	rdi, rbx
-	call	_ZNKSt5ctypeIcE13_M_widen_initEv
-.Ltmp29:
-<i><font color="#9A1900"># BB#32:                                # %.noexc46</font></i>
-	mov	rax, qword ptr [rbx]
-	mov	rax, qword ptr [rax + 48]
-.Ltmp30:
-	mov	esi, 10
-	mov	rdi, rbx
-	call	rax
-.Ltmp31:
-.LBB1_33:                               <i><font color="#9A1900"># %.noexc26</font></i>
-.Ltmp32:
-	movsx	esi, al
-	mov	rdi, r14
-	call	_ZNSo3putEc
-.Ltmp33:
-<i><font color="#9A1900"># BB#34:                                # %.noexc27</font></i>
-.Ltmp34:
-	mov	rdi, rax
-	call	_ZNSo5flushEv
-.Ltmp35:
-<i><font color="#9A1900"># BB#35:                                # %_ZNSolsEPFRSoS_E.exit25</font></i>
-	mov	rdi, qword ptr [rsp]
-	cmp	rdi, r12
-	je	.LBB1_37
-<i><font color="#9A1900"># BB#36:</font></i>
-	call	_ZdlPv
-.LBB1_37:                               <i><font color="#9A1900"># %_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev.exit32</font></i>
-	mov	rdi, qword ptr [rsp + 32]
-	cmp	rdi, r15
-	je	.LBB1_39
-<i><font color="#9A1900"># BB#38:</font></i>
-	call	_ZdlPv
-.LBB1_39:                               <i><font color="#9A1900"># %_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev.exit3</font></i>
-	xor	eax, eax
-	add	rsp, 64
-	pop	rbx
-	pop	r12
-	pop	r14
-	pop	r15
-	pop	rbp
-	ret
-.LBB1_2:
-.Ltmp40:
-	call	_ZSt16__throw_bad_castv
-.Ltmp41:
-	jmp	.LBB1_3
-.LBB1_12:
-.Ltmp38:
-	call	_ZSt16__throw_bad_castv
-.Ltmp39:
-	jmp	.LBB1_13
-.LBB1_28:
-.Ltmp36:
-	call	_ZSt16__throw_bad_castv
-.Ltmp37:
-	jmp	.LBB1_29
-.LBB1_40:
-.Ltmp42:
-	mov	rbx, rax
-	mov	rdi, qword ptr [rsp]
-	cmp	rdi, r12
-	je	.LBB1_42
-<i><font color="#9A1900"># BB#41:</font></i>
-	call	_ZdlPv
-.LBB1_42:                               <i><font color="#9A1900"># %_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev.exit33</font></i>
-	mov	rdi, qword ptr [rsp + 32]
-	cmp	rdi, r15
-	je	.LBB1_44
-<i><font color="#9A1900"># BB#43:</font></i>
-	call	_ZdlPv
-.LBB1_44:                               <i><font color="#9A1900"># %_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev.exit</font></i>
-	mov	rdi, rbx
-	call	_Unwind_Resume
-.Lfunc_end1:
-	.size	main, .Lfunc_end1-main
-	.cfi_endproc
-	.section	.gcc_except_table,<font color="#FF0000">"a"</font>,@progbits
-	.align	4
-GCC_except_table1:
-.Lexception0:
-	.byte	255                     <i><font color="#9A1900"># @LPStart Encoding = omit</font></i>
-	.byte	3                       <i><font color="#9A1900"># @TType Encoding = udata4</font></i>
-	.asciz	<font color="#FF0000">"</font><font color="#CC33CC">\2</font><font color="#FF0000">34"</font>                  <i><font color="#9A1900"># @TType base offset</font></i>
-	.byte	3                       <i><font color="#9A1900"># Call site Encoding = udata4</font></i>
-	.byte	26                      <i><font color="#9A1900"># Call site table length</font></i>
-	.long	.Ltmp0-.Lfunc_begin0    <i><font color="#9A1900"># &gt;&gt; Call Site 1 &lt;&lt;</font></i>
-	.long	.Ltmp37-.Ltmp0          <i><font color="#9A1900">#   Call between .Ltmp0 and .Ltmp37</font></i>
-	.long	.Ltmp42-.Lfunc_begin0   <i><font color="#9A1900">#     jumps to .Ltmp42</font></i>
-	.byte	0                       <i><font color="#9A1900">#   On action: cleanup</font></i>
-	.long	.Ltmp37-.Lfunc_begin0   <i><font color="#9A1900"># &gt;&gt; Call Site 2 &lt;&lt;</font></i>
-	.long	.Lfunc_end1-.Ltmp37     <i><font color="#9A1900">#   Call between .Ltmp37 and .Lfunc_end1</font></i>
-	.long	0                       <i><font color="#9A1900">#     has no landing pad</font></i>
-	.byte	0                       <i><font color="#9A1900">#   On action: cleanup</font></i>
-	.align	4
+<b><span style="color:#000080">	.globl</span></b>	main
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	main<span style="color:#990000">,</span>@function
+<b><span style="color:#000080">main:</span></b>                                   # @main
+<b><span style="color:#000080">.Lfunc</span></b>_begin<span style="color:#993399">0</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+<b><span style="color:#000080">	.cfi</span></b>_personality <span style="color:#993399">3</span><span style="color:#990000">,</span> __gxx_personality_v<span style="color:#993399">0</span>
+<b><span style="color:#000080">	.cfi</span></b>_lsda <span style="color:#993399">3</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>Lexception<span style="color:#993399">0</span>
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rbp
+<b><span style="color:#000080">.Ltmp43</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">push</span></b>	r<span style="color:#993399">15</span>
+<b><span style="color:#000080">.Ltmp44</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">24</span>
+	<b><span style="color:#0000FF">push</span></b>	r<span style="color:#993399">14</span>
+<b><span style="color:#000080">.Ltmp45</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">32</span>
+	<b><span style="color:#0000FF">push</span></b>	r<span style="color:#993399">12</span>
+<b><span style="color:#000080">.Ltmp46</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">40</span>
+	<b><span style="color:#0000FF">push</span></b>	rbx
+<b><span style="color:#000080">.Ltmp47</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">48</span>
+	<b><span style="color:#0000FF">sub</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">64</span>
+<b><span style="color:#000080">.Ltmp48</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">112</span>
+<b><span style="color:#000080">.Ltmp49</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset rbx<span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">48</span>
+<b><span style="color:#000080">.Ltmp50</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset r<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">40</span>
+<b><span style="color:#000080">.Ltmp51</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset r<span style="color:#993399">14</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">32</span>
+<b><span style="color:#000080">.Ltmp52</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset r<span style="color:#993399">15</span><span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">24</span>
+<b><span style="color:#000080">.Ltmp53</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_offset rbp<span style="color:#990000">,</span> <span style="color:#990000">-</span><span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">lea</span></b>	r<span style="color:#993399">15</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">],</span> r<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">40</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">lea</span></b>	r<span style="color:#993399">12</span><span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">],</span> r<span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">8</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">16</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+<b><span style="color:#000080">.Ltmp0</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+<b><span style="color:#000080">.Ltmp1</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">1</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%</span>_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rip <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">+</span><span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_2</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_3</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc<span style="color:#993399">34</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_5</span>
+# BB#<span style="color:#993399">4</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_7</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_5</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp2</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+<b><span style="color:#000080">.Ltmp3</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">6</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%.</span>noexc<span style="color:#993399">38</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.Ltmp4</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	rax
+<b><span style="color:#000080">.Ltmp5</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_7</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc
+<b><span style="color:#000080">.Ltmp6</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+<b><span style="color:#000080">.Ltmp7</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">8</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%.</span>noexc<span style="color:#993399">4</span>
+<b><span style="color:#000080">.Ltmp8</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+<b><span style="color:#000080">.Ltmp9</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">9</span><span style="color:#990000">:</span>                                 # <span style="color:#990000">%</span>_ZNSolsEPFRSoS_E<span style="color:#990000">.</span>exit
+<b><span style="color:#000080">.Ltmp10</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZStrsIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEERSt<span style="color:#993399">13</span>basic_istreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">7</span>_RNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIS<span style="color:#993399">4</span>_S<span style="color:#993399">5</span>_T<span style="color:#993399">1</span>_EE
+<b><span style="color:#000080">.Ltmp11</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">10</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp12</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+<b><span style="color:#000080">.Ltmp13</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">11</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc<span style="color:#990000">.</span>exit<span style="color:#993399">8</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rip <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> _ZSt<span style="color:#993399">4</span>cout<span style="color:#990000">+</span><span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_12</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_13</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%.</span>noexc<span style="color:#993399">17</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_15</span>
+# BB#<span style="color:#993399">14</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_17</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_15</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp14</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+<b><span style="color:#000080">.Ltmp15</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">16</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc<span style="color:#993399">19</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.Ltmp16</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	rax
+<b><span style="color:#000080">.Ltmp17</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_17</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%.</span>noexc<span style="color:#993399">11</span>
+<b><span style="color:#000080">.Ltmp18</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+<b><span style="color:#000080">.Ltmp19</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">18</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc<span style="color:#993399">12</span>
+<b><span style="color:#000080">.Ltmp20</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+<b><span style="color:#000080">.Ltmp21</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">19</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZNSolsEPFRSoS_E<span style="color:#990000">.</span>exit<span style="color:#993399">10</span>
+<b><span style="color:#000080">.Ltmp22</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">lea</span></b>	rsi<span style="color:#990000">,</span> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">3</span>cin
+	<b><span style="color:#0000FF">call</span></b>	_ZStrsIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEERSt<span style="color:#993399">13</span>basic_istreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">7</span>_RNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIS<span style="color:#993399">4</span>_S<span style="color:#993399">5</span>_T<span style="color:#993399">1</span>_EE
+<b><span style="color:#000080">.Ltmp23</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">20</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rcx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">bl</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rcx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	<span style="color:#009900">bl</span><span style="color:#990000">,</span> <span style="color:#009900">bl</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_24</span>
+# BB#<span style="color:#993399">21</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>lr<span style="color:#990000">.</span>ph<span style="color:#990000">.</span>i<span style="color:#990000">.</span>preheader
+	<b><span style="color:#0000FF">inc</span></b>	rcx
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_22</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%.</span>lr<span style="color:#990000">.</span>ph<span style="color:#990000">.</span>i
+                                        # <span style="color:#990000">=&gt;</span><b><span style="color:#0000FF">This</span></b> Inner <b><span style="color:#0000FF">Loop</span></b> Header<span style="color:#990000">:</span> Depth<span style="color:#990000">=</span><span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">bl</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">edx</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_25</span>
+# BB#<span style="color:#993399">23</span><span style="color:#990000">:</span>                                #   <b><span style="color:#0000FF">in</span></b> <b><span style="color:#0000FF">Loop</span></b><span style="color:#990000">:</span> Header<span style="color:#990000">=</span>BB<span style="color:#993399">1_22</span> Depth<span style="color:#990000">=</span><span style="color:#993399">1</span>
+	<b><span style="color:#0000FF">inc</span></b>	rax
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">bl</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rcx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">inc</span></b>	rcx
+	<b><span style="color:#0000FF">test</span></b>	<span style="color:#009900">bl</span><span style="color:#990000">,</span> <span style="color:#009900">bl</span>
+	<b><span style="color:#0000FF">jne</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_22</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_24</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">ebx</span><span style="color:#990000">,</span> <span style="color:#009900">ebx</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_25</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>compare_string<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">mov</span></b>	bpl<span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax<span style="color:#990000">]</span>
+<b><span style="color:#000080">.Ltmp24</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> <span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__ostream_insertIcSt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIT_T<span style="color:#993399">0</span>_ES<span style="color:#993399">6</span>_PKS<span style="color:#993399">3</span>_l
+<b><span style="color:#000080">.Ltmp25</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">26</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZStlsISt<span style="color:#993399">11</span>char_traitsIcEERSt<span style="color:#993399">13</span>basic_ostreamIcT_ES<span style="color:#993399">5</span>_PKc<span style="color:#990000">.</span>exit<span style="color:#993399">22</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> bpl
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">bl</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">ecx</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">sete</span></b>	<span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">movzx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+<b><span style="color:#000080">.Ltmp26</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZSt<span style="color:#993399">4</span>cout
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">9</span>_M_insertIbEERSoT_
+	<b><span style="color:#0000FF">mov</span></b>	r<span style="color:#993399">14</span><span style="color:#990000">,</span> rax
+<b><span style="color:#000080">.Ltmp27</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">27</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZNSolsEb<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>r<span style="color:#993399">14</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">-</span> <span style="color:#993399">24</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>r<span style="color:#993399">14</span> <span style="color:#990000">+</span> rax <span style="color:#990000">+</span> <span style="color:#993399">240</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">test</span></b>	rbx<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_28</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_29</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%.</span>noexc<span style="color:#993399">42</span>
+	<b><span style="color:#0000FF">cmp</span></b>	<span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">56</span><span style="color:#990000">],</span> <span style="color:#993399">0</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_31</span>
+# BB#<span style="color:#993399">30</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">al</span><span style="color:#990000">,</span> <span style="color:#009900">byte</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx <span style="color:#990000">+</span> <span style="color:#993399">67</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_33</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_31</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp28</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_ZNKSt<span style="color:#993399">5</span>ctypeIcE<span style="color:#993399">13</span>_M_widen_initEv
+<b><span style="color:#000080">.Ltmp29</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">32</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc<span style="color:#993399">46</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rbx<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">mov</span></b>	rax<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rax <span style="color:#990000">+</span> <span style="color:#993399">48</span><span style="color:#990000">]</span>
+<b><span style="color:#000080">.Ltmp30</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#993399">10</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	rax
+<b><span style="color:#000080">.Ltmp31</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_33</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%.</span>noexc<span style="color:#993399">26</span>
+<b><span style="color:#000080">.Ltmp32</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">movsx</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> <span style="color:#009900">al</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">14</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">3</span>putEc
+<b><span style="color:#000080">.Ltmp33</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">34</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%.</span>noexc<span style="color:#993399">27</span>
+<b><span style="color:#000080">.Ltmp34</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">call</span></b>	_ZNSo<span style="color:#993399">5</span>flushEv
+<b><span style="color:#000080">.Ltmp35</span></b><span style="color:#990000">:</span>
+# BB#<span style="color:#993399">35</span><span style="color:#990000">:</span>                                # <span style="color:#990000">%</span>_ZNSolsEPFRSoS_E<span style="color:#990000">.</span>exit<span style="color:#993399">25</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_37</span>
+# BB#<span style="color:#993399">36</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZdlPv
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_37</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">2</span>Ev<span style="color:#990000">.</span>exit<span style="color:#993399">32</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_39</span>
+# BB#<span style="color:#993399">38</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZdlPv
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_39</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">2</span>Ev<span style="color:#990000">.</span>exit<span style="color:#993399">3</span>
+	<b><span style="color:#0000FF">xor</span></b>	<span style="color:#009900">eax</span><span style="color:#990000">,</span> <span style="color:#009900">eax</span>
+	<b><span style="color:#0000FF">add</span></b>	rsp<span style="color:#990000">,</span> <span style="color:#993399">64</span>
+	<b><span style="color:#0000FF">pop</span></b>	rbx
+	<b><span style="color:#0000FF">pop</span></b>	r<span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">pop</span></b>	r<span style="color:#993399">14</span>
+	<b><span style="color:#0000FF">pop</span></b>	r<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">pop</span></b>	rbp
+	<b><span style="color:#0000FF">ret</span></b>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp40</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__throw_bad_castv
+<b><span style="color:#000080">.Ltmp41</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_3</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_12</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp38</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__throw_bad_castv
+<b><span style="color:#000080">.Ltmp39</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_13</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_28</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp36</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZSt<span style="color:#993399">16</span>__throw_bad_castv
+<b><span style="color:#000080">.Ltmp37</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">jmp</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_29</span>
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_40</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Ltmp42</span></b><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">mov</span></b>	rbx<span style="color:#990000">,</span> rax
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp<span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">12</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_42</span>
+# BB#<span style="color:#993399">41</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZdlPv
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_42</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">2</span>Ev<span style="color:#990000">.</span>exit<span style="color:#993399">33</span>
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> <span style="color:#009900">qword</span> <b><span style="color:#0000FF">ptr</span></b> <span style="color:#990000">[</span>rsp <span style="color:#990000">+</span> <span style="color:#993399">32</span><span style="color:#990000">]</span>
+	<b><span style="color:#0000FF">cmp</span></b>	rdi<span style="color:#990000">,</span> r<span style="color:#993399">15</span>
+	<b><span style="color:#0000FF">je</span></b>	<span style="color:#990000">.</span>LBB<span style="color:#993399">1_44</span>
+# BB#<span style="color:#993399">43</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">call</span></b>	_ZdlPv
+<b><span style="color:#000080">.LBB1</span></b><span style="color:#993399">_44</span><span style="color:#990000">:</span>                               # <span style="color:#990000">%</span>_ZNSt<span style="color:#993399">7</span>__cxx<span style="color:#993399">1112</span>basic_stringIcSt<span style="color:#993399">11</span>char_traitsIcESaIcEED<span style="color:#993399">2</span>Ev<span style="color:#990000">.</span>exit
+	<b><span style="color:#0000FF">mov</span></b>	rdi<span style="color:#990000">,</span> rbx
+	<b><span style="color:#0000FF">call</span></b>	_Unwind_Resume
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	main<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-</span>main
+<b><span style="color:#000080">	.cfi</span></b>_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>gcc_except_table<span style="color:#990000">,</span><span style="color:#FF0000">"a"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">4</span>
+GCC_except_table<span style="color:#993399">1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">.Lexception0</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">255</span>                     # @LPStart Encoding <span style="color:#990000">=</span> omit
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">3</span>                       # @TType Encoding <span style="color:#990000">=</span> udata<span style="color:#993399">4</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"</span><span style="color:#CC33CC">\2</span><span style="color:#FF0000">34"</span>                  # @TType base <b><span style="color:#0000FF">offset</span></b>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">3</span>                       # <b><span style="color:#0000FF">Call</span></b> site Encoding <span style="color:#990000">=</span> udata<span style="color:#993399">4</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">26</span>                      # <b><span style="color:#0000FF">Call</span></b> site table <b><span style="color:#0000FF">length</span></b>
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#990000">.</span>Ltmp<span style="color:#993399">0</span><span style="color:#990000">-.</span>Lfunc_begin<span style="color:#993399">0</span>    # <span style="color:#990000">&gt;&gt;</span> <b><span style="color:#0000FF">Call</span></b> Site <span style="color:#993399">1</span> <span style="color:#990000">&lt;&lt;</span>
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#990000">.</span>Ltmp<span style="color:#993399">37</span><span style="color:#990000">-.</span>Ltmp<span style="color:#993399">0</span>          #   <b><span style="color:#0000FF">Call</span></b> between <span style="color:#990000">.</span>Ltmp<span style="color:#993399">0</span> <b><span style="color:#0000FF">and</span></b> <span style="color:#990000">.</span>Ltmp<span style="color:#993399">37</span>
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#990000">.</span>Ltmp<span style="color:#993399">42</span><span style="color:#990000">-.</span>Lfunc_begin<span style="color:#993399">0</span>   #     jumps to <span style="color:#990000">.</span>Ltmp<span style="color:#993399">42</span>
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">0</span>                       #   On action<span style="color:#990000">:</span> cleanup
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#990000">.</span>Ltmp<span style="color:#993399">37</span><span style="color:#990000">-.</span>Lfunc_begin<span style="color:#993399">0</span>   # <span style="color:#990000">&gt;&gt;</span> <b><span style="color:#0000FF">Call</span></b> Site <span style="color:#993399">2</span> <span style="color:#990000">&lt;&lt;</span>
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span><span style="color:#990000">-.</span>Ltmp<span style="color:#993399">37</span>     #   <b><span style="color:#0000FF">Call</span></b> between <span style="color:#990000">.</span>Ltmp<span style="color:#993399">37</span> <b><span style="color:#0000FF">and</span></b> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">1</span>
+<b><span style="color:#000080">	.long</span></b>	<span style="color:#993399">0</span>                       #     has no landing pad
+<b><span style="color:#000080">	.byte</span></b>	<span style="color:#993399">0</span>                       #   On action<span style="color:#990000">:</span> cleanup
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">4</span>
 
-	.section	.text.startup,<font color="#FF0000">"ax"</font>,@progbits
-	.align	16, 0x90
-	.type	_GLOBAL__sub_I_test_string_compare.cpp,@function
-_GLOBAL__sub_I_test_string_compare.cpp: <i><font color="#9A1900"># @_GLOBAL__sub_I_test_string_compare.cpp</font></i>
-	.cfi_startproc
-<i><font color="#9A1900"># BB#0:</font></i>
-	push	rax
-.Ltmp54:
-	.cfi_def_cfa_offset 16
-	mov	edi, _ZStL8__ioinit
-	call	_ZNSt8ios_base4InitC1Ev
-	mov	edi, _ZNSt8ios_base4InitD1Ev
-	mov	esi, _ZStL8__ioinit
-	mov	edx, __dso_handle
-	pop	rax
-	jmp	__cxa_atexit            <i><font color="#9A1900"># TAILCALL</font></i>
-.Lfunc_end2:
-	.size	_GLOBAL__sub_I_test_string_compare.cpp, .Lfunc_end2-_GLOBAL__sub_I_test_string_compare.cpp
-	.cfi_endproc
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>text<span style="color:#990000">.</span>startup<span style="color:#990000">,</span><span style="color:#FF0000">"ax"</span><span style="color:#990000">,</span>@progbits
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">16</span><span style="color:#990000">,</span> <span style="color:#993399">0x90</span>
+<b><span style="color:#000080">	.type</span></b>	_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span>@function
+_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp<span style="color:#990000">:</span> # @_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_startproc
+# BB#<span style="color:#993399">0</span><span style="color:#990000">:</span>
+	<b><span style="color:#0000FF">push</span></b>	rax
+<b><span style="color:#000080">.Ltmp54</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.cfi</span></b>_def_cfa_offset <span style="color:#993399">16</span>
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">call</span></b>	_ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitC<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edi</span><span style="color:#990000">,</span> _ZNSt<span style="color:#993399">8</span>ios_base<span style="color:#993399">4</span>InitD<span style="color:#993399">1</span>Ev
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">esi</span><span style="color:#990000">,</span> _ZStL<span style="color:#993399">8</span>__ioinit
+	<b><span style="color:#0000FF">mov</span></b>	<span style="color:#009900">edx</span><span style="color:#990000">,</span> __dso_handle
+	<b><span style="color:#0000FF">pop</span></b>	rax
+	<b><span style="color:#0000FF">jmp</span></b>	__cxa_atexit            # TAILCALL
+<b><span style="color:#000080">.Lfunc</span></b>_end<span style="color:#993399">2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.size</span></b>	_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp<span style="color:#990000">,</span> <span style="color:#990000">.</span>Lfunc_end<span style="color:#993399">2</span><span style="color:#990000">-</span>_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp
+<b><span style="color:#000080">	.cfi</span></b>_endproc
 
-	.type	_ZStL8__ioinit,@object  <i><font color="#9A1900"># @_ZStL8__ioinit</font></i>
-	.local	_ZStL8__ioinit
-	.comm	_ZStL8__ioinit,1,1
-	.type	.L.str,@object          <i><font color="#9A1900"># @.str</font></i>
-	.section	.rodata.str1.1,<font color="#FF0000">"aMS"</font>,@progbits,1
-.L.str:
-	.asciz	<font color="#FF0000">"Enter string 1: "</font>
-	.size	.L.str, 17
+<b><span style="color:#000080">	.type</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span>@object  # @_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.local</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit
+<b><span style="color:#000080">	.comm</span></b>	_ZStL<span style="color:#993399">8</span>__ioinit<span style="color:#990000">,</span><span style="color:#993399">1</span><span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span>@object          # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>rodata<span style="color:#990000">.</span>str<span style="color:#993399">1.1</span><span style="color:#990000">,</span><span style="color:#FF0000">"aMS"</span><span style="color:#990000">,</span>@progbits<span style="color:#990000">,</span><span style="color:#993399">1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter string 1: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#990000">,</span> <span style="color:#993399">17</span>
 
-	.type	.L.str.1,@object        <i><font color="#9A1900"># @.str.1</font></i>
-.L.str.1:
-	.asciz	<font color="#FF0000">"Enter string 2: "</font>
-	.size	.L.str.1, 17
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"Enter string 2: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.1</span><span style="color:#990000">,</span> <span style="color:#993399">17</span>
 
-	.type	.L.str.2,@object        <i><font color="#9A1900"># @.str.2</font></i>
-.L.str.2:
-	.asciz	<font color="#FF0000">"The result is: "</font>
-	.size	.L.str.2, 16
+<b><span style="color:#000080">	.type</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span>@object        # @<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span>
+<b><span style="color:#000080">.L</span></b><span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">:</span>
+<b><span style="color:#000080">	.asciz</span></b>	<span style="color:#FF0000">"The result is: "</span>
+<b><span style="color:#000080">	.size</span></b>	<span style="color:#990000">.</span>L<span style="color:#990000">.</span><b><span style="color:#0000FF">str</span></b><span style="color:#993399">.2</span><span style="color:#990000">,</span> <span style="color:#993399">16</span>
 
-	.section	.init_array,<font color="#FF0000">"aw"</font>,@init_array
-	.align	8
-	.quad	_GLOBAL__sub_I_test_string_compare.cpp
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#990000">.</span>init_array<span style="color:#990000">,</span><span style="color:#FF0000">"aw"</span><span style="color:#990000">,</span>@init_array
+<b><span style="color:#000080">	.align</span></b>	<span style="color:#993399">8</span>
+<b><span style="color:#000080">	.quad</span></b>	_GLOBAL__sub_I_test_string_compare<span style="color:#990000">.</span>cpp
 
-	.ident	<font color="#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</font>
-	.section	<font color="#FF0000">".note.GNU-stack"</font>,<font color="#FF0000">""</font>,@progbits
-</tt></pre>
+<b><span style="color:#000080">	.ident</span></b>	<span style="color:#FF0000">"clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)"</span>
+<b><span style="color:#000080">	.section</span></b>	<span style="color:#FF0000">".note.GNU-stack"</span><span style="color:#990000">,</span><span style="color:#FF0000">""</span><span style="color:#990000">,</span>@progbits
+</pre>
 </body>
 </html>

--- a/slides/code/08-assembly-64bit/test_string_compare.s.html
+++ b/slides/code/08-assembly-64bit/test_string_compare.s.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/09-advanced-cpp/name-contact.cpp.html
+++ b/slides/code/09-advanced-cpp/name-contact.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/09-advanced-cpp/name-contact.cpp.html
+++ b/slides/code/09-advanced-cpp/name-contact.cpp.html
@@ -1,55 +1,55 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>name-contact.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">Name</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Name</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">myName</font></b><font color="#990000">(</font><font color="#FF0000">""</font><font color="#990000">)</font> <font color="#FF0000">{</font> <font color="#FF0000">}</font>
-    <font color="#990000">~</font><b><font color="#000000">Name</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>  <font color="#FF0000">}</font>
-    <font color="#009900">void</font> <b><font color="#000000">SetName</font></b><font color="#990000">(</font><font color="#008080">string</font> theName<font color="#990000">)</font> <font color="#FF0000">{</font>
-        myName <font color="#990000">=</font> theName<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#009900">void</font> <b><font color="#000000">print</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> myName <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Name</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Name</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">myName</span></b><span style="color:#990000">(</span><span style="color:#FF0000">""</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">}</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">Name</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>  <span style="color:#FF0000">}</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">SetName</span></b><span style="color:#990000">(</span><span style="color:#008080">string</span> theName<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        myName <span style="color:#990000">=</span> theName<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> myName <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">string</font> myName<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">string</span> myName<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">Contact</font><font color="#990000">:</font> <b><font color="#0000FF">public</font></b> Name <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Contact</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        myAddress <font color="#990000">=</font> <font color="#FF0000">""</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#990000">~</font><b><font color="#000000">Contact</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font> <font color="#FF0000">}</font>
-    <font color="#009900">void</font> <b><font color="#000000">SetAddress</font></b><font color="#990000">(</font><font color="#008080">string</font> theAddress<font color="#990000">)</font> <font color="#FF0000">{</font>
-        myAddress <font color="#990000">=</font> theAddress<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <font color="#009900">void</font> <b><font color="#000000">print</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-        Name<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
-        cout <font color="#990000">&lt;&lt;</font> myAddress <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">string</font> myAddress<font color="#990000">;</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Contact</span><span style="color:#990000">:</span> <b><span style="color:#0000FF">public</span></b> Name <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Contact</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        myAddress <span style="color:#990000">=</span> <span style="color:#FF0000">""</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">Contact</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span> <span style="color:#FF0000">}</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">SetAddress</span></b><span style="color:#990000">(</span><span style="color:#008080">string</span> theAddress<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        myAddress <span style="color:#990000">=</span> theAddress<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        Name<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
+        cout <span style="color:#990000">&lt;&lt;</span> myAddress <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">string</span> myAddress<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#008080">Contact</font> c<font color="#990000">;</font>
-    c<font color="#990000">.</font><b><font color="#000000">SetName</font></b><font color="#990000">(</font><font color="#FF0000">"John Doe"</font><font color="#990000">);</font>
-    c<font color="#990000">.</font><b><font color="#000000">SetAddress</font></b><font color="#990000">(</font><font color="#FF0000">"009 Olsson Hall"</font><font color="#990000">);</font>
-    c<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#008080">Contact</span> c<span style="color:#990000">;</span>
+    c<span style="color:#990000">.</span><b><span style="color:#000000">SetName</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"John Doe"</span><span style="color:#990000">);</span>
+    c<span style="color:#990000">.</span><b><span style="color:#000000">SetAddress</span></b><span style="color:#990000">(</span><span style="color:#FF0000">"009 Olsson Hall"</span><span style="color:#990000">);</span>
+    c<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/10-heaps-huffman/binary_heap.cpp.html
+++ b/slides/code/10-heaps-huffman/binary_heap.cpp.html
@@ -1,124 +1,124 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>binary_heap.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Code written by Aaron Bloomfield, 2014</font></i>
-<i><font color="#9A1900">// Released under a CC BY-SA license</font></i>
-<i><font color="#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Code written by Aaron Bloomfield, 2014</span></i>
+<i><span style="color:#9A1900">// Released under a CC BY-SA license</span></i>
+<i><span style="color:#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"binary_heap.h"</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"binary_heap.h"</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// default constructor</font></i>
-binary_heap<font color="#990000">::</font><b><font color="#000000">binary_heap</font></b><font color="#990000">()</font> <font color="#990000">:</font> <b><font color="#000000">heap_size</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    heap<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// default constructor</span></i>
+binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">()</span> <span style="color:#990000">:</span> <b><span style="color:#000000">heap_size</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    heap<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// builds a heap from an unsorted vector</font></i>
-binary_heap<font color="#990000">::</font><b><font color="#000000">binary_heap</font></b><font color="#990000">(</font><font color="#008080">vector&lt;int&gt;</font> vec<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">heap_size</font></b><font color="#990000">(</font>vec<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">())</font> <font color="#FF0000">{</font>
-    heap <font color="#990000">=</font> vec<font color="#990000">;</font>
-    heap<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font>heap<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]);</font>
-    heap<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> heap_size<font color="#990000">/</font><font color="#993399">2</font><font color="#990000">;</font> i <font color="#990000">&gt;</font> <font color="#993399">0</font><font color="#990000">;</font> i<font color="#990000">--</font> <font color="#990000">)</font>
-        <b><font color="#000000">percolateDown</font></b><font color="#990000">(</font>i<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// builds a heap from an unsorted vector</span></i>
+binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">(</span><span style="color:#008080">vector&lt;int&gt;</span> vec<span style="color:#990000">)</span> <span style="color:#990000">:</span> <b><span style="color:#000000">heap_size</span></b><span style="color:#990000">(</span>vec<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">())</span> <span style="color:#FF0000">{</span>
+    heap <span style="color:#990000">=</span> vec<span style="color:#990000">;</span>
+    heap<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span>heap<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+    heap<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> heap_size<span style="color:#990000">/</span><span style="color:#993399">2</span><span style="color:#990000">;</span> i <span style="color:#990000">&gt;</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i<span style="color:#990000">--</span> <span style="color:#990000">)</span>
+        <b><span style="color:#000000">percolateDown</span></b><span style="color:#990000">(</span>i<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// the destructor doesn't need to do much</font></i>
-binary_heap<font color="#990000">::~</font><b><font color="#000000">binary_heap</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-<font color="#FF0000">}</font>
+<i><span style="color:#9A1900">// the destructor doesn't need to do much</span></i>
+binary_heap<span style="color:#990000">::~</span><b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> binary_heap<font color="#990000">::</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// a vector push_back will resize as necessary</font></i>
-    heap<font color="#990000">.</font><b><font color="#000000">push_back</font></b><font color="#990000">(</font>x<font color="#990000">);</font>
-    <i><font color="#9A1900">// move it up into the right position</font></i>
-    <b><font color="#000000">percolateUp</font></b><font color="#990000">(++</font>heap_size<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// a vector push_back will resize as necessary</span></i>
+    heap<span style="color:#990000">.</span><b><span style="color:#000000">push_back</span></b><span style="color:#990000">(</span>x<span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// move it up into the right position</span></i>
+    <b><span style="color:#000000">percolateUp</span></b><span style="color:#990000">(++</span>heap_size<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> binary_heap<font color="#990000">::</font><b><font color="#000000">percolateUp</font></b><font color="#990000">(</font><font color="#009900">int</font> hole<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// get the value just inserted</font></i>
-    <font color="#009900">int</font> x <font color="#990000">=</font> heap<font color="#990000">[</font>hole<font color="#990000">];</font>
-    <i><font color="#9A1900">// while we haven't run off the top and while the</font></i>
-    <i><font color="#9A1900">// value is less than the parent...</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#990000">;</font> <font color="#990000">(</font>hole <font color="#990000">&gt;</font> <font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>x <font color="#990000">&lt;</font> heap<font color="#990000">[</font>hole<font color="#990000">/</font><font color="#993399">2</font><font color="#990000">]);</font> hole <font color="#990000">/=</font> <font color="#993399">2</font> <font color="#990000">)</font>
-        heap<font color="#990000">[</font>hole<font color="#990000">]</font> <font color="#990000">=</font> heap<font color="#990000">[</font>hole<font color="#990000">/</font><font color="#993399">2</font><font color="#990000">];</font> <i><font color="#9A1900">// move the parent down</font></i>
-    <i><font color="#9A1900">// correct position found!  insert at that spot</font></i>
-    heap<font color="#990000">[</font>hole<font color="#990000">]</font> <font color="#990000">=</font> x<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">percolateUp</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> hole<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// get the value just inserted</span></i>
+    <span style="color:#009900">int</span> x <span style="color:#990000">=</span> heap<span style="color:#990000">[</span>hole<span style="color:#990000">];</span>
+    <i><span style="color:#9A1900">// while we haven't run off the top and while the</span></i>
+    <i><span style="color:#9A1900">// value is less than the parent...</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#990000">;</span> <span style="color:#990000">(</span>hole <span style="color:#990000">&gt;</span> <span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>x <span style="color:#990000">&lt;</span> heap<span style="color:#990000">[</span>hole<span style="color:#990000">/</span><span style="color:#993399">2</span><span style="color:#990000">]);</span> hole <span style="color:#990000">/=</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span>
+        heap<span style="color:#990000">[</span>hole<span style="color:#990000">]</span> <span style="color:#990000">=</span> heap<span style="color:#990000">[</span>hole<span style="color:#990000">/</span><span style="color:#993399">2</span><span style="color:#990000">];</span> <i><span style="color:#9A1900">// move the parent down</span></i>
+    <i><span style="color:#9A1900">// correct position found!  insert at that spot</span></i>
+    heap<span style="color:#990000">[</span>hole<span style="color:#990000">]</span> <span style="color:#990000">=</span> x<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> binary_heap<font color="#990000">::</font><b><font color="#000000">deleteMin</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// make sure the heap is not empty</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> heap_size <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">throw</font></b> <font color="#FF0000">"deleteMin() called on empty heap"</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// save the value to be returned</font></i>
-    <font color="#009900">int</font> ret <font color="#990000">=</font> heap<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">];</font>
-    <i><font color="#9A1900">// move the last inserted position into the root</font></i>
-    heap<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">=</font> heap<font color="#990000">[</font>heap_size<font color="#990000">--];</font>
-    <i><font color="#9A1900">// make sure the vector knows that there is one less element</font></i>
-    heap<font color="#990000">.</font><b><font color="#000000">pop_back</font></b><font color="#990000">();</font>
-    <i><font color="#9A1900">// percolate the root down to the proper position</font></i>
-    <b><font color="#000000">percolateDown</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <i><font color="#9A1900">// return the old root node</font></i>
-    <b><font color="#0000FF">return</font></b> ret<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">deleteMin</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// make sure the heap is not empty</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> heap_size <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">throw</span></b> <span style="color:#FF0000">"deleteMin() called on empty heap"</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// save the value to be returned</span></i>
+    <span style="color:#009900">int</span> ret <span style="color:#990000">=</span> heap<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+    <i><span style="color:#9A1900">// move the last inserted position into the root</span></i>
+    heap<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">=</span> heap<span style="color:#990000">[</span>heap_size<span style="color:#990000">--];</span>
+    <i><span style="color:#9A1900">// make sure the vector knows that there is one less element</span></i>
+    heap<span style="color:#990000">.</span><b><span style="color:#000000">pop_back</span></b><span style="color:#990000">();</span>
+    <i><span style="color:#9A1900">// percolate the root down to the proper position</span></i>
+    <b><span style="color:#000000">percolateDown</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">// return the old root node</span></i>
+    <b><span style="color:#0000FF">return</span></b> ret<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> binary_heap<font color="#990000">::</font><b><font color="#000000">percolateDown</font></b><font color="#990000">(</font><font color="#009900">int</font> hole<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">// get the value to percolate down</font></i>
-    <font color="#009900">int</font> x <font color="#990000">=</font> heap<font color="#990000">[</font>hole<font color="#990000">];</font>
-    <i><font color="#9A1900">// while there is a left child...</font></i>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> hole<font color="#990000">*</font><font color="#993399">2</font> <font color="#990000">&lt;=</font> heap_size <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <font color="#009900">int</font> child <font color="#990000">=</font> hole<font color="#990000">*</font><font color="#993399">2</font><font color="#990000">;</font> <i><font color="#9A1900">// the left child</font></i>
-        <i><font color="#9A1900">// is there a right child?  if so, is it lesser?</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>child<font color="#990000">+</font><font color="#993399">1</font> <font color="#990000">&lt;=</font> heap_size<font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>heap<font color="#990000">[</font>child<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;</font> heap<font color="#990000">[</font>child<font color="#990000">])</font> <font color="#990000">)</font>
-            child<font color="#990000">++;</font>
-        <i><font color="#9A1900">// if the child is greater than the node...</font></i>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> x <font color="#990000">&gt;</font> heap<font color="#990000">[</font>child<font color="#990000">]</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            heap<font color="#990000">[</font>hole<font color="#990000">]</font> <font color="#990000">=</font> heap<font color="#990000">[</font>child<font color="#990000">];</font> <i><font color="#9A1900">// move child up</font></i>
-            hole <font color="#990000">=</font> child<font color="#990000">;</font>             <i><font color="#9A1900">// move hole down</font></i>
-        <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b>
-            <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// correct position found!  insert at that spot</font></i>
-    heap<font color="#990000">[</font>hole<font color="#990000">]</font> <font color="#990000">=</font> x<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">percolateDown</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> hole<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">// get the value to percolate down</span></i>
+    <span style="color:#009900">int</span> x <span style="color:#990000">=</span> heap<span style="color:#990000">[</span>hole<span style="color:#990000">];</span>
+    <i><span style="color:#9A1900">// while there is a left child...</span></i>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> hole<span style="color:#990000">*</span><span style="color:#993399">2</span> <span style="color:#990000">&lt;=</span> heap_size <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">int</span> child <span style="color:#990000">=</span> hole<span style="color:#990000">*</span><span style="color:#993399">2</span><span style="color:#990000">;</span> <i><span style="color:#9A1900">// the left child</span></i>
+        <i><span style="color:#9A1900">// is there a right child?  if so, is it lesser?</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>child<span style="color:#990000">+</span><span style="color:#993399">1</span> <span style="color:#990000">&lt;=</span> heap_size<span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>heap<span style="color:#990000">[</span>child<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;</span> heap<span style="color:#990000">[</span>child<span style="color:#990000">])</span> <span style="color:#990000">)</span>
+            child<span style="color:#990000">++;</span>
+        <i><span style="color:#9A1900">// if the child is greater than the node...</span></i>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> x <span style="color:#990000">&gt;</span> heap<span style="color:#990000">[</span>child<span style="color:#990000">]</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            heap<span style="color:#990000">[</span>hole<span style="color:#990000">]</span> <span style="color:#990000">=</span> heap<span style="color:#990000">[</span>child<span style="color:#990000">];</span> <i><span style="color:#9A1900">// move child up</span></i>
+            hole <span style="color:#990000">=</span> child<span style="color:#990000">;</span>             <i><span style="color:#9A1900">// move hole down</span></i>
+        <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b>
+            <b><span style="color:#0000FF">break</span></b><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// correct position found!  insert at that spot</span></i>
+    heap<span style="color:#990000">[</span>hole<span style="color:#990000">]</span> <span style="color:#990000">=</span> x<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> binary_heap<font color="#990000">::</font><b><font color="#000000">findMin</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> heap_size <font color="#990000">==</font> <font color="#993399">0</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">throw</font></b> <font color="#FF0000">"findMin() called on empty heap"</font><font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> heap<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">];</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">findMin</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> heap_size <span style="color:#990000">==</span> <span style="color:#993399">0</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">throw</span></b> <span style="color:#FF0000">"findMin() called on empty heap"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> heap<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">unsigned</font> <font color="#009900">int</font> binary_heap<font color="#990000">::</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> heap_size<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> heap_size<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> binary_heap<font color="#990000">::</font><b><font color="#000000">makeEmpty</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    heap_size <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    heap<font color="#990000">.</font><b><font color="#000000">resize</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    heap_size <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    heap<span style="color:#990000">.</span><b><span style="color:#000000">resize</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">bool</font> binary_heap<font color="#990000">::</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> heap_size <font color="#990000">==</font> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">bool</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> heap_size <span style="color:#990000">==</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">void</font> binary_heap<font color="#990000">::</font><b><font color="#000000">print</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"("</font> <font color="#990000">&lt;&lt;</font> heap<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">") "</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;=</font> heap_size<font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> heap<font color="#990000">[</font>i<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" "</font><font color="#990000">;</font>
-        <i><font color="#9A1900">// next line from http://tinyurl.com/mf9tbgm</font></i>
-        <font color="#009900">bool</font> isPow2 <font color="#990000">=</font> <font color="#990000">(((</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">&amp;</font> <font color="#990000">~(</font>i<font color="#990000">))==(</font>i<font color="#990000">+</font><font color="#993399">1</font><font color="#990000">))?</font> i<font color="#990000">+</font><font color="#993399">1</font> <font color="#990000">:</font> <font color="#993399">0</font><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> isPow2 <font color="#990000">)</font>
-            cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">void</span> binary_heap<span style="color:#990000">::</span><b><span style="color:#000000">print</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"("</span> <span style="color:#990000">&lt;&lt;</span> heap<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">") "</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;=</span> heap_size<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> heap<span style="color:#990000">[</span>i<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" "</span><span style="color:#990000">;</span>
+        <i><span style="color:#9A1900">// next line from http://tinyurl.com/mf9tbgm</span></i>
+        <span style="color:#009900">bool</span> isPow2 <span style="color:#990000">=</span> <span style="color:#990000">(((</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;</span> <span style="color:#990000">~(</span>i<span style="color:#990000">))==(</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">))?</span> i<span style="color:#990000">+</span><span style="color:#993399">1</span> <span style="color:#990000">:</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> isPow2 <span style="color:#990000">)</span>
+            cout <span style="color:#990000">&lt;&lt;</span> endl <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/10-heaps-huffman/binary_heap.cpp.html
+++ b/slides/code/10-heaps-huffman/binary_heap.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/10-heaps-huffman/binary_heap.h.html
+++ b/slides/code/10-heaps-huffman/binary_heap.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/10-heaps-huffman/binary_heap.h.html
+++ b/slides/code/10-heaps-huffman/binary_heap.h.html
@@ -1,47 +1,47 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>binary_heap.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Code written by Aaron Bloomfield, 2014</font></i>
-<i><font color="#9A1900">// Released under a CC BY-SA license</font></i>
-<i><font color="#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Code written by Aaron Bloomfield, 2014</span></i>
+<i><span style="color:#9A1900">// Released under a CC BY-SA license</span></i>
+<i><span style="color:#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</span></i>
 
-<b><font color="#000080">#ifndef</font></b> BINARY_HEAP_H
-<b><font color="#000080">#define</font></b> BINARY_HEAP_H
+<b><span style="color:#000080">#ifndef</span></b> BINARY_HEAP_H
+<b><span style="color:#000080">#define</span></b> BINARY_HEAP_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;vector&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;vector&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">binary_heap</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">binary_heap</font></b><font color="#990000">();</font>
-    <b><font color="#000000">binary_heap</font></b><font color="#990000">(</font><font color="#008080">vector&lt;int&gt;</font> vec<font color="#990000">);</font>
-    <font color="#990000">~</font><b><font color="#000000">binary_heap</font></b><font color="#990000">();</font>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">binary_heap</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">(</span><span style="color:#008080">vector&lt;int&gt;</span> vec<span style="color:#990000">);</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">binary_heap</span></b><span style="color:#990000">();</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">insert</font></b><font color="#990000">(</font><font color="#009900">int</font> x<font color="#990000">);</font>
-    <font color="#009900">int</font> <b><font color="#000000">findMin</font></b><font color="#990000">();</font>
-    <font color="#009900">int</font> <b><font color="#000000">deleteMin</font></b><font color="#990000">();</font>
-    <font color="#009900">unsigned</font> <font color="#009900">int</font> <b><font color="#000000">size</font></b><font color="#990000">();</font>
-    <font color="#009900">void</font> <b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>
-    <font color="#009900">bool</font> <b><font color="#000000">isEmpty</font></b><font color="#990000">();</font>
-    <font color="#009900">void</font> <b><font color="#000000">print</font></b><font color="#990000">();</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> x<span style="color:#990000">);</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">findMin</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">int</span> <b><span style="color:#000000">deleteMin</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> <b><span style="color:#000000">size</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">bool</span> <b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">();</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
 
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#008080">vector&lt;int&gt;</font> heap<font color="#990000">;</font>
-    <font color="#009900">unsigned</font> <font color="#009900">int</font> heap_size<font color="#990000">;</font>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#008080">vector&lt;int&gt;</span> heap<span style="color:#990000">;</span>
+    <span style="color:#009900">unsigned</span> <span style="color:#009900">int</span> heap_size<span style="color:#990000">;</span>
 
-    <font color="#009900">void</font> <b><font color="#000000">percolateUp</font></b><font color="#990000">(</font><font color="#009900">int</font> hole<font color="#990000">);</font>
-    <font color="#009900">void</font> <b><font color="#000000">percolateDown</font></b><font color="#990000">(</font><font color="#009900">int</font> hole<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">percolateUp</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> hole<span style="color:#990000">);</span>
+    <span style="color:#009900">void</span> <b><span style="color:#000000">percolateDown</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> hole<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
 
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/slides/code/10-heaps-huffman/heap-test.cpp.html
+++ b/slides/code/10-heaps-huffman/heap-test.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/10-heaps-huffman/heap-test.cpp.html
+++ b/slides/code/10-heaps-huffman/heap-test.cpp.html
@@ -1,71 +1,71 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>heap-test.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// Code written by Aaron Bloomfield, 2014</font></i>
-<i><font color="#9A1900">// Released under a CC BY-SA license</font></i>
-<i><font color="#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">// Code written by Aaron Bloomfield, 2014</span></i>
+<i><span style="color:#9A1900">// Released under a CC BY-SA license</span></i>
+<i><span style="color:#9A1900">// This code is part of the https://github.com/aaronbloomfield/pdr repository</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;time.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;time.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"binary_heap.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"binary_heap.h"</span>
 
-<font color="#008080">binary_heap</font> bh<font color="#990000">;</font>
+<span style="color:#008080">binary_heap</span> bh<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#000000">srand</font></b><font color="#990000">(</font><b><font color="#000000">time</font></b><font color="#990000">(</font>NULL<font color="#990000">));</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"isEmpty(): "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">try</font></b> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">findMin</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">catch</font></b> <font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>e<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Exception thrown: "</font> <font color="#990000">&lt;&lt;</font> e <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">try</font></b> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">deleteMin</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">catch</font></b> <font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>e<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Exception thrown: "</font> <font color="#990000">&lt;&lt;</font> e <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"inserting a value into the heap..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#000000">rand</font></b><font color="#990000">()</font> <font color="#990000">%</font> <font color="#993399">1000</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"isEmpty(): "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">try</font></b> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">findMin</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">catch</font></b> <font color="#990000">(</font><b><font color="#0000FF">const</font></b> <font color="#009900">char</font> <font color="#990000">*</font>e<font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Exception thrown: "</font> <font color="#990000">&lt;&lt;</font> e <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">40</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        bh<font color="#990000">.</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><b><font color="#000000">rand</font></b><font color="#990000">()</font> <font color="#990000">%</font> <font color="#993399">1000</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">findMin</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size: "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"deleting min..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#009900">int</font> min <font color="#990000">=</font> bh<font color="#990000">.</font><b><font color="#000000">deleteMin</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">"</font> <font color="#990000">&lt;&lt;</font> min <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size: "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">print</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"isEmpty(): "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling makeEmpty()"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">makeEmpty</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"isEmpty(): "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"inserting a value into the heap..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">insert</font></b><font color="#990000">(</font><font color="#993399">100</font><font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size: "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"deleting min..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    bh<font color="#990000">.</font><b><font color="#000000">deleteMin</font></b><font color="#990000">();</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"size: "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">size</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"isEmpty(): "</font> <font color="#990000">&lt;&lt;</font> bh<font color="#990000">.</font><b><font color="#000000">isEmpty</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#000000">srand</span></b><span style="color:#990000">(</span><b><span style="color:#000000">time</span></b><span style="color:#990000">(</span>NULL<span style="color:#990000">));</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"isEmpty(): "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">try</span></b> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">findMin</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">catch</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>e<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Exception thrown: "</span> <span style="color:#990000">&lt;&lt;</span> e <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">try</span></b> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">deleteMin</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">catch</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>e<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Exception thrown: "</span> <span style="color:#990000">&lt;&lt;</span> e <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"inserting a value into the heap..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#000000">rand</span></b><span style="color:#990000">()</span> <span style="color:#990000">%</span> <span style="color:#993399">1000</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"isEmpty(): "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">try</span></b> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">findMin</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">catch</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">const</span></b> <span style="color:#009900">char</span> <span style="color:#990000">*</span>e<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Exception thrown: "</span> <span style="color:#990000">&lt;&lt;</span> e <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">40</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        bh<span style="color:#990000">.</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><b><span style="color:#000000">rand</span></b><span style="color:#990000">()</span> <span style="color:#990000">%</span> <span style="color:#993399">1000</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">findMin</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size: "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"deleting min..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> min <span style="color:#990000">=</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">deleteMin</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> min <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size: "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">print</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"isEmpty(): "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"calling makeEmpty()"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">makeEmpty</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"isEmpty(): "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"inserting a value into the heap..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">insert</span></b><span style="color:#990000">(</span><span style="color:#993399">100</span><span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size: "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"deleting min..."</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    bh<span style="color:#990000">.</span><b><span style="color:#000000">deleteMin</span></b><span style="color:#990000">();</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"size: "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">size</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"isEmpty(): "</span> <span style="color:#990000">&lt;&lt;</span> bh<span style="color:#990000">.</span><b><span style="color:#000000">isEmpty</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/code/12-memory/cache.cpp.html
+++ b/slides/code/12-memory/cache.cpp.html
@@ -1,39 +1,39 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>cache.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;unistd.h&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;unistd.h&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">void</font><font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"page size: "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">getpagesize</font></b><font color="#990000">()</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#009900">int</font> array<font color="#990000">[</font><font color="#993399">1024</font><font color="#990000">][</font><font color="#993399">1024</font><font color="#990000">];</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> j <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> j <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> j<font color="#990000">++</font> <font color="#990000">)</font>
-            array<font color="#990000">[</font>i<font color="#990000">][</font>j<font color="#990000">]</font> <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> c <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> c <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> c<font color="#990000">++</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-            <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> j <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> j <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> j<font color="#990000">++</font> <font color="#990000">)</font>
-                array<font color="#990000">[</font>i<font color="#990000">][</font>j<font color="#990000">]++;</font>
-    <font color="#009900">int</font> sum <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> i<font color="#990000">++</font> <font color="#990000">)</font>
-        <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> j <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> j <font color="#990000">&lt;</font> <font color="#993399">1024</font><font color="#990000">;</font> j<font color="#990000">++</font> <font color="#990000">)</font>
-            sum <font color="#990000">+=</font> array<font color="#990000">[</font>i<font color="#990000">][</font>j<font color="#990000">];</font>
-    cout <font color="#990000">&lt;&lt;</font> sum <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">void</span><span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"page size: "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">getpagesize</span></b><span style="color:#990000">()</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> array<span style="color:#990000">[</span><span style="color:#993399">1024</span><span style="color:#990000">][</span><span style="color:#993399">1024</span><span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> j <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> j <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> j<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+            array<span style="color:#990000">[</span>i<span style="color:#990000">][</span>j<span style="color:#990000">]</span> <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> c <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> c <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> c<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> j <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> j <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> j<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+                array<span style="color:#990000">[</span>i<span style="color:#990000">][</span>j<span style="color:#990000">]++;</span>
+    <span style="color:#009900">int</span> sum <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> j <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> j <span style="color:#990000">&lt;</span> <span style="color:#993399">1024</span><span style="color:#990000">;</span> j<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+            sum <span style="color:#990000">+=</span> array<span style="color:#990000">[</span>i<span style="color:#990000">][</span>j<span style="color:#990000">];</span>
+    cout <span style="color:#990000">&lt;&lt;</span> sum <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<i><font color="#9A1900">// average time for i as outer, j as inner: 2.696  sec</font></i>
-<i><font color="#9A1900">// average time for j as outer, i as inner: 124.947 sec</font></i>
-<i><font color="#9A1900">// a factor of 46.345</font></i>
-</tt></pre>
+<i><span style="color:#9A1900">// average time for i as outer, j as inner: 2.696  sec</span></i>
+<i><span style="color:#9A1900">// average time for j as outer, i as inner: 124.947 sec</span></i>
+<i><span style="color:#9A1900">// a factor of 46.345</span></i>
+</pre>
 </body>
 </html>

--- a/slides/code/12-memory/cache.cpp.html
+++ b/slides/code/12-memory/cache.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/12-memory/strings.c.html
+++ b/slides/code/12-memory/strings.c.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/code/12-memory/strings.c.html
+++ b/slides/code/12-memory/strings.c.html
@@ -1,36 +1,36 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>strings.c</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font>
-    <i><font color="#9A1900">// allocate a space in memory for result</font></i>
-    <font color="#009900">char</font> <font color="#990000">*</font>result <font color="#990000">=</font> <font color="#990000">(</font><font color="#009900">char</font> <font color="#990000">*)</font> <b><font color="#000000">malloc</font></b> <font color="#990000">(</font><b><font color="#0000FF">sizeof</font></b> <font color="#990000">(*</font>result<font color="#990000">));</font>
-    <font color="#990000">*</font>result <font color="#990000">=</font> <font color="#FF0000">'</font><font color="#CC33CC">\0</font><font color="#FF0000">'</font><font color="#990000">;</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font>i <font color="#990000">&lt;</font> argc<font color="#990000">)</font> <font color="#FF0000">{</font>  <i><font color="#9A1900">// while there are still arguments</font></i>
-        <font color="#009900">char</font> <font color="#990000">*</font>s <font color="#990000">=</font> <font color="#990000">(</font><font color="#009900">char</font> <font color="#990000">*)</font> <b><font color="#000000">malloc</font></b> <font color="#990000">(</font><b><font color="#0000FF">sizeof</font></b> <font color="#990000">(*</font>s<font color="#990000">)</font> <font color="#990000">*</font>
-                                   <font color="#990000">(</font><b><font color="#000000">strlen</font></b> <font color="#990000">(</font>result<font color="#990000">)</font> <font color="#990000">+</font> <b><font color="#000000">strlen</font></b> <font color="#990000">(</font>argv<font color="#990000">[</font>i<font color="#990000">])</font> <font color="#990000">+</font> <font color="#993399">1</font><font color="#990000">));</font>
-        <b><font color="#000000">strcpy</font></b> <font color="#990000">(</font>s<font color="#990000">,</font> result<font color="#990000">);</font>
-        <i><font color="#9A1900">// add "free(result); here...</font></i>
-        <b><font color="#000000">strcat</font></b> <font color="#990000">(</font>s<font color="#990000">,</font> argv<font color="#990000">[</font>i<font color="#990000">]);</font>
-        <i><font color="#9A1900">// ... or here</font></i>
-        result <font color="#990000">=</font> s<font color="#990000">;</font>
-        i<font color="#990000">++;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Concatenation: %s</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> result<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// allocate a space in memory for result</span></i>
+    <span style="color:#009900">char</span> <span style="color:#990000">*</span>result <span style="color:#990000">=</span> <span style="color:#990000">(</span><span style="color:#009900">char</span> <span style="color:#990000">*)</span> <b><span style="color:#000000">malloc</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(*</span>result<span style="color:#990000">));</span>
+    <span style="color:#990000">*</span>result <span style="color:#990000">=</span> <span style="color:#FF0000">'</span><span style="color:#CC33CC">\0</span><span style="color:#FF0000">'</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span>i <span style="color:#990000">&lt;</span> argc<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>  <i><span style="color:#9A1900">// while there are still arguments</span></i>
+        <span style="color:#009900">char</span> <span style="color:#990000">*</span>s <span style="color:#990000">=</span> <span style="color:#990000">(</span><span style="color:#009900">char</span> <span style="color:#990000">*)</span> <b><span style="color:#000000">malloc</span></b> <span style="color:#990000">(</span><b><span style="color:#0000FF">sizeof</span></b> <span style="color:#990000">(*</span>s<span style="color:#990000">)</span> <span style="color:#990000">*</span>
+                                   <span style="color:#990000">(</span><b><span style="color:#000000">strlen</span></b><span style="color:#990000">(</span>result<span style="color:#990000">)</span> <span style="color:#990000">+</span> <b><span style="color:#000000">strlen</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>i<span style="color:#990000">])</span> <span style="color:#990000">+</span> <span style="color:#993399">1</span><span style="color:#990000">));</span>
+        <b><span style="color:#000000">strcpy</span></b> <span style="color:#990000">(</span>s<span style="color:#990000">,</span> result<span style="color:#990000">);</span>
+        <i><span style="color:#9A1900">// add "free(result); here...</span></i>
+        <b><span style="color:#000000">strcat</span></b> <span style="color:#990000">(</span>s<span style="color:#990000">,</span> argv<span style="color:#990000">[</span>i<span style="color:#990000">]);</span>
+        <i><span style="color:#9A1900">// ... or here</span></i>
+        result <span style="color:#990000">=</span> s<span style="color:#990000">;</span>
+        i<span style="color:#990000">++;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Concatenation: %s</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> result<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/slides/graphs/Makefile.html
+++ b/slides/graphs/Makefile.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">graphs:</span>
+	@echo Making all graphs into .svg files<span style="color:#990000">...</span>
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep -v Red-black <span style="color:#990000">|</span> grep -v graph <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep -v Red-black <span style="color:#990000">|</span> grep -v graph <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep -v Red-black <span style="color:#990000">|</span> grep -v graph <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep Red-black <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg -Kneato "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep Red-black <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps -Kneato "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls <span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> grep Red-black <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kneato "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg -Kneato "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps -Kneato "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kneato "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">56</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">56</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">56</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg -Kneato -Gstart=5 "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps -Kneato -Gstart=5 "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kneato -Gstart=5 "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">8</span><span style="color:#990000">]</span>.dot graph-<span style="color:#993399">13</span><span style="color:#990000">?</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tsvg -Kfdp "$$1".dot -o "$$1".svg"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">8</span><span style="color:#990000">]</span>.dot graph-<span style="color:#993399">13</span><span style="color:#990000">?</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tps -Kfdp "$$1".dot -o "$$1".ps"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">8</span><span style="color:#990000">]</span>.dot graph-<span style="color:#993399">13</span><span style="color:#990000">?</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kfdp "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+
+<span style="color:#990000">graphpngs:</span>
+	@ls graph-<span style="color:#990000">*</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kneato "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">56</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">4</span><span style="color:#990000">]</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kneato -Gstart=5 "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+	@ls graph-<span style="color:#990000">[</span><span style="color:#993399">8</span><span style="color:#990000">]</span>.dot graph-<span style="color:#993399">13</span><span style="color:#990000">?</span>.dot <span style="color:#990000">|</span> sed s<span style="color:#990000">/</span>.dot//g <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "dot -Tpng -Kfdp "$$1".dot -o "$$1".png"}'</span> <span style="color:#990000">|</span> bash
+
+<span style="color:#990000">markdown:</span>
+	@ls <span style="color:#990000">*</span>.svg <span style="color:#990000">|</span> awk <span style="color:#FF0000">'{print "["$$1"]("$$1"), "}'</span>
+
+<span style="color:#990000">clean:</span>
+	/bin/rm -f <span style="color:#990000">*</span>.ps <span style="color:#990000">*</span>.png <span style="color:#990000">*~</span>
+</pre>
+</body>
+</html>

--- a/slides/graphs/Makefile.html
+++ b/slides/graphs/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/graphs/generate-graph-12.cpp.html
+++ b/slides/graphs/generate-graph-12.cpp.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>generate-graph-12.cpp</title>
+</head>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;math.h&gt;</span>
+
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> num<span style="color:#990000">,</span> ret<span style="color:#990000">;</span>
+    <span style="color:#009900">float</span> radius <span style="color:#990000">=</span> <span style="color:#993399">5.0</span><span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// error checks</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">3</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" &lt;num&gt; [&lt;radius&gt;]"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    ret <span style="color:#990000">=</span> <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%d"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>num<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> ret <span style="color:#990000">!=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Bad number format: '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">3</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        ret <span style="color:#990000">=</span> <b><span style="color:#000000">sscanf</span></b> <span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">],</span> <span style="color:#FF0000">"%f"</span><span style="color:#990000">,</span> <span style="color:#990000">&amp;</span>radius<span style="color:#990000">);</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> ret <span style="color:#990000">!=</span> <span style="color:#993399">1</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cerr <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Bad radius format: '"</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"'"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// print header</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"# This graph generated with "</span> <span style="color:#990000">&lt;&lt;</span> num <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" nodes"</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" and the radius set to the default of 5.0"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" and a radius of "</span> <span style="color:#990000">&lt;&lt;</span> radius <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"digraph G {"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">graph [fontname = </span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">Helvetica</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">];"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">node [fontname = </span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">Helvetica</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">,shape=circle,width=0.6];"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">edge [fontname = </span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">Helvetica</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">,dir=none];"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// generate node positions</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> num<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <span style="color:#009900">double</span> angle <span style="color:#990000">=</span> <span style="color:#993399">360.0</span><span style="color:#990000">/((</span><span style="color:#009900">double</span><span style="color:#990000">)</span>num<span style="color:#990000">)</span> <span style="color:#990000">*</span> i <span style="color:#990000">*</span> <span style="color:#990000">(</span>M_PI<span style="color:#990000">/</span><span style="color:#993399">180.0</span><span style="color:#990000">);</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">v"</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">(</span>i<span style="color:#990000">+</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" [pin=true,pos=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">"</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">sin</span></b><span style="color:#990000">(</span>angle<span style="color:#990000">)*</span>radius <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">","</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">cos</span></b><span style="color:#990000">(</span>angle<span style="color:#990000">)*</span>radius <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">];"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// generate edges</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;=</span> num<span style="color:#990000">;</span> i<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+        <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> j <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> j <span style="color:#990000">&lt;=</span> num<span style="color:#990000">;</span> j<span style="color:#990000">++</span> <span style="color:#990000">)</span>
+            <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> i <span style="color:#990000">&lt;</span> j <span style="color:#990000">)</span>
+                cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\t</span><span style="color:#FF0000">v"</span> <span style="color:#990000">&lt;&lt;</span> i <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" -&gt; "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"v"</span> <span style="color:#990000">&lt;&lt;</span> j <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">";"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"}"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
+</body>
+</html>

--- a/slides/graphs/generate-graph-12.cpp.html
+++ b/slides/graphs/generate-graph-12.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/x86/32bit/Makefile.html
+++ b/slides/x86/32bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/slides/x86/32bit/Makefile.html
+++ b/slides/x86/32bit/Makefile.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">main:</span>
+	dot -Tsvg -O x86-cc-stack-64.dot
+	dot -Tsvg -O x86-cc-esp-64.dot
+	dot -Tsvg -O x86-cc-regs-64.dot
+	dot -Tpng -O x86-cc-stack-64.dot
+	dot -Tpng -O x86-cc-esp-64.dot
+	dot -Tpng -O x86-cc-regs-64.dot
+</pre>
+</body>
+</html>

--- a/slides/x86/64bit/Makefile.html
+++ b/slides/x86/64bit/Makefile.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">main:</span>
+	dot -Tsvg -O x86-cc-stack.dot
+	dot -Tsvg -O x86-cc-rsp.dot
+	dot -Tsvg -O x86-cc-regs.dot
+	dot -Tpng -O x86-cc-stack.dot
+	dot -Tpng -O x86-cc-rsp.dot
+	dot -Tpng -O x86-cc-regs.dot
+</pre>
+</body>
+</html>

--- a/slides/x86/64bit/Makefile.html
+++ b/slides/x86/64bit/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/02-gdb/debug.cpp.html
+++ b/tutorials/02-gdb/debug.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/02-gdb/debug.cpp.html
+++ b/tutorials/02-gdb/debug.cpp.html
@@ -1,82 +1,82 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>debug.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-<i><font color="#9A1900">// This program reads five numbers from the keyboard, and prints out the</font></i>
-<i><font color="#9A1900">// average and the maximum value</font></i>
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// This program reads five numbers from the keyboard, and prints out the</span></i>
+<i><span style="color:#9A1900">// average and the maximum value</span></i>
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Global Constants</font></i>
-<b><font color="#0000FF">const</font></b> <font color="#009900">int</font> MAX <font color="#990000">=</font> <font color="#993399">5</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// Global Constants</span></i>
+<b><span style="color:#0000FF">const</span></b> <span style="color:#009900">int</span> MAX <span style="color:#990000">=</span> <span style="color:#993399">5</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Function Prototypes</font></i>
-<font color="#009900">double</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">);</font>
-<font color="#009900">int</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax <font color="#990000">);</font>
-
-
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-
-    <font color="#009900">int</font> nValues<font color="#990000">[</font>MAX<font color="#990000">];</font>
-    <font color="#009900">int</font> nCount<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// Display a prompt:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter five numbers: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// First we read in the numbers.</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> nCount <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> nCount <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> nCount<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter the next number : "</font><font color="#990000">;</font>
-        cin <font color="#990000">&gt;&gt;</font> nValues<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">];</font>
-    <font color="#FF0000">}</font>
-
-    <i><font color="#9A1900">// Now we echo the input back to the user</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> nCount <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> nCount <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> nCount<font color="#990000">++)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Value [ "</font> <font color="#990000">&lt;&lt;</font> nCount <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"] is : "</font> <font color="#990000">&lt;&lt;</font> nValues<font color="#990000">[</font>nCount<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-
-    <i><font color="#9A1900">// Now lets call a function to get the average:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The average is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font>nValues<font color="#990000">,</font> MAX <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// Now lets call a function to get the max:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The max is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font>nValues<font color="#990000">,</font> MAX <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of main</font></i>
+<i><span style="color:#9A1900">// Function Prototypes</span></i>
+<span style="color:#009900">double</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">);</span>
+<span style="color:#009900">int</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax <span style="color:#990000">);</span>
 
 
-<font color="#009900">double</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font><font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">)</font> <font color="#FF0000">{</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
 
-    <font color="#009900">double</font> temp <font color="#990000">=</font> <font color="#993399">0.0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&gt;</font> nMax<font color="#990000">;</font> i<font color="#990000">++)</font>
-        temp <font color="#990000">+=</font> nIn<font color="#990000">[</font>i<font color="#990000">];</font>
-    temp <font color="#990000">/=</font> nMax<font color="#990000">;</font>
+    <span style="color:#009900">int</span> nValues<span style="color:#990000">[</span>MAX<span style="color:#990000">];</span>
+    <span style="color:#009900">int</span> nCount<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of GetAverage()</font></i>
+    <i><span style="color:#9A1900">// Display a prompt:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter five numbers: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <i><span style="color:#9A1900">// First we read in the numbers.</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> nCount <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> nCount <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> nCount<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter the next number : "</span><span style="color:#990000">;</span>
+        cin <span style="color:#990000">&gt;&gt;</span> nValues<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// Now we echo the input back to the user</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> nCount <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> nCount <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> nCount<span style="color:#990000">++)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Value [ "</span> <span style="color:#990000">&lt;&lt;</span> nCount <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"] is : "</span> <span style="color:#990000">&lt;&lt;</span> nValues<span style="color:#990000">[</span>nCount<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// Now lets call a function to get the average:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The average is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span>nValues<span style="color:#990000">,</span> MAX <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <i><span style="color:#9A1900">// Now lets call a function to get the max:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The max is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span>nValues<span style="color:#990000">,</span> MAX <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of main</span></i>
 
 
-<font color="#009900">int</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> nBiggest <font color="#990000">=</font> nIn<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">];</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> nMax<font color="#990000">;</font> i<font color="#990000">++)</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>nBiggest <font color="#990000">&gt;</font> nIn<font color="#990000">[</font>i<font color="#990000">])</font>
-            nBiggest <font color="#990000">=</font> nIn<font color="#990000">[</font>i<font color="#990000">];</font>
-    <b><font color="#0000FF">return</font></b> nBiggest<font color="#990000">;</font>
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of GetMax()</font></i>
+<span style="color:#009900">double</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
 
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-<i><font color="#9A1900">// END OF LISTING</font></i>
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-</tt></pre>
+    <span style="color:#009900">double</span> temp <span style="color:#990000">=</span> <span style="color:#993399">0.0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&gt;</span> nMax<span style="color:#990000">;</span> i<span style="color:#990000">++)</span>
+        temp <span style="color:#990000">+=</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+    temp <span style="color:#990000">/=</span> nMax<span style="color:#990000">;</span>
+
+    <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of GetAverage()</span></i>
+
+
+<span style="color:#009900">int</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> nBiggest <span style="color:#990000">=</span> nIn<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> nMax<span style="color:#990000">;</span> i<span style="color:#990000">++)</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>nBiggest <span style="color:#990000">&gt;</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">])</span>
+            nBiggest <span style="color:#990000">=</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">return</span></b> nBiggest<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of GetMax()</span></i>
+
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// END OF LISTING</span></i>
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+</pre>
 </body>
 </html>

--- a/tutorials/02-gdb/prog1.cpp.html
+++ b/tutorials/02-gdb/prog1.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/02-gdb/prog1.cpp.html
+++ b/tutorials/02-gdb/prog1.cpp.html
@@ -1,29 +1,29 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>prog1.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">my_subroutine</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Hello world"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">my_subroutine</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Hello world"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> x <font color="#990000">=</font> <font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>p <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <b><font color="#000000">my_subroutine</font></b><font color="#990000">();</font>
-    <font color="#990000">*</font>p <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> <font color="#FF0000">", "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>p <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> x <span style="color:#990000">=</span> <span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>p <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <b><span style="color:#000000">my_subroutine</span></b><span style="color:#990000">();</span>
+    <span style="color:#990000">*</span>p <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">", "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>p <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/02-lldb/debug.cpp.html
+++ b/tutorials/02-lldb/debug.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/02-lldb/debug.cpp.html
+++ b/tutorials/02-lldb/debug.cpp.html
@@ -1,82 +1,82 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>debug.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-<i><font color="#9A1900">// This program reads five numbers from the keyboard, and prints out the</font></i>
-<i><font color="#9A1900">// average and the maximum value</font></i>
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// This program reads five numbers from the keyboard, and prints out the</span></i>
+<i><span style="color:#9A1900">// average and the maximum value</span></i>
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Global Constants</font></i>
-<b><font color="#0000FF">const</font></b> <font color="#009900">int</font> MAX <font color="#990000">=</font> <font color="#993399">5</font><font color="#990000">;</font>
+<i><span style="color:#9A1900">// Global Constants</span></i>
+<b><span style="color:#0000FF">const</span></b> <span style="color:#009900">int</span> MAX <span style="color:#990000">=</span> <span style="color:#993399">5</span><span style="color:#990000">;</span>
 
-<i><font color="#9A1900">// Function Prototypes</font></i>
-<font color="#009900">double</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">);</font>
-<font color="#009900">int</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax <font color="#990000">);</font>
-
-
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-
-    <font color="#009900">int</font> nValues<font color="#990000">[</font>MAX<font color="#990000">];</font>
-    <font color="#009900">int</font> nCount<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// Display a prompt:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter five numbers: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// First we read in the numbers.</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> nCount <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> nCount <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> nCount<font color="#990000">++</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter the next number : "</font><font color="#990000">;</font>
-        cin <font color="#990000">&gt;&gt;</font> nValues<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">];</font>
-    <font color="#FF0000">}</font>
-
-    <i><font color="#9A1900">// Now we echo the input back to the user</font></i>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> nCount <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> nCount <font color="#990000">&lt;</font> MAX<font color="#990000">;</font> nCount<font color="#990000">++)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Value [ "</font> <font color="#990000">&lt;&lt;</font> nCount <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"] is : "</font> <font color="#990000">&lt;&lt;</font> nValues<font color="#990000">[</font>nCount<font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-
-    <i><font color="#9A1900">// Now lets call a function to get the average:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The average is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font>nValues<font color="#990000">,</font> MAX <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <i><font color="#9A1900">// Now lets call a function to get the max:</font></i>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The max is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font>nValues<font color="#990000">,</font> MAX <font color="#990000">)</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of main</font></i>
+<i><span style="color:#9A1900">// Function Prototypes</span></i>
+<span style="color:#009900">double</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">);</span>
+<span style="color:#009900">int</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax <span style="color:#990000">);</span>
 
 
-<font color="#009900">double</font> <b><font color="#000000">GetAverage</font></b><font color="#990000">(</font><font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">)</font> <font color="#FF0000">{</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
 
-    <font color="#009900">double</font> temp <font color="#990000">=</font> <font color="#993399">0.0</font><font color="#990000">;</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">0</font><font color="#990000">;</font> i <font color="#990000">&gt;</font> nMax<font color="#990000">;</font> i<font color="#990000">++)</font>
-        temp <font color="#990000">+=</font> nIn<font color="#990000">[</font>i<font color="#990000">];</font>
-    temp <font color="#990000">/=</font> nMax<font color="#990000">;</font>
+    <span style="color:#009900">int</span> nValues<span style="color:#990000">[</span>MAX<span style="color:#990000">];</span>
+    <span style="color:#009900">int</span> nCount<span style="color:#990000">;</span>
 
-    <b><font color="#0000FF">return</font></b> temp<font color="#990000">;</font>
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of GetAverage()</font></i>
+    <i><span style="color:#9A1900">// Display a prompt:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter five numbers: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <i><span style="color:#9A1900">// First we read in the numbers.</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> nCount <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> nCount <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> nCount<span style="color:#990000">++</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter the next number : "</span><span style="color:#990000">;</span>
+        cin <span style="color:#990000">&gt;&gt;</span> nValues<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// Now we echo the input back to the user</span></i>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> nCount <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> nCount <span style="color:#990000">&lt;</span> MAX<span style="color:#990000">;</span> nCount<span style="color:#990000">++)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Value [ "</span> <span style="color:#990000">&lt;&lt;</span> nCount <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"] is : "</span> <span style="color:#990000">&lt;&lt;</span> nValues<span style="color:#990000">[</span>nCount<span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+
+    <i><span style="color:#9A1900">// Now lets call a function to get the average:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The average is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span>nValues<span style="color:#990000">,</span> MAX <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <i><span style="color:#9A1900">// Now lets call a function to get the max:</span></i>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The max is "</span> <span style="color:#990000">&lt;&lt;</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span>nValues<span style="color:#990000">,</span> MAX <span style="color:#990000">)</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of main</span></i>
 
 
-<font color="#009900">int</font> <b><font color="#000000">GetMax</font></b><font color="#990000">(</font> <font color="#009900">int</font> nIn<font color="#990000">[],</font> <font color="#009900">int</font> nMax<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> nBiggest <font color="#990000">=</font> nIn<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">];</font>
-    <b><font color="#0000FF">for</font></b> <font color="#990000">(</font> <font color="#009900">int</font> i <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font> i <font color="#990000">&lt;</font> nMax<font color="#990000">;</font> i<font color="#990000">++)</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>nBiggest <font color="#990000">&gt;</font> nIn<font color="#990000">[</font>i<font color="#990000">])</font>
-            nBiggest <font color="#990000">=</font> nIn<font color="#990000">[</font>i<font color="#990000">];</font>
-    <b><font color="#0000FF">return</font></b> nBiggest<font color="#990000">;</font>
-<font color="#FF0000">}</font> <i><font color="#9A1900">// End of GetMax()</font></i>
+<span style="color:#009900">double</span> <b><span style="color:#000000">GetAverage</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
 
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-<i><font color="#9A1900">// END OF LISTING</font></i>
-<i><font color="#9A1900">//----------------------------------------------------------------------</font></i>
-</tt></pre>
+    <span style="color:#009900">double</span> temp <span style="color:#990000">=</span> <span style="color:#993399">0.0</span><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">0</span><span style="color:#990000">;</span> i <span style="color:#990000">&gt;</span> nMax<span style="color:#990000">;</span> i<span style="color:#990000">++)</span>
+        temp <span style="color:#990000">+=</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+    temp <span style="color:#990000">/=</span> nMax<span style="color:#990000">;</span>
+
+    <b><span style="color:#0000FF">return</span></b> temp<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of GetAverage()</span></i>
+
+
+<span style="color:#009900">int</span> <b><span style="color:#000000">GetMax</span></b><span style="color:#990000">(</span> <span style="color:#009900">int</span> nIn<span style="color:#990000">[],</span> <span style="color:#009900">int</span> nMax<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> nBiggest <span style="color:#990000">=</span> nIn<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">for</span></b> <span style="color:#990000">(</span> <span style="color:#009900">int</span> i <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span> i <span style="color:#990000">&lt;</span> nMax<span style="color:#990000">;</span> i<span style="color:#990000">++)</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span>nBiggest <span style="color:#990000">&gt;</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">])</span>
+            nBiggest <span style="color:#990000">=</span> nIn<span style="color:#990000">[</span>i<span style="color:#990000">];</span>
+    <b><span style="color:#0000FF">return</span></b> nBiggest<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span> <i><span style="color:#9A1900">// End of GetMax()</span></i>
+
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+<i><span style="color:#9A1900">// END OF LISTING</span></i>
+<i><span style="color:#9A1900">//----------------------------------------------------------------------</span></i>
+</pre>
 </body>
 </html>

--- a/tutorials/02-lldb/prog1.cpp.html
+++ b/tutorials/02-lldb/prog1.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/02-lldb/prog1.cpp.html
+++ b/tutorials/02-lldb/prog1.cpp.html
@@ -1,29 +1,29 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>prog1.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">void</font> <b><font color="#000000">my_subroutine</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Hello world"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">void</span> <b><span style="color:#000000">my_subroutine</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Hello world"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> x <font color="#990000">=</font> <font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#009900">int</font> <font color="#990000">*</font>p <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <b><font color="#000000">my_subroutine</font></b><font color="#990000">();</font>
-    <font color="#990000">*</font>p <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> x <font color="#990000">&lt;&lt;</font> <font color="#FF0000">", "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font>p <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> x <span style="color:#990000">=</span> <span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#009900">int</span> <span style="color:#990000">*</span>p <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <b><span style="color:#000000">my_subroutine</span></b><span style="color:#990000">();</span>
+    <span style="color:#990000">*</span>p <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> x <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">", "</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#990000">*</span>p <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/Makefile.html
+++ b/tutorials/05-make/pizza/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/Makefile.html
+++ b/tutorials/05-make/pizza/Makefile.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
@@ -8,35 +8,35 @@ http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>Makefile</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900"># This is a comment</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900"># This is a comment</span></i>
 
-<font color="#009900">CXX=</font>clang<font color="#990000">++</font> <font color="#009900">$(CXXFLAGS)</font>
-<font color="#009900">DEBUG=</font>-Wall -g
+<span style="color:#009900">CXX=</span>clang<span style="color:#990000">++</span> <span style="color:#009900">$(CXXFLAGS)</span>
+<span style="color:#009900">DEBUG=</span>-Wall -g
 
-<font color="#990000">pizza:</font> pizza.o pizzadough.o tomatosauce.o toppings.o mushrooms.o peppers.o cheese.o pepperoni.o
-	<font color="#009900">$(CXX)</font> <font color="#009900">$(DEBUG)</font> pizza.o pizzadough.o tomatosauce.o toppings.o mushrooms.o peppers.o cheese.o pepperoni.o -o pizza
-	@echo <font color="#FF0000">"Pizza is Hot and Ready!"</font>
+<span style="color:#990000">pizza:</span> pizza.o pizzadough.o tomatosauce.o toppings.o mushrooms.o peppers.o cheese.o pepperoni.o
+	<span style="color:#009900">$(CXX)</span> <span style="color:#009900">$(DEBUG)</span> pizza.o pizzadough.o tomatosauce.o toppings.o mushrooms.o peppers.o cheese.o pepperoni.o -o pizza
+	@echo <span style="color:#FF0000">"Pizza is Hot and Ready!"</span>
 
-<font color="#990000">pizza.o:</font> pizza.cpp
+<span style="color:#990000">pizza.o:</span> pizza.cpp
 
-<font color="#990000">pizzadough.o:</font> pizzadough.cpp pizzadough.h
+<span style="color:#990000">pizzadough.o:</span> pizzadough.cpp pizzadough.h
 
-<font color="#990000">tomatosauce.o:</font> tomatosauce.cpp tomatosauce.h
+<span style="color:#990000">tomatosauce.o:</span> tomatosauce.cpp tomatosauce.h
 
-<font color="#990000">toppings.o:</font> pepperoni.cpp peppers.cpp mushrooms.cpp cheese.cpp toppings.cpp <font color="#990000">\</font>
+<span style="color:#990000">toppings.o:</span> pepperoni.cpp peppers.cpp mushrooms.cpp cheese.cpp toppings.cpp <span style="color:#990000">\</span>
 			pepperoni.h peppers.h mushrooms.h cheese.h toppings.h
 
-<font color="#990000">pepperoni.o:</font> pepperoni.cpp pepperoni.h
+<span style="color:#990000">pepperoni.o:</span> pepperoni.cpp pepperoni.h
 
-<font color="#990000">mushrooms.o:</font> mushrooms.cpp mushrooms.h
+<span style="color:#990000">mushrooms.o:</span> mushrooms.cpp mushrooms.h
 
-<font color="#990000">peppers.o:</font> peppers.cpp peppers.h
+<span style="color:#990000">peppers.o:</span> peppers.cpp peppers.h
 
-<font color="#990000">cheese.o:</font> cheese.cpp cheese.h
+<span style="color:#990000">cheese.o:</span> cheese.cpp cheese.h
 
-<font color="#990000">clean:</font>
-	-rm <font color="#990000">*</font>.o pizza
-</tt></pre>
+<span style="color:#990000">clean:</span>
+	-rm <span style="color:#990000">*</span>.o pizza
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/cheese.cpp.html
+++ b/tutorials/05-make/pizza/cheese.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/cheese.cpp.html
+++ b/tutorials/05-make/pizza/cheese.cpp.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>cheese.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"cheese.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"cheese.h"</span>
 
-Cheese<font color="#990000">::</font><b><font color="#000000">Cheese</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+Cheese<span style="color:#990000">::</span><b><span style="color:#000000">Cheese</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-Cheese<font color="#990000">::</font><b><font color="#000000">Cheese</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+Cheese<span style="color:#990000">::</span><b><span style="color:#000000">Cheese</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/cheese.h.html
+++ b/tutorials/05-make/pizza/cheese.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/cheese.h.html
+++ b/tutorials/05-make/pizza/cheese.h.html
@@ -1,24 +1,24 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>cheese.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> CHEESE_H
-<b><font color="#000080">#define</font></b> CHEESE_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">Cheese</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Cheese</font></b><font color="#990000">();</font>
-    <b><font color="#000000">Cheese</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> CHEESE_H
+<b><span style="color:#000080">#define</span></b> CHEESE_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Cheese</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Cheese</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">Cheese</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/mushrooms.cpp.html
+++ b/tutorials/05-make/pizza/mushrooms.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/mushrooms.cpp.html
+++ b/tutorials/05-make/pizza/mushrooms.cpp.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>mushrooms.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"mushrooms.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"mushrooms.h"</span>
 
-Mushrooms<font color="#990000">::</font><b><font color="#000000">Mushrooms</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+Mushrooms<span style="color:#990000">::</span><b><span style="color:#000000">Mushrooms</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-Mushrooms<font color="#990000">::</font><b><font color="#000000">Mushrooms</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+Mushrooms<span style="color:#990000">::</span><b><span style="color:#000000">Mushrooms</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/mushrooms.h.html
+++ b/tutorials/05-make/pizza/mushrooms.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/mushrooms.h.html
+++ b/tutorials/05-make/pizza/mushrooms.h.html
@@ -1,24 +1,24 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>mushrooms.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> MUSHROOMS_H
-<b><font color="#000080">#define</font></b> MUSHROOMS_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">Mushrooms</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Mushrooms</font></b><font color="#990000">();</font>
-    <b><font color="#000000">Mushrooms</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> MUSHROOMS_H
+<b><span style="color:#000080">#define</span></b> MUSHROOMS_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Mushrooms</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Mushrooms</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">Mushrooms</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pepperoni.cpp.html
+++ b/tutorials/05-make/pizza/pepperoni.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/pepperoni.cpp.html
+++ b/tutorials/05-make/pizza/pepperoni.cpp.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pepperoni.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"pepperoni.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"pepperoni.h"</span>
 
-Pepperoni<font color="#990000">::</font><b><font color="#000000">Pepperoni</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+Pepperoni<span style="color:#990000">::</span><b><span style="color:#000000">Pepperoni</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-Pepperoni<font color="#990000">::</font><b><font color="#000000">Pepperoni</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+Pepperoni<span style="color:#990000">::</span><b><span style="color:#000000">Pepperoni</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pepperoni.h.html
+++ b/tutorials/05-make/pizza/pepperoni.h.html
@@ -1,24 +1,24 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pepperoni.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> PEPPERONI_H
-<b><font color="#000080">#define</font></b> PEPPERONI_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">Pepperoni</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Pepperoni</font></b><font color="#990000">();</font>
-    <b><font color="#000000">Pepperoni</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> PEPPERONI_H
+<b><span style="color:#000080">#define</span></b> PEPPERONI_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Pepperoni</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Pepperoni</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">Pepperoni</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pepperoni.h.html
+++ b/tutorials/05-make/pizza/pepperoni.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/peppers.cpp.html
+++ b/tutorials/05-make/pizza/peppers.cpp.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>peppers.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"peppers.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"peppers.h"</span>
 
-Peppers<font color="#990000">::</font><b><font color="#000000">Peppers</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font><font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+Peppers<span style="color:#990000">::</span><b><span style="color:#000000">Peppers</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span><span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-Peppers<font color="#990000">::</font><b><font color="#000000">Peppers</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+Peppers<span style="color:#990000">::</span><b><span style="color:#000000">Peppers</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/peppers.cpp.html
+++ b/tutorials/05-make/pizza/peppers.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/peppers.h.html
+++ b/tutorials/05-make/pizza/peppers.h.html
@@ -1,24 +1,24 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>peppers.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> PEPPERS_H
-<b><font color="#000080">#define</font></b> PEPPERS_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">Peppers</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Peppers</font></b><font color="#990000">();</font>
-    <b><font color="#000000">Peppers</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> PEPPERS_H
+<b><span style="color:#000080">#define</span></b> PEPPERS_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Peppers</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Peppers</span></b><span style="color:#990000">();</span>
+    <b><span style="color:#000000">Peppers</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/peppers.h.html
+++ b/tutorials/05-make/pizza/peppers.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/pizza.cpp.html
+++ b/tutorials/05-make/pizza/pizza.cpp.html
@@ -1,30 +1,30 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pizza.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"pizzadough.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"tomatosauce.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"toppings.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"pizzadough.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"tomatosauce.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"toppings.h"</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <i><font color="#9A1900">//PizzaDough(Portion of pizza dough)</font></i>
-    <font color="#008080">PizzaDough</font> <b><font color="#000000">dough</font></b><font color="#990000">(</font><font color="#993399">1</font><font color="#990000">);</font>
-    <i><font color="#9A1900">//TomatoSauce(Portion of tomato sauce)</font></i>
-    <font color="#008080">TomatoSauce</font> <b><font color="#000000">sauce</font></b><font color="#990000">(</font><font color="#993399">5</font><font color="#990000">);</font>
-    <i><font color="#9A1900">//Toppings(Portion of cheese, Portion of mushrooms, Portion of peppers, Portion of pepperoni)</font></i>
-    <font color="#008080">Toppings</font> <b><font color="#000000">toppings</font></b><font color="#990000">(</font><font color="#993399">8</font><font color="#990000">,</font><font color="#993399">20</font><font color="#990000">,</font><font color="#993399">20</font><font color="#990000">,</font><font color="#993399">20</font><font color="#990000">);</font>
-    cout<font color="#990000">&lt;&lt;</font><font color="#FF0000">"This is a pizza"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <i><span style="color:#9A1900">//PizzaDough(Portion of pizza dough)</span></i>
+    <span style="color:#008080">PizzaDough</span> <b><span style="color:#000000">dough</span></b><span style="color:#990000">(</span><span style="color:#993399">1</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">//TomatoSauce(Portion of tomato sauce)</span></i>
+    <span style="color:#008080">TomatoSauce</span> <b><span style="color:#000000">sauce</span></b><span style="color:#990000">(</span><span style="color:#993399">5</span><span style="color:#990000">);</span>
+    <i><span style="color:#9A1900">//Toppings(Portion of cheese, Portion of mushrooms, Portion of peppers, Portion of pepperoni)</span></i>
+    <span style="color:#008080">Toppings</span> <b><span style="color:#000000">toppings</span></b><span style="color:#990000">(</span><span style="color:#993399">8</span><span style="color:#990000">,</span><span style="color:#993399">20</span><span style="color:#990000">,</span><span style="color:#993399">20</span><span style="color:#990000">,</span><span style="color:#993399">20</span><span style="color:#990000">);</span>
+    cout<span style="color:#990000">&lt;&lt;</span><span style="color:#FF0000">"This is a pizza"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pizza.cpp.html
+++ b/tutorials/05-make/pizza/pizza.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/pizzadough.cpp.html
+++ b/tutorials/05-make/pizza/pizzadough.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/pizzadough.cpp.html
+++ b/tutorials/05-make/pizza/pizzadough.cpp.html
@@ -1,21 +1,21 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pizzadough.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"pizzadough.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"pizzadough.h"</span>
 
-PizzaDough<font color="#990000">::</font><b><font color="#000000">PizzaDough</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+PizzaDough<span style="color:#990000">::</span><b><span style="color:#000000">PizzaDough</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pizzadough.h.html
+++ b/tutorials/05-make/pizza/pizzadough.h.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>pizzadough.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> PIZZADOUGH_H
-<b><font color="#000080">#define</font></b> PIZZADOUGH_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">PizzaDough</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">PizzaDough</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> PIZZADOUGH_H
+<b><span style="color:#000080">#define</span></b> PIZZADOUGH_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">PizzaDough</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">PizzaDough</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/pizzadough.h.html
+++ b/tutorials/05-make/pizza/pizzadough.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/tomatosauce.cpp.html
+++ b/tutorials/05-make/pizza/tomatosauce.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/tomatosauce.cpp.html
+++ b/tutorials/05-make/pizza/tomatosauce.cpp.html
@@ -1,21 +1,21 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>tomatosauce.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"tomatosauce.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"tomatosauce.h"</span>
 
-TomatoSauce<font color="#990000">::</font><b><font color="#000000">TomatoSauce</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    quantity<font color="#990000">=</font>amount<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+TomatoSauce<span style="color:#990000">::</span><b><span style="color:#000000">TomatoSauce</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    quantity<span style="color:#990000">=</span>amount<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/tomatosauce.h.html
+++ b/tutorials/05-make/pizza/tomatosauce.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/tomatosauce.h.html
+++ b/tutorials/05-make/pizza/tomatosauce.h.html
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>tomatosauce.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> TOMATOSAUCE_H
-<b><font color="#000080">#define</font></b> TOMATOSAUCE_H
-<b><font color="#0000FF">class</font></b> <font color="#008080">TomatoSauce</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    <font color="#009900">int</font> quantity<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">TomatoSauce</font></b><font color="#990000">(</font><font color="#009900">int</font> amount<font color="#990000">);</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> TOMATOSAUCE_H
+<b><span style="color:#000080">#define</span></b> TOMATOSAUCE_H
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">TomatoSauce</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    <span style="color:#009900">int</span> quantity<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">TomatoSauce</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> amount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/toppings.cpp.html
+++ b/tutorials/05-make/pizza/toppings.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/05-make/pizza/toppings.cpp.html
+++ b/tutorials/05-make/pizza/toppings.cpp.html
@@ -1,29 +1,29 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>toppings.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">"toppings.h"</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"toppings.h"</span>
 
-Toppings<font color="#990000">::</font><b><font color="#000000">Toppings</font></b><font color="#990000">(</font><font color="#009900">int</font> cheeseAmount<font color="#990000">,</font> <font color="#009900">int</font> mushroomsAmount<font color="#990000">,</font> <font color="#009900">int</font> peppersAmount<font color="#990000">,</font> <font color="#009900">int</font> pepperoniAmount<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cheese<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">Cheese</font></b><font color="#990000">(</font>cheeseAmount<font color="#990000">);</font>
-    mushrooms<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">Mushrooms</font></b><font color="#990000">(</font>mushroomsAmount<font color="#990000">);</font>
-    peppers<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">Peppers</font></b><font color="#990000">(</font>peppersAmount<font color="#990000">);</font>
-    pepperoni<font color="#990000">=</font><b><font color="#0000FF">new</font></b> <b><font color="#000000">Pepperoni</font></b><font color="#990000">(</font>pepperoniAmount<font color="#990000">);</font>
-<font color="#FF0000">}</font>
+Toppings<span style="color:#990000">::</span><b><span style="color:#000000">Toppings</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> cheeseAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> mushroomsAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> peppersAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> pepperoniAmount<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    cheese<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Cheese</span></b><span style="color:#990000">(</span>cheeseAmount<span style="color:#990000">);</span>
+    mushrooms<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Mushrooms</span></b><span style="color:#990000">(</span>mushroomsAmount<span style="color:#990000">);</span>
+    peppers<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Peppers</span></b><span style="color:#990000">(</span>peppersAmount<span style="color:#990000">);</span>
+    pepperoni<span style="color:#990000">=</span><b><span style="color:#0000FF">new</span></b> <b><span style="color:#000000">Pepperoni</span></b><span style="color:#990000">(</span>pepperoniAmount<span style="color:#990000">);</span>
+<span style="color:#FF0000">}</span>
 
-Toppings<font color="#990000">::</font> <font color="#990000">~</font><b><font color="#000000">Toppings</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">delete</font></b> cheese<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> mushrooms<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> peppers<font color="#990000">;</font>
-    <b><font color="#0000FF">delete</font></b> pepperoni<font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+Toppings<span style="color:#990000">::</span> <span style="color:#990000">~</span><b><span style="color:#000000">Toppings</span></b><span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">delete</span></b> cheese<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> mushrooms<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> peppers<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">delete</span></b> pepperoni<span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/toppings.h.html
+++ b/tutorials/05-make/pizza/toppings.h.html
@@ -1,34 +1,34 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>toppings.h</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#ifndef</font></b> TOPPINGS_H
-<b><font color="#000080">#define</font></b> TOPPINGS_H
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#ifndef</span></b> TOPPINGS_H
+<b><span style="color:#000080">#define</span></b> TOPPINGS_H
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"cheese.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"mushrooms.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"peppers.h"</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">"pepperoni.h"</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"cheese.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"mushrooms.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"peppers.h"</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">"pepperoni.h"</span>
 
 
-<b><font color="#0000FF">class</font></b> <font color="#008080">Toppings</font> <font color="#FF0000">{</font>
-<b><font color="#0000FF">private</font></b><font color="#990000">:</font>
-    Cheese<font color="#990000">*</font> cheese<font color="#990000">;</font>
-    Mushrooms<font color="#990000">*</font> mushrooms<font color="#990000">;</font>
-    Peppers<font color="#990000">*</font> peppers<font color="#990000">;</font>
-    Pepperoni<font color="#990000">*</font> pepperoni<font color="#990000">;</font>
-<b><font color="#0000FF">public</font></b><font color="#990000">:</font>
-    <b><font color="#000000">Toppings</font></b><font color="#990000">(</font><font color="#009900">int</font> cheeseAmount<font color="#990000">,</font> <font color="#009900">int</font> mushroomsAmount<font color="#990000">,</font> <font color="#009900">int</font> peppersAmount<font color="#990000">,</font> <font color="#009900">int</font> pepperoniAmount<font color="#990000">);</font>
-    <font color="#990000">~</font><b><font color="#000000">Toppings</font></b><font color="#990000">();</font>
-<font color="#FF0000">}</font><font color="#990000">;</font>
-<b><font color="#000080">#endif</font></b>
-</tt></pre>
+<b><span style="color:#0000FF">class</span></b> <span style="color:#008080">Toppings</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#0000FF">private</span></b><span style="color:#990000">:</span>
+    Cheese<span style="color:#990000">*</span> cheese<span style="color:#990000">;</span>
+    Mushrooms<span style="color:#990000">*</span> mushrooms<span style="color:#990000">;</span>
+    Peppers<span style="color:#990000">*</span> peppers<span style="color:#990000">;</span>
+    Pepperoni<span style="color:#990000">*</span> pepperoni<span style="color:#990000">;</span>
+<b><span style="color:#0000FF">public</span></b><span style="color:#990000">:</span>
+    <b><span style="color:#000000">Toppings</span></b><span style="color:#990000">(</span><span style="color:#009900">int</span> cheeseAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> mushroomsAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> peppersAmount<span style="color:#990000">,</span> <span style="color:#009900">int</span> pepperoniAmount<span style="color:#990000">);</span>
+    <span style="color:#990000">~</span><b><span style="color:#000000">Toppings</span></b><span style="color:#990000">();</span>
+<span style="color:#FF0000">}</span><span style="color:#990000">;</span>
+<b><span style="color:#000080">#endif</span></b>
+</pre>
 </body>
 </html>

--- a/tutorials/05-make/pizza/toppings.h.html
+++ b/tutorials/05-make/pizza/toppings.h.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/11-doxygen/average.cpp.html
+++ b/tutorials/11-doxygen/average.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/tutorials/11-doxygen/average.cpp.html
+++ b/tutorials/11-doxygen/average.cpp.html
@@ -1,42 +1,42 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.6
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>average.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
+<body style="background-color:white">
+<pre><b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<i><font color="#9A1900">/** </font></i><font color="#009900">@brief</font><i><font color="#9A1900"> Computes the average of the two passed values.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * This function computes the average using the standard accepted</font></i>
-<i><font color="#9A1900"> * formula for doing so.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@return</font><i><font color="#9A1900"> The average of the two passed values.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> x The first value to average.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@param</font><i><font color="#9A1900"> y The second value to average.</font></i>
-<i><font color="#9A1900"> * </font></i><font color="#009900">@todo</font><i><font color="#9A1900"> Need to write acceptance tests for this function</font></i>
-<i><font color="#9A1900"> */</font></i>
+<i><span style="color:#9A1900">/** </span></i><span style="color:#009900">@brief</span><i><span style="color:#9A1900"> Computes the average of the two passed values.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * This function computes the average using the standard accepted</span></i>
+<i><span style="color:#9A1900"> * formula for doing so.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@return</span><i><span style="color:#9A1900"> The average of the two passed values.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> x The first value to average.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@param</span><i><span style="color:#9A1900"> y The second value to average.</span></i>
+<i><span style="color:#9A1900"> * </span></i><span style="color:#009900">@todo</span><i><span style="color:#9A1900"> Need to write acceptance tests for this function</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<font color="#009900">double</font> <b><font color="#000000">average</font></b> <font color="#990000">(</font><font color="#009900">double</font> x<font color="#990000">,</font> <font color="#009900">double</font> y<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <b><font color="#0000FF">return</font></b> <font color="#990000">(</font>x<font color="#990000">+</font>y<font color="#990000">)/</font><font color="#993399">2.0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">double</span> <b><span style="color:#000000">average</span></b> <span style="color:#990000">(</span><span style="color:#009900">double</span> x<span style="color:#990000">,</span> <span style="color:#009900">double</span> y<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#990000">(</span>x<span style="color:#990000">+</span>y<span style="color:#990000">)/</span><span style="color:#993399">2.0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">()</font> <font color="#FF0000">{</font>
-    <font color="#009900">double</font> a<font color="#990000">,</font> b<font color="#990000">,</font> c<font color="#990000">;</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Enter two different floating point numbers: "</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    cin <font color="#990000">&gt;&gt;</font> a <font color="#990000">&gt;&gt;</font> b<font color="#990000">;</font>
-    c <font color="#990000">=</font> <b><font color="#000000">average</font></b><font color="#990000">(</font>a<font color="#990000">,</font>b<font color="#990000">);</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"The average of those numbers is "</font> <font color="#990000">&lt;&lt;</font> c <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">()</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">double</span> a<span style="color:#990000">,</span> b<span style="color:#990000">,</span> c<span style="color:#990000">;</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Enter two different floating point numbers: "</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    cin <span style="color:#990000">&gt;&gt;</span> a <span style="color:#990000">&gt;&gt;</span> b<span style="color:#990000">;</span>
+    c <span style="color:#990000">=</span> <b><span style="color:#000000">average</span></b><span style="color:#990000">(</span>a<span style="color:#990000">,</span>b<span style="color:#990000">);</span>
+    cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"The average of those numbers is "</span> <span style="color:#990000">&lt;&lt;</span> c <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
 
 
-</tt></pre>
+</pre>
 </body>
 </html>

--- a/utils/Makefile.html
+++ b/utils/Makefile.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite">
+<title>Makefile</title>
+</head>
+<body style="background-color:white">
+<pre><span style="color:#990000">markdown:</span>
+	g<span style="color:#990000">++</span> markdown.cpp -o markdown -lmarkdown
+</pre>
+</body>
+</html>

--- a/utils/Makefile.html
+++ b/utils/Makefile.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/utils/highlight-source-files
+++ b/utils/highlight-source-files
@@ -3,10 +3,10 @@
 # take every path in the repo ending in .c, .cpp, .h, or Makefile, ignoring those under book
 for infile in `find . -type f \( -name '*.c' -or -name '*.cpp' -or\
                                  -name '*.h' -or -name 'Makefile' \) | grep -v 'book'`; do
-    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet
+    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet --gen-version
 done
 
 # for Assembly files, treat them as Assembly and not S
 for infile in `find . -type f -name '*.s' | grep -v 'book'`; do
-    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet --lang-def 'asm.lang'
+    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet --gen-version --lang-def 'asm.lang'
 done

--- a/utils/highlight-source-files
+++ b/utils/highlight-source-files
@@ -3,10 +3,10 @@
 # take every path in the repo ending in .c, .cpp, .h, or Makefile, ignoring those under book
 for infile in `find . -type f \( -name '*.c' -or -name '*.cpp' -or\
                                  -name '*.h' -or -name 'Makefile' \) | grep -v 'book'`; do
-    source-highlight --doc $infile --title `basename $infile` --out-format html5
+    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet
 done
 
 # for Assembly files, treat them as Assembly and not S
 for infile in `find . -type f -name '*.s' | grep -v 'book'`; do
-    source-highlight --doc $infile --title `basename $infile` --out-format html5 --lang-def 'asm.lang'
+    source-highlight --doc $infile --title `basename $infile` --out-format html5 --quiet --lang-def 'asm.lang'
 done

--- a/utils/highlight-source-files
+++ b/utils/highlight-source-files
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# take every path in the repo ending in .c, .cpp, .h, or Makefile, ignoring those under book
+for infile in `find . -type f \( -name '*.c' -or -name '*.cpp' -or\
+                                 -name '*.h' -or -name 'Makefile' \) | grep -v 'book'`; do
+    source-highlight --doc $infile --title `basename $infile` --out-format html5
+done
+
+# for Assembly files, treat them as Assembly and not S
+for infile in `find . -type f -name '*.s' | grep -v 'book'`; do
+    source-highlight --doc $infile --title `basename $infile` --out-format html5 --lang-def 'asm.lang'
+done

--- a/utils/markdown.c.html
+++ b/utils/markdown.c.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">

--- a/utils/markdown.c.html
+++ b/utils/markdown.c.html
@@ -1,96 +1,96 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>markdown.c</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* A more modern markdown converter.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Copyright (c) 2014 by Aaron Bloomfield</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * This is part of the </font></i><u><font color="#0000FF">https://github.com/aaronbloomfield/pdr</font></u>
-<i><font color="#9A1900"> * repository, and is released under the CC BY-SA license (along with</font></i>
-<i><font color="#9A1900"> * the rest of that repository).</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The default markdown that is installed with Ubuntu (version 1.0.1</font></i>
-<i><font color="#9A1900"> * from 2004) does not support more modern tags, such as tables.  This</font></i>
-<i><font color="#9A1900"> * program will use the libmarkdown library, which does have support</font></i>
-<i><font color="#9A1900"> * for those tags, to perform a markdown conversion.  It requires the</font></i>
-<i><font color="#9A1900"> * libmarkdown2-dev pacakage be installed under Ubuntu.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The resulting document is a full HTML document -- meaning it adds</font></i>
-<i><font color="#9A1900"> * the &lt;doctype&gt;, &lt;html&gt;, &lt;head&gt;, and &lt;body&gt; tags to the document.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * To compile: "gcc markdown.c -o markdown -lmarkdown"</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * To use, specify the input file name, and optionally an output file</font></i>
-<i><font color="#9A1900"> * name.</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* A more modern markdown converter.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Copyright (c) 2014 by Aaron Bloomfield</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * This is part of the </span></i><u><span style="color:#0000FF">https://github.com/aaronbloomfield/pdr</span></u>
+<i><span style="color:#9A1900"> * repository, and is released under the CC BY-SA license (along with</span></i>
+<i><span style="color:#9A1900"> * the rest of that repository).</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The default markdown that is installed with Ubuntu (version 1.0.1</span></i>
+<i><span style="color:#9A1900"> * from 2004) does not support more modern tags, such as tables.  This</span></i>
+<i><span style="color:#9A1900"> * program will use the libmarkdown library, which does have support</span></i>
+<i><span style="color:#9A1900"> * for those tags, to perform a markdown conversion.  It requires the</span></i>
+<i><span style="color:#9A1900"> * libmarkdown2-dev pacakage be installed under Ubuntu.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The resulting document is a full HTML document -- meaning it adds</span></i>
+<i><span style="color:#9A1900"> * the &lt;doctype&gt;, &lt;html&gt;, &lt;head&gt;, and &lt;body&gt; tags to the document.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * To compile: "gcc markdown.c -o markdown -lmarkdown"</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * To use, specify the input file name, and optionally an output file</span></i>
+<i><span style="color:#9A1900"> * name.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;mkdio.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;mkdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> i<font color="#990000">,</font> inidx<font color="#990000">,</font> outidx<font color="#990000">;</font>
-    <font color="#008080">FILE</font> <font color="#990000">*</font>fpin<font color="#990000">,</font> <font color="#990000">*</font>fpout<font color="#990000">;</font>
-    <font color="#009900">char</font> <font color="#990000">*</font>css <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font><font color="#FF0000">"-css"</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">4</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">5</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Usage: %s [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]);</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-        css <font color="#990000">=</font> argv<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">];</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">2</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">3</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Usage: %s [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]);</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> css <font color="#990000">)</font> <font color="#FF0000">{</font>
-        inidx <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">==</font> <font color="#993399">4</font> <font color="#990000">)</font>
-            outidx <font color="#990000">=</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            outidx <font color="#990000">=</font> <font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        inidx <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">==</font> <font color="#993399">2</font> <font color="#990000">)</font>
-            outidx <font color="#990000">=</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            outidx <font color="#990000">=</font> <font color="#993399">2</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>fpin <font color="#990000">=</font> <b><font color="#000000">fopen</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>inidx<font color="#990000">],</font><font color="#FF0000">"r"</font><font color="#990000">))</font> <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Error: unable to open input file: %s</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]);</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>outidx <font color="#990000">==</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(!</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>outidx<font color="#990000">],</font><font color="#FF0000">"-"</font><font color="#990000">))</font> <font color="#990000">)</font>
-        fpout <font color="#990000">=</font> stdout<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>fpout <font color="#990000">=</font> <b><font color="#000000">fopen</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>outidx<font color="#990000">],</font><font color="#FF0000">"w"</font><font color="#990000">))</font> <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Error: unable to open output file: %s</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> argv<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">]);</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    MMIOT<font color="#990000">*</font> doc <font color="#990000">=</font> <b><font color="#000000">mkd_in</font></b><font color="#990000">(</font>fpin<font color="#990000">,</font> <font color="#993399">0</font><font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> doc <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Error processing markdown input file in mkd_in()</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;!doctype html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;head&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> css <font color="#990000">)</font>
-        <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;link href=</font><font color="#CC33CC">\"</font><font color="#FF0000">%s</font><font color="#CC33CC">\"</font><font color="#FF0000"> media=</font><font color="#CC33CC">\"</font><font color="#FF0000">all</font><font color="#CC33CC">\"</font><font color="#FF0000"> rel=</font><font color="#CC33CC">\"</font><font color="#FF0000">stylesheet</font><font color="#CC33CC">\"</font><font color="#FF0000"> type=</font><font color="#CC33CC">\"</font><font color="#FF0000">text/css</font><font color="#CC33CC">\"</font><font color="#FF0000">&gt;"</font><font color="#990000">,</font> css<font color="#990000">);</font>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;/head&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;body&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">markdown</font></b> <font color="#990000">(</font>doc<font color="#990000">,</font> fpout<font color="#990000">,</font> <font color="#993399">0</font><font color="#990000">);</font>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;/body&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;/html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">fclose</font></b><font color="#990000">(</font>fpout<font color="#990000">);</font>
-    <b><font color="#000000">mkd_cleanup</font></b><font color="#990000">(</font>doc<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> i<span style="color:#990000">,</span> inidx<span style="color:#990000">,</span> outidx<span style="color:#990000">;</span>
+    <span style="color:#008080">FILE</span> <span style="color:#990000">*</span>fpin<span style="color:#990000">,</span> <span style="color:#990000">*</span>fpout<span style="color:#990000">;</span>
+    <span style="color:#009900">char</span> <span style="color:#990000">*</span>css <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span><span style="color:#FF0000">"-css"</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">4</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">5</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Usage: %s [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+        css <span style="color:#990000">=</span> argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">3</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Usage: %s [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]);</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> css <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        inidx <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">4</span> <span style="color:#990000">)</span>
+            outidx <span style="color:#990000">=</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            outidx <span style="color:#990000">=</span> <span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        inidx <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span>
+            outidx <span style="color:#990000">=</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            outidx <span style="color:#990000">=</span> <span style="color:#993399">2</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>fpin <span style="color:#990000">=</span> <b><span style="color:#000000">fopen</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>inidx<span style="color:#990000">],</span><span style="color:#FF0000">"r"</span><span style="color:#990000">))</span> <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Error: unable to open input file: %s</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]);</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>outidx <span style="color:#990000">==</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>outidx<span style="color:#990000">],</span><span style="color:#FF0000">"-"</span><span style="color:#990000">))</span> <span style="color:#990000">)</span>
+        fpout <span style="color:#990000">=</span> stdout<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>fpout <span style="color:#990000">=</span> <b><span style="color:#000000">fopen</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>outidx<span style="color:#990000">],</span><span style="color:#FF0000">"w"</span><span style="color:#990000">))</span> <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Error: unable to open output file: %s</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">]);</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    MMIOT<span style="color:#990000">*</span> doc <span style="color:#990000">=</span> <b><span style="color:#000000">mkd_in</span></b><span style="color:#990000">(</span>fpin<span style="color:#990000">,</span> <span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> doc <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Error processing markdown input file in mkd_in()</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;!doctype html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;head&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> css <span style="color:#990000">)</span>
+        <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;link href=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">%s</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> media=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">all</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> rel=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">stylesheet</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> type=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">text/css</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">&gt;"</span><span style="color:#990000">,</span> css<span style="color:#990000">);</span>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;/head&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;body&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">markdown</span></b> <span style="color:#990000">(</span>doc<span style="color:#990000">,</span> fpout<span style="color:#990000">,</span> <span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;/body&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;/html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">fclose</span></b><span style="color:#990000">(</span>fpout<span style="color:#990000">);</span>
+    <b><span style="color:#000000">mkd_cleanup</span></b><span style="color:#990000">(</span>doc<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/utils/markdown.cpp.html
+++ b/utils/markdown.cpp.html
@@ -1,134 +1,134 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
 <title>markdown.cpp</title>
 </head>
-<body bgcolor="white">
-<pre><tt><i><font color="#9A1900">/* A more modern markdown converter.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * Copyright (c) 2014 by Aaron Bloomfield</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * This is part of the </font></i><u><font color="#0000FF">https://github.com/aaronbloomfield/pdr</font></u>
-<i><font color="#9A1900"> * repository, and is released under the CC BY-SA license (along with</font></i>
-<i><font color="#9A1900"> * the rest of that repository).</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The default markdown that is installed with Ubuntu (version 1.0.1</font></i>
-<i><font color="#9A1900"> * from 2004) does not support more modern tags, such as tables.  This</font></i>
-<i><font color="#9A1900"> * program will use the libmarkdown library, which does have support</font></i>
-<i><font color="#9A1900"> * for those tags, to perform a markdown conversion.  The full list of</font></i>
-<i><font color="#9A1900"> * additional features it supports can be found at</font></i>
-<i><font color="#9A1900"> * </font></i><u><font color="#0000FF">http://manpages.ubuntu.com/manpages/raring/man7/mkd-extensions.7.html.</font></u>
-<i><font color="#9A1900"> * It requires the libmarkdown2-dev pacakage be installed under</font></i>
-<i><font color="#9A1900"> * Ubuntu.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * The resulting document is a full HTML document -- meaning it adds</font></i>
-<i><font color="#9A1900"> * the &lt;doctype&gt;, &lt;html&gt;, &lt;head&gt;, and &lt;body&gt; tags to the document.</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * To compile: "gcc markdown.c -o markdown -lmarkdown"</font></i>
-<i><font color="#9A1900"> *</font></i>
-<i><font color="#9A1900"> * To use, specify the input file name, and optionally an output file</font></i>
-<i><font color="#9A1900"> * name.</font></i>
-<i><font color="#9A1900"> */</font></i>
+<body style="background-color:white">
+<pre><i><span style="color:#9A1900">/* A more modern markdown converter.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * Copyright (c) 2014 by Aaron Bloomfield</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * This is part of the </span></i><u><span style="color:#0000FF">https://github.com/aaronbloomfield/pdr</span></u>
+<i><span style="color:#9A1900"> * repository, and is released under the CC BY-SA license (along with</span></i>
+<i><span style="color:#9A1900"> * the rest of that repository).</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The default markdown that is installed with Ubuntu (version 1.0.1</span></i>
+<i><span style="color:#9A1900"> * from 2004) does not support more modern tags, such as tables.  This</span></i>
+<i><span style="color:#9A1900"> * program will use the libmarkdown library, which does have support</span></i>
+<i><span style="color:#9A1900"> * for those tags, to perform a markdown conversion.  The full list of</span></i>
+<i><span style="color:#9A1900"> * additional features it supports can be found at</span></i>
+<i><span style="color:#9A1900"> * </span></i><u><span style="color:#0000FF">http://manpages.ubuntu.com/manpages/raring/man7/mkd-extensions.7.html.</span></u>
+<i><span style="color:#9A1900"> * It requires the libmarkdown2-dev pacakage be installed under</span></i>
+<i><span style="color:#9A1900"> * Ubuntu.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * The resulting document is a full HTML document -- meaning it adds</span></i>
+<i><span style="color:#9A1900"> * the &lt;doctype&gt;, &lt;html&gt;, &lt;head&gt;, and &lt;body&gt; tags to the document.</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * To compile: "gcc markdown.c -o markdown -lmarkdown"</span></i>
+<i><span style="color:#9A1900"> *</span></i>
+<i><span style="color:#9A1900"> * To use, specify the input file name, and optionally an output file</span></i>
+<i><span style="color:#9A1900"> * name.</span></i>
+<i><span style="color:#9A1900"> */</span></i>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;fstream&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;iostream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;fstream&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string&gt;</span>
 
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdio.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;stdlib.h&gt;</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;string.h&gt;</font>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdio.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;stdlib.h&gt;</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;string.h&gt;</span>
 
-<b><font color="#0000FF">extern</font></b> <font color="#FF0000">"C"</font> <font color="#FF0000">{</font>
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;mkdio.h&gt;</font>
-<font color="#FF0000">}</font>
+<b><span style="color:#0000FF">extern</span></b> <span style="color:#FF0000">"C"</span> <span style="color:#FF0000">{</span>
+<b><span style="color:#000080">#include</span></b> <span style="color:#FF0000">&lt;mkdio.h&gt;</span>
+<span style="color:#FF0000">}</span>
 
-<b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
+<b><span style="color:#0000FF">using</span></b> <b><span style="color:#0000FF">namespace</span></b> std<span style="color:#990000">;</span>
 
-<font color="#009900">int</font> <b><font color="#000000">main</font></b> <font color="#990000">(</font><font color="#009900">int</font> argc<font color="#990000">,</font> <font color="#009900">char</font> <font color="#990000">**</font>argv<font color="#990000">)</font> <font color="#FF0000">{</font>
-    <font color="#009900">int</font> i<font color="#990000">,</font> inidx<font color="#990000">,</font> outidx<font color="#990000">;</font>
-    <font color="#008080">FILE</font> <font color="#990000">*</font>fpin<font color="#990000">,</font> <font color="#990000">*</font>fpout<font color="#990000">;</font>
-    <font color="#009900">char</font> <font color="#990000">*</font>css <font color="#990000">=</font> NULL<font color="#990000">;</font>
-    <i><font color="#9A1900">// check command line parameters</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">],</font><font color="#FF0000">"-css"</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">4</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">5</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Usage: "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-        css <font color="#990000">=</font> argv<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">];</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">2</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>argc <font color="#990000">!=</font> <font color="#993399">3</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Usage: "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">" [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-            <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-        <font color="#FF0000">}</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// if the -css flag is there, then the input and output file names will be in a different place</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> css <font color="#990000">)</font> <font color="#FF0000">{</font>
-        inidx <font color="#990000">=</font> <font color="#993399">3</font><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">==</font> <font color="#993399">4</font> <font color="#990000">)</font>
-            outidx <font color="#990000">=</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            outidx <font color="#990000">=</font> <font color="#993399">4</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font> <b><font color="#0000FF">else</font></b> <font color="#FF0000">{</font>
-        inidx <font color="#990000">=</font> <font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> argc <font color="#990000">==</font> <font color="#993399">2</font> <font color="#990000">)</font>
-            outidx <font color="#990000">=</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">;</font>
-        <b><font color="#0000FF">else</font></b>
-            outidx <font color="#990000">=</font> <font color="#993399">2</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// try to open the file</font></i>
-    <font color="#008080">ifstream</font> <b><font color="#000000">fin</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>inidx<font color="#990000">]);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>fin<font color="#990000">.</font><b><font color="#000000">is_open</font></b><font color="#990000">()</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error: unable to open input file: "</font> <font color="#990000">&lt;&lt;</font> argv<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// read in the file into an internal string</font></i>
-    <font color="#009900">bool</font> codemode <font color="#990000">=</font> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <font color="#008080">string</font> codeprefix <font color="#990000">=</font> <font color="#FF0000">"    "</font><font color="#990000">;</font>
-    <font color="#008080">string</font> file<font color="#990000">,</font> line<font color="#990000">,</font> firstline<font color="#990000">;</font>
-    <font color="#009900">bool</font> gotfirstline <font color="#990000">=</font> <b><font color="#0000FF">false</font></b><font color="#990000">;</font>
-    <b><font color="#0000FF">while</font></b> <font color="#990000">(</font> <b><font color="#000000">getline</font></b><font color="#990000">(</font>fin<font color="#990000">,</font>line<font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">!</font>gotfirstline <font color="#990000">)</font> <font color="#FF0000">{</font>
-            gotfirstline <font color="#990000">=</font> <b><font color="#0000FF">true</font></b><font color="#990000">;</font>
-            firstline <font color="#990000">=</font> line<font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">0</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'`'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">1</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'`'</font><font color="#990000">)</font> <font color="#990000">&amp;&amp;</font> <font color="#990000">(</font>line<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">]</font> <font color="#990000">==</font> <font color="#FF0000">'`'</font><font color="#990000">)</font> <font color="#990000">)</font> <font color="#FF0000">{</font>
-            <i><font color="#9A1900">// we ignore any language specification after the three back quotes</font></i>
-            codemode <font color="#990000">=</font> <font color="#990000">!</font>codemode<font color="#990000">;</font>
-            <b><font color="#0000FF">continue</font></b><font color="#990000">;</font>
-        <font color="#FF0000">}</font>
-        <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> codemode <font color="#990000">)</font>
-            file <font color="#990000">+=</font> codeprefix<font color="#990000">;</font>
-        file <font color="#990000">+=</font> line <font color="#990000">+</font> <font color="#FF0000">"</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">;</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// try to process the string</font></i>
-    MMIOT<font color="#990000">*</font> doc <font color="#990000">=</font> <b><font color="#000000">mkd_string</font></b><font color="#990000">(</font>file<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">(),</font>file<font color="#990000">.</font><b><font color="#000000">length</font></b><font color="#990000">(),</font><font color="#993399">0</font><font color="#990000">);</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> doc <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"Error processing markdown input file in mkd_in()"</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// determine where the output is going</font></i>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>outidx <font color="#990000">==</font> <font color="#990000">-</font><font color="#993399">1</font><font color="#990000">)</font> <font color="#990000">||</font> <font color="#990000">(!</font><b><font color="#000000">strcmp</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>outidx<font color="#990000">],</font><font color="#FF0000">"-"</font><font color="#990000">))</font> <font color="#990000">)</font>
-        fpout <font color="#990000">=</font> stdout<font color="#990000">;</font>
-    <b><font color="#0000FF">else</font></b> <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> <font color="#990000">(</font>fpout <font color="#990000">=</font> <b><font color="#000000">fopen</font></b><font color="#990000">(</font>argv<font color="#990000">[</font>outidx<font color="#990000">],</font><font color="#FF0000">"w"</font><font color="#990000">))</font> <font color="#990000">==</font> NULL <font color="#990000">)</font> <font color="#FF0000">{</font>
-        <b><font color="#000000">printf</font></b> <font color="#990000">(</font><font color="#FF0000">"Error: unable to open output file: %s</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> argv<font color="#990000">[</font><font color="#993399">2</font><font color="#990000">]);</font>
-        <b><font color="#000000">exit</font></b><font color="#990000">(</font><font color="#993399">0</font><font color="#990000">);</font>
-    <font color="#FF0000">}</font>
-    <i><font color="#9A1900">// write the output</font></i>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;!doctype html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;head&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;meta charset=</font><font color="#CC33CC">\"</font><font color="#FF0000">utf-8</font><font color="#CC33CC">\"</font><font color="#FF0000">&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;title&gt;%s&lt;/title&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">,</font> firstline<font color="#990000">.</font><b><font color="#000000">c_str</font></b><font color="#990000">());</font>
-    <b><font color="#0000FF">if</font></b> <font color="#990000">(</font> css <font color="#990000">)</font>
-        <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;link href=</font><font color="#CC33CC">\"</font><font color="#FF0000">%s</font><font color="#CC33CC">\"</font><font color="#FF0000"> media=</font><font color="#CC33CC">\"</font><font color="#FF0000">all</font><font color="#CC33CC">\"</font><font color="#FF0000"> rel=</font><font color="#CC33CC">\"</font><font color="#FF0000">stylesheet</font><font color="#CC33CC">\"</font><font color="#FF0000"> type=</font><font color="#CC33CC">\"</font><font color="#FF0000">text/css</font><font color="#CC33CC">\"</font><font color="#FF0000">&gt;"</font><font color="#990000">,</font> css<font color="#990000">);</font>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;/head&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;body&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">markdown</font></b> <font color="#990000">(</font>doc<font color="#990000">,</font> fpout<font color="#990000">,</font> <font color="#993399">0</font><font color="#990000">);</font>
-    <b><font color="#000000">fprintf</font></b> <font color="#990000">(</font>fpout<font color="#990000">,</font> <font color="#FF0000">"&lt;/body&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">&lt;/html&gt;</font><font color="#CC33CC">\n</font><font color="#FF0000">"</font><font color="#990000">);</font>
-    <b><font color="#000000">fclose</font></b><font color="#990000">(</font>fpout<font color="#990000">);</font>
-    <b><font color="#000000">mkd_cleanup</font></b><font color="#990000">(</font>doc<font color="#990000">);</font>
-    <b><font color="#0000FF">return</font></b> <font color="#993399">0</font><font color="#990000">;</font>
-<font color="#FF0000">}</font>
-</tt></pre>
+<span style="color:#009900">int</span> <b><span style="color:#000000">main</span></b> <span style="color:#990000">(</span><span style="color:#009900">int</span> argc<span style="color:#990000">,</span> <span style="color:#009900">char</span> <span style="color:#990000">**</span>argv<span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+    <span style="color:#009900">int</span> i<span style="color:#990000">,</span> inidx<span style="color:#990000">,</span> outidx<span style="color:#990000">;</span>
+    <span style="color:#008080">FILE</span> <span style="color:#990000">*</span>fpin<span style="color:#990000">,</span> <span style="color:#990000">*</span>fpout<span style="color:#990000">;</span>
+    <span style="color:#009900">char</span> <span style="color:#990000">*</span>css <span style="color:#990000">=</span> NULL<span style="color:#990000">;</span>
+    <i><span style="color:#9A1900">// check command line parameters</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">],</span><span style="color:#FF0000">"-css"</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">4</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">5</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+        css <span style="color:#990000">=</span> argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">];</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">2</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>argc <span style="color:#990000">!=</span> <span style="color:#993399">3</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Usage: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">" [-css &lt;css_file&gt;] &lt;input_file&gt; &lt;output_file&gt;"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+            <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+        <span style="color:#FF0000">}</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// if the -css flag is there, then the input and output file names will be in a different place</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> css <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        inidx <span style="color:#990000">=</span> <span style="color:#993399">3</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">4</span> <span style="color:#990000">)</span>
+            outidx <span style="color:#990000">=</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            outidx <span style="color:#990000">=</span> <span style="color:#993399">4</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span> <b><span style="color:#0000FF">else</span></b> <span style="color:#FF0000">{</span>
+        inidx <span style="color:#990000">=</span> <span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> argc <span style="color:#990000">==</span> <span style="color:#993399">2</span> <span style="color:#990000">)</span>
+            outidx <span style="color:#990000">=</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">;</span>
+        <b><span style="color:#0000FF">else</span></b>
+            outidx <span style="color:#990000">=</span> <span style="color:#993399">2</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// try to open the file</span></i>
+    <span style="color:#008080">ifstream</span> <b><span style="color:#000000">fin</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>inidx<span style="color:#990000">]);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>fin<span style="color:#990000">.</span><b><span style="color:#000000">is_open</span></b><span style="color:#990000">()</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error: unable to open input file: "</span> <span style="color:#990000">&lt;&lt;</span> argv<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// read in the file into an internal string</span></i>
+    <span style="color:#009900">bool</span> codemode <span style="color:#990000">=</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <span style="color:#008080">string</span> codeprefix <span style="color:#990000">=</span> <span style="color:#FF0000">"    "</span><span style="color:#990000">;</span>
+    <span style="color:#008080">string</span> file<span style="color:#990000">,</span> line<span style="color:#990000">,</span> firstline<span style="color:#990000">;</span>
+    <span style="color:#009900">bool</span> gotfirstline <span style="color:#990000">=</span> <b><span style="color:#0000FF">false</span></b><span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">while</span></b> <span style="color:#990000">(</span> <b><span style="color:#000000">getline</span></b><span style="color:#990000">(</span>fin<span style="color:#990000">,</span>line<span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">!</span>gotfirstline <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            gotfirstline <span style="color:#990000">=</span> <b><span style="color:#0000FF">true</span></b><span style="color:#990000">;</span>
+            firstline <span style="color:#990000">=</span> line<span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">0</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'`'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">1</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'`'</span><span style="color:#990000">)</span> <span style="color:#990000">&amp;&amp;</span> <span style="color:#990000">(</span>line<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">]</span> <span style="color:#990000">==</span> <span style="color:#FF0000">'`'</span><span style="color:#990000">)</span> <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+            <i><span style="color:#9A1900">// we ignore any language specification after the three back quotes</span></i>
+            codemode <span style="color:#990000">=</span> <span style="color:#990000">!</span>codemode<span style="color:#990000">;</span>
+            <b><span style="color:#0000FF">continue</span></b><span style="color:#990000">;</span>
+        <span style="color:#FF0000">}</span>
+        <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> codemode <span style="color:#990000">)</span>
+            file <span style="color:#990000">+=</span> codeprefix<span style="color:#990000">;</span>
+        file <span style="color:#990000">+=</span> line <span style="color:#990000">+</span> <span style="color:#FF0000">"</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">;</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// try to process the string</span></i>
+    MMIOT<span style="color:#990000">*</span> doc <span style="color:#990000">=</span> <b><span style="color:#000000">mkd_string</span></b><span style="color:#990000">(</span>file<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">(),</span>file<span style="color:#990000">.</span><b><span style="color:#000000">length</span></b><span style="color:#990000">(),</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> doc <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        cout <span style="color:#990000">&lt;&lt;</span> <span style="color:#FF0000">"Error processing markdown input file in mkd_in()"</span> <span style="color:#990000">&lt;&lt;</span> endl<span style="color:#990000">;</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// determine where the output is going</span></i>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>outidx <span style="color:#990000">==</span> <span style="color:#990000">-</span><span style="color:#993399">1</span><span style="color:#990000">)</span> <span style="color:#990000">||</span> <span style="color:#990000">(!</span><b><span style="color:#000000">strcmp</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>outidx<span style="color:#990000">],</span><span style="color:#FF0000">"-"</span><span style="color:#990000">))</span> <span style="color:#990000">)</span>
+        fpout <span style="color:#990000">=</span> stdout<span style="color:#990000">;</span>
+    <b><span style="color:#0000FF">else</span></b> <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> <span style="color:#990000">(</span>fpout <span style="color:#990000">=</span> <b><span style="color:#000000">fopen</span></b><span style="color:#990000">(</span>argv<span style="color:#990000">[</span>outidx<span style="color:#990000">],</span><span style="color:#FF0000">"w"</span><span style="color:#990000">))</span> <span style="color:#990000">==</span> NULL <span style="color:#990000">)</span> <span style="color:#FF0000">{</span>
+        <b><span style="color:#000000">printf</span></b> <span style="color:#990000">(</span><span style="color:#FF0000">"Error: unable to open output file: %s</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> argv<span style="color:#990000">[</span><span style="color:#993399">2</span><span style="color:#990000">]);</span>
+        <b><span style="color:#000000">exit</span></b><span style="color:#990000">(</span><span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <span style="color:#FF0000">}</span>
+    <i><span style="color:#9A1900">// write the output</span></i>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;!doctype html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;head&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;meta charset=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">utf-8</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;title&gt;%s&lt;/title&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">,</span> firstline<span style="color:#990000">.</span><b><span style="color:#000000">c_str</span></b><span style="color:#990000">());</span>
+    <b><span style="color:#0000FF">if</span></b> <span style="color:#990000">(</span> css <span style="color:#990000">)</span>
+        <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;link href=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">%s</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> media=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">all</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> rel=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">stylesheet</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000"> type=</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">text/css</span><span style="color:#CC33CC">\"</span><span style="color:#FF0000">&gt;"</span><span style="color:#990000">,</span> css<span style="color:#990000">);</span>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;/head&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;body&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">markdown</span></b> <span style="color:#990000">(</span>doc<span style="color:#990000">,</span> fpout<span style="color:#990000">,</span> <span style="color:#993399">0</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">fprintf</span></b> <span style="color:#990000">(</span>fpout<span style="color:#990000">,</span> <span style="color:#FF0000">"&lt;/body&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">&lt;/html&gt;</span><span style="color:#CC33CC">\n</span><span style="color:#FF0000">"</span><span style="color:#990000">);</span>
+    <b><span style="color:#000000">fclose</span></b><span style="color:#990000">(</span>fpout<span style="color:#990000">);</span>
+    <b><span style="color:#000000">mkd_cleanup</span></b><span style="color:#990000">(</span>doc<span style="color:#990000">);</span>
+    <b><span style="color:#0000FF">return</span></b> <span style="color:#993399">0</span><span style="color:#990000">;</span>
+<span style="color:#FF0000">}</span>
+</pre>
 </body>
 </html>

--- a/utils/markdown.cpp.html
+++ b/utils/markdown.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.8
+<meta name="GENERATOR" content="GNU source-highlight 
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">


### PR DESCRIPTION
It's easy to forget to perform this step.

Also, I've changed the output format to HTML5, which gets us off of the use of obsolete font tags (but unfortunately does not make the pages responsive, because the template source-highlight uses is extremely barebones).

There are very few actual changes as a result of running the script:
- Some minor code updates that weren't synced with the HTML version
- Some Assembly files were being highlighted as S rather than Assembly, which the script fixed
- More Makefiles

If you also like #32, I can create a new PR incorporating both of them so that you don't have to resolve merge conflicts with Makefile.

* [ ] Should Makefiles be highlighted?