### PR TITLE
Lab 6: Remove -lrt hint

### DIFF
--- a/labs/lab06/code/timer.cpp
+++ b/labs/lab06/code/timer.cpp
@@ -1,6 +1,3 @@
-// NOTE: in order to compile this system on Linux (and most Unix
-// systems) you will have to include the -lrt flag to your compiler.
-
 #include <sstream>
 #include <math.h>
 #include <cstring>

--- a/labs/lab06/code/timer.cpp.html
+++ b/labs/lab06/code/timer.cpp.html
@@ -9,10 +9,7 @@ http://www.gnu.org/software/src-highlite">
 <title>labs/lab06/code/timer.cpp</title>
 </head>
 <body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
-
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sstream&gt;</font>
+<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;sstream&gt;</font>
 <b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;math.h&gt;</font>
 <b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;cstring&gt;</font>
 

--- a/labs/lab06/code/timer.h
+++ b/labs/lab06/code/timer.h
@@ -1,6 +1,3 @@
-// NOTE: in order to compile this system on Linux (and most Unix
-// systems) you will have to include the -lrt flag to your compiler.
-//
 // This timer typically has 1/1000000 second (1 micro-second) accuracy
 // under most Linux distributions
 

--- a/labs/lab06/code/timer.h.html
+++ b/labs/lab06/code/timer.h.html
@@ -9,10 +9,7 @@ http://www.gnu.org/software/src-highlite">
 <title>labs/lab06/code/timer.h</title>
 </head>
 <body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
-<i><font color="#9A1900">//</font></i>
-<i><font color="#9A1900">// This timer typically has 1/1000000 second (1 micro-second) accuracy</font></i>
+<pre><tt><i><font color="#9A1900">// This timer typically has 1/1000000 second (1 micro-second) accuracy</font></i>
 <i><font color="#9A1900">// under most Linux distributions</font></i>
 
 <b><font color="#000080">#ifndef</font></b> TIMER_H

--- a/labs/lab06/code/timer_test.cpp
+++ b/labs/lab06/code/timer_test.cpp
@@ -1,6 +1,3 @@
-// NOTE: in order to compile this system on Linux (and most Unix
-// systems) you will have to include the -lrt flag to your compiler.
-
 #include <iostream>
 #include "timer.h"
 using namespace std;

--- a/labs/lab06/code/timer_test.cpp.html
+++ b/labs/lab06/code/timer_test.cpp.html
@@ -9,10 +9,7 @@ http://www.gnu.org/software/src-highlite">
 <title>labs/lab06/code/timer_test.cpp</title>
 </head>
 <body bgcolor="white">
-<pre><tt><i><font color="#9A1900">// NOTE: in order to compile this system on Linux (and most Unix</font></i>
-<i><font color="#9A1900">// systems) you will have to include the -lrt flag to your compiler.</font></i>
-
-<b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
+<pre><tt><b><font color="#000080">#include</font></b> <font color="#FF0000">&lt;iostream&gt;</font>
 <b><font color="#000080">#include</font></b> <font color="#FF0000">"timer.h"</font>
 <b><font color="#0000FF">using</font></b> <b><font color="#0000FF">namespace</font></b> std<font color="#990000">;</font>
 


### PR DESCRIPTION
Per https://stackoverflow.com/a/47703372/5661593, -lrt is no longer needed since glibc 2.17, released in 2013. We get multiple Piazza questions on this every semester.