### PR TITLE
Improve TAs page

### DIFF
--- a/uva/tas.html
+++ b/uva/tas.html
@@ -6,7 +6,45 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Teaching Assistants</title>
   <link rel="stylesheet" href="../markdown.css">
-  <style type="text/css">code{white-space: pre;}img{max-width: 50%; max-height: 400px;}.container{display: grid; grid-template-columns: 1fr 1fr; row-gap: 3em; column-gap: 3em;}.bio img{float: left; padding-right: 1em;}</style>
+  <style type="text/css">
+    .container {
+      display: grid;
+      row-gap: 3em;
+      column-gap: 3em;
+    }
+
+    @media screen {
+      .container {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media screen and (min-width: 1366px) {
+      .container {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    @media screen and (min-width: 2560px) {
+      .container {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+    }
+
+    /* Scale down images so they're not humongous */
+    .bio img {
+      max-height: 400px;
+    }
+
+    /* Float images left on big-enough screens */
+    @media screen and (min-width: 768px) {
+      .bio img {
+        max-width: 50%;
+        float: left;
+        padding-right: 1em;
+      }
+    }
+  </style>
 </head>
 <body>
 <h1 id="teaching-assistants">Teaching Assistants</h1>

--- a/uva/tas.html
+++ b/uva/tas.html
@@ -122,7 +122,7 @@
   <div class="ta">
     <h2 id="hank-weber">Hank Weber</h2>
     <div class="bio">
-      <img src="https://user-images.githubusercontent.com/38435776/68172074-35623b80-ff44-11e9-8492-f80eaa21aa8b.jpg" alt="Hank Weber" />
+      <img src="https://user-images.githubusercontent.com/2766036/68237831-f8468980-ffd5-11e9-9a5c-0cba5ae1fc9f.jpg" alt="Hank Weber" />
       <p>Hi, I'm a fourth year CS (BS) and Econ major with a Engineering Business minor. This is my 3rd semester TAing for 2150 and before that I was a TA for 1110. I got interested in programming to automate simple tasks such as alerting me when people get on the 2150 queue or getting basketball tickets to UVA games.</p>
       <p>Outside of school I like to stay active (running, tennis, basketball, pretty much anything). Sadly, I also waste a lot of time playing video games (mostly PUBG and CSGO).</p>
     </div>
@@ -158,7 +158,7 @@
   <div class="ta">
     <h2 id="megan-marshall">Megan Marshall</h2>
     <div class="bio">
-      <img src="https://user-images.githubusercontent.com/2766036/67354421-0a7aef00-f523-11e9-862b-c37b2b1eb0a1.JPG" alt="Megan Marshall" />
+      <img src="https://user-images.githubusercontent.com/2766036/68238170-9d616200-ffd6-11e9-8622-ccee669870ca.jpg" alt="Megan Marshall" />
       <p>Hi! I'm a third year majoring in computer science and statistics and this is my first semester as a TA. I'm from Nova and have a little sister. I am a huge (and very optimistic) college sports fan, primarily for football and basketball, and love hiking, playing various IM sports, and just being outside in general. Another fun fact is I have a cactus named Bob and I know how to knit.</p>
     </div>
   </div>
@@ -230,7 +230,7 @@
   <div class="ta">
     <h2 id="wade-hisiro">Wade Hisiro</h2>
     <div class="bio">
-      <img src="https://user-images.githubusercontent.com/2766036/67354413-09e25880-f523-11e9-971a-97ffa848abfe.jpeg" alt="Wade Hisiro" />
+      <img src="https://user-images.githubusercontent.com/2766036/68238067-6428f200-ffd6-11e9-8041-4e9d79193422.jpg" alt="Wade Hisiro" />
       <p>Hey! I'm a fourth-year majoring in Computer Engineering from Harrisburg, PA. This will be my third semester TAing CS 2150. In my free time, you can catch me rock climbing, running, or playing intramurals like football. A fun fact about me is that I have an 18-year-old cat named Oreo.</p>
     </div>
   </div>

--- a/uva/tas.html
+++ b/uva/tas.html
@@ -5,95 +5,205 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Teaching Assistants</title>
-  <style type="text/css">code{white-space: pre;}img{max-height: 400px;}</style>
   <link rel="stylesheet" href="../markdown.css">
+  <style type="text/css">code{white-space: pre;}img{max-width: 50%; max-height: 400px;}.container{display: grid; grid-template-columns: 1fr 1fr; row-gap: 3em; column-gap: 3em;}.bio img{float: left; padding-right: 1em;}</style>
 </head>
 <body>
 <h1 id="teaching-assistants">Teaching Assistants</h1>
-<h2 id="aman-garg">Aman Garg</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354410-09e25880-f523-11e9-869a-d04889a3e3c9.png" alt="Aman Garg" />
-<p>Hi everyone! I am currently a 4th year computer science major and I am from the NOVA area. In my free time I am usually eating, sleeping, procrastinating or some combination of the three.</p>
-<h2 id="anna-cuddeback">Anna Cuddeback</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354417-0a7aef00-f523-11e9-91a3-07b006169c5f.jpg" alt="Anna Cuddeback" />
-<p>Hey Friends! My name is Anna Cuddeback and I'm a second year from Medford, Massachusetts studying computer engineering and physics. Outside of TAing and classes, I do physics research, resident-advise a first year dorm, and an officer in Outdoors at UVa. I'm really into my chacos, and my diet primarily subsets of peanut butter Clif bars and Dunkin Donuts iced coffee. I am also emotionally attached to my Nalgene. If you're not sure where I am, you can probably find me climbing at Slaughter or scooping up deals at the local Goodwill. Like Dwight Schrute, I always keep an extra set of Birkenstocks in the car for special occasions.</p>
-<h2 id="austin-sullivan">Austin Sullivan</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354415-0a7aef00-f523-11e9-99c0-e987eb45e575.JPG" alt="Austin Sullivan" />
-<p>Hello hello! I'm a fourth year in the E-School studying Computer Science with an Engineering Business minor. I grew up in the town of Swanton, Vermont and studied abroad in Auckland, New Zealand for a semester my second year. My hobbies include being an Engineering Guide, hiking, climbing, and playing basically any sport I can get my hands on, though I particularly love basketball and throwing the football on the Hereford lawn. I'm also genuinely curious to know how many people actually read these bios, so if you see me at office hours (Mondays 8-10pm), tell me a fun fact about yourself and I'll give you a special surprise!</p>
-<h2 id="bill-zhang">Bill Zhang</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354405-09e25880-f523-11e9-8e0f-c7e4c3463914.jpg" alt="Bill Zhang" />
-<p>Hi everyone! I am currently a 4th year Computer Engineering and Math double major. This is my 3rd semester TAing for this class. CS 2150 was honestly one of my favorite courses at UVa, so I hope I can help make the course just as enjoyable for all of you! Other than TAing, I also work as a research assistant and recently joined CSO. Fun fact about me is that I went axe throwing for the first time this last summer. I also have a pet cat at home!</p>
-<h2 id="charles-lim">Charles Lim</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354408-09e25880-f523-11e9-98a9-97c8828f2b3f.jpg" alt="Charles Lim" />
-<p>I would like to become a CS professor one day! I really enjoy leading other into understanding, and honestly, I live for those &quot;???...OHHH&quot; moments that we all have when we finally understand something we thought was impossible a second earlier! I will try my best to <em>point</em> you in the right direction!</p>
-<h2 id="cristopher-truong">Cristopher Truong</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354403-0949c200-f523-11e9-9a14-0467c404884a.jpg" alt="Cristopher Truong" />
-<p>Hi all, I'm a fourth year Computer Engineering major going into my third semester of TAing 2150. In my spare time I enjoy hiking, photography, and playing Smash.</p>
-<h2 id="courtney-jacobs">Courtney Jacobs</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354428-0b138580-f523-11e9-9cd3-6fea2582546d.png" alt="Courtney Jacobs" />
-<p>I'm a third year BSCS major, and this is my first semester as a CS 2150 TA. In my free time, I do research in the Link Lab, and I'm also involved in the Flying V's a cappella group, Veggies of Virginia, and my rock band, Silver Retriever.</p>
-<h2 id="dalianna-vaysman">Dalianna Vaysman</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354407-09e25880-f523-11e9-8b48-5c24ee2e74b1.jpg" alt="Dalianna Vaysman" />
-<p>Hi! I'm a fourth year double majoring in CS and Commerce with a minor in Technology Entrepreneurship. In my free time, I can be found playing tennis, listening to music, sending relatable gifs, or binge-watching a TV show that I don't have time for. A fun fact about me is that I've been to over 70 concerts. If you're interested in product management or double majoring in Comm &amp; CS, feel free to ask me any questions! Can't wait to meet you all this semester :)</p>
-<h2 id="daniel-tran">Daniel Tran</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354424-0a7aef00-f523-11e9-8f22-802f5dc7ffb7.jpg" alt="Daniel Tran" />
-<p>Hiyo! I'm a third-year CS Major from McLean, VA. This is my first semester TAing for 2150. I started TAing for the course because of how much I loved this course when I took it and of course because of how much I love Professor Aaron Bloomfield. He is THE MAN and a CS GOD. (Professor Nguyen and Floryan are also amazing!!) Outside of doing CS and living in Thornton Stacks, I'm an active member of VSA (Vietnamese Student Association). I have too many hobbies at the moment: I play lots of volleyball, basketball, and I have recently gotten into climbing at Slaughter. You'll catch me a lot in Mem gym or the AFC because I also like to dance with the Hooligans club. If you're ever looking to play volleyball or interested in dancing, I'm your guy!</p>
-<h2 id="disha-jain">Disha Jain</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354412-09e25880-f523-11e9-8a8d-5f35b053dffc.jpg" alt="Disha Jain" />
-<p>Hey! I'm a 4th-year BSCS major, minoring in Entrepreneurship. I dance, sing, and read in my free time, and I'm co-captain of a Bollywood dance team! I'm also co-President of HooHacks, UVA largest annual hackathon. A fun fact about me is that I saw Jimmy Fallon, Seth Meyers, John Oliver, Jake Gyllenhaal, and the Jonas Brothers this summer! I love talking to people, so hmu if you have any questions about anything or just want to chat :)</p>
-<h2 id="hank-weber">Hank Weber</h2>
-<img src="https://user-images.githubusercontent.com/38435776/68172074-35623b80-ff44-11e9-8492-f80eaa21aa8b.jpg" alt="Hank Weber" />
-<p>Hi, I'm a fourth year CS (BS) and Econ major with a Engineering Business minor. This is my 3rd semester TAing for 2150 and before that I was a TA for 1110. I got interested in programming to automate simple tasks such as alerting me when people get on the 2150 queue or getting basketball tickets to UVA games.</p>
-<p>Outside of school I like to stay active (running, tennis, basketball, pretty much anything). Sadly, I also waste a lot of time playing video games (mostly PUBG and CSGO).</p>
-<h2 id="jack-schefer">Jack Schefer</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354411-09e25880-f523-11e9-8a27-94343f43997a.jpg" alt="Jack Schefer" />
-<p>Hello! My name's Jack and I'm a third year CS/CpE double major in the E-School. I love to TA, run, cook, and rock climb in my free time . I love talking about CS, personal finance, and (of course) CS 2150! Fun fact: my left wrist has appeared on the front page of the CustomInk website.</p>
-<h2 id="john-saunders">John Saunders</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354414-0a7aef00-f523-11e9-8e89-610057923707.png" alt="John Saunders" />
-<p>Hey guys! I am a third year B.S. CS major. I love coding and problem solving which is what this class is all about. I ta for this class because I enjoyed this class and how challenging it was. It is also great because you learn so many fundamental ideas of CS. A fun fact about me is that I grew up on an Apple farm in Southern Virginia, and I used to spend my summers helping out on the farm.</p>
-<h2 id="madi-flynn">Madi Flynn</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354402-0949c200-f523-11e9-934b-5e070bacabdb.png" alt="Madi Flynn" />
-<p>Hi, I'm a 3rd year majoring in CS in the E-School! I am interested in cybersecurity and back-end development, and I want to learn more about ML and cloud. I'm a TA for 2150 because I really like helping people (especially with code) and since I used OH a lot when I took the course, I wanted to give back a little bit.</p>
-<h2 id="marina-kun">Marina Kun</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354419-0a7aef00-f523-11e9-9324-e173e43e35a5.jpeg" alt="Marina Kun" />
-<p>Hey! I'm a 3rd year in the engineering school studying computer science. This is my 2nd semester TA-ing this course. I also teach a web development course at HackCville. When I actually have free time :( I like to draw and paint! Fun fact about me is I'm really, reallyyy good at this board game called Pucket. I'm always up for a good talk about anything, and I'm definitely down for a Pucket match!</p>
-<h2 id="megan-marshall">Megan Marshall</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354421-0a7aef00-f523-11e9-862b-c37b2b1eb0a1.JPG" alt="Megan Marshall" />
-<p>Hi! I'm a third year majoring in computer science and statistics and this is my first semester as a TA. I'm from Nova and have a little sister. I am a huge (and very optimistic) college sports fan, primarily for football and basketball, and love hiking, playing various IM sports, and just being outside in general. Another fun fact is I have a cactus named Bob and I know how to knit.</p>
-<h2 id="nace-plesko">Nace Plesko</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354425-0b138580-f523-11e9-92ea-8bf7a0ec9f25.jpg" alt="Nace Plesko" />
-<p>I am fourth year student-athlete double majoring in CS and Math. In my free time I like to play League of Legends. Fun fact: Instant Pot changed my life</p>
-<h2 id="nate-strawser">Nate Strawser</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354406-09e25880-f523-11e9-8a1e-32f54dc2087d.jpg" alt="Nate Strawser" />
-<p>I'm a 4th year Computer Science major. 2150 was one of my favorite CS courses, and I wanted to help other students love it as much as I did. Some fun facts about me: I was born in Sweden but grew up in Orlando, Florida. I've interned in Kansas City and NYC. I love all things outdoors, and I've been to Moab, Utah twice with the Outdoors Club. I can ride a unicycle and juggle, but not at the same time, and I'm taking Intro to SCUBA this semester!</p>
-<h2 id="neal-patel">Neal Patel</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354422-0a7aef00-f523-11e9-8125-228f387df2e3.jpg" alt="Neal Patel" />
-<p>Hey! I am a third-year computer science and statistics major from Richmond, Virginia. This is my first semester as a TA for 2150, and I am looking forward to working with you all! On Grounds, I am involved in CS research, the organizing team for HooHacks, and the developer team for theCourseForum.</p>
-<h2 id="nick-mohammed">Nick Mohammed</h2>
-<p>Hey Guys! I'm a fourth year from Bristow, Virginia, majoring in computer engineering. This is my third semester TAing for 2150, and I hope to keep my record of &quot;&quot;making 0 students cry in office hours&quot;&quot; alive. If you see me around outside of lab / office hours, I'll most likely be in the NI lab at Thornton or the Dell playing basketball. I'm always down to play so if anyone ever needs a shooting partner I'm down!</p>
-<p>Some fun facts about me: 1) I don't have a single photo of myself on my phone, 2) I can solve a Rubiks cube in &lt; 30 seconds, 3) I love collecting sneakers.</p>
-<h2 id="ramya-bhaskara">Ramya Bhaskara</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354416-0a7aef00-f523-11e9-8ac5-1573a4f8dcaa.jpeg" alt="Ramya Bhaskara" />
-<p>I'm a second year Computer Science major and this is my first semester TAing this class! I'm really interested in data science, cooking/eating, and art. I'm also a part of SWE, A.O.E., and WiCS. I'm a TA because it can be really rewarding, and I loved CS 2150 as a student.</p>
-<h2 id="sam-mcbroom">Sam McBroom</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354418-0a7aef00-f523-11e9-9a23-a45363150aeb.JPG" alt="Sam McBroom" />
-<p>I am a third year BSCS and Physics major and this is my third semester as a TA for CS 2150. I am involved in Veggies of Virginia and swing dancing. In my free time, I like to work on side projects, cook, run, and hike.</p>
-<h2 id="sam-spelsberg">Sam Spelsberg</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354423-0a7aef00-f523-11e9-9a75-06e110ea4243.jpg" alt="Sam Spelsberg" />
-<p>I am Sam Spelsberg, third year in e-school CS, with a focus in Cyber Security. 2150 is one of my favorite classes in the CS major, and I believe that the concepts I learned in this class have been foundational to the rest of my computer science experience. I now strive to help other students learn, and get as much as possible from this course.</p>
-<p>I love traveling, and experiencing other cultures, and I hope to travel to each continent some day. I was born in Seattle and I will always love the west coast. Social Psychology is my favorite course I've taken outside of the engineering school, and I find the studies of human behavior, philosophy, ethics, and history fascinating.</p>
-<p>Hit me up if you ever have any questions about cyber security!</p>
-<h2 id="sandy-gould">Sandy Gould</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354427-0b138580-f523-11e9-8b74-ab6cf9966fdb.jpg" alt="Sandy Gould" />
-<p>Hi everyone, my name is Sandy Gould! I am a 4th year BSCS major, and I am from Leesburg, VA. I am also involved with Women in Computing Sciences (WiCS) and CSA. If you ever want to talk to me about CS, life at UVA, or anything really I'd love to chat! A fun fact about me is that I have done four Humpback sunrise hikes and one Humpback sunset hike since coming to UVA (and I plan on doing more this year!).</p>
-<h2 id="trent-ballard">Trent Ballard</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354404-0949c200-f523-11e9-92ce-a3c9b58cf183.PNG" alt="Trent Ballard" />
-<p>Hey! I'm a second year studying Computer Science and pursuing a minor in Engineering Business. I am from northern Virginia and am on the club Ultimate Frisbee team here at UVA. Some fun facts about me is that I have eaten the hottest pepper in the world, am a loyal DC sports fan (sadly), and just got 20+ stitches in my right eyebrow!</p>
-<h2 id="wade-hisiro">Wade Hisiro</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67354413-09e25880-f523-11e9-971a-97ffa848abfe.jpeg" alt="Wade Hisiro" />
-<p>Hey! I'm a fourth-year majoring in Computer Engineering from Harrisburg, PA. This will be my third semester TAing CS 2150. In my free time, you can catch me rock climbing, running, or playing intramurals like football. A fun fact about me is that I have an 18-year-old cat named Oreo.</p>
-<h2 id="winston-liu">Winston Liu</h2>
-<img src="https://user-images.githubusercontent.com/2766036/67355401-37c89c80-f525-11e9-87cf-c4c9601998d5.jpg" alt="Winston Liu" />
-<p>Hey hey! I'm from Morris Plains, New Jersey and majoring in Computer Science with a minor in Spanish. I like to stay active - I absolutely love rock climbing, and I also dabble with volleyball, badminton, soccer, basketball, hiking, running, and ballroom dancing. Need a rock-climbing partner or want to learn more about it? Look no further 😁. I'm here if you want to talk about the CS curriculum, interviews and internships, TAing, residential colleges (go Hereford!), life, or anything, really :).</p>
-<p>Fun facts! I'm ambidextrous, am weirdly good at remembering computing IDs, and have walked the last 200km of the Camino de Santiago!</p>
+<div class="container">
+  <div class="ta">
+    <h2 id="aman-garg">Aman Garg</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354410-09e25880-f523-11e9-869a-d04889a3e3c9.png" alt="Aman Garg" />
+      <p>Hi everyone! I am currently a 4th year computer science major and I am from the NOVA area. In my free time I am usually eating, sleeping, procrastinating or some combination of the three.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="anna-cuddeback">Anna Cuddeback</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354417-0a7aef00-f523-11e9-91a3-07b006169c5f.jpg" alt="Anna Cuddeback" />
+      <p>Hey Friends! My name is Anna Cuddeback and I'm a second year from Medford, Massachusetts studying computer engineering and physics. Outside of TAing and classes, I do physics research, resident-advise a first year dorm, and an officer in Outdoors at UVa. I'm really into my chacos, and my diet primarily subsets of peanut butter Clif bars and Dunkin Donuts iced coffee. I am also emotionally attached to my Nalgene. If you're not sure where I am, you can probably find me climbing at Slaughter or scooping up deals at the local Goodwill. Like Dwight Schrute, I always keep an extra set of Birkenstocks in the car for special occasions.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="austin-sullivan">Austin Sullivan</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354415-0a7aef00-f523-11e9-99c0-e987eb45e575.JPG" alt="Austin Sullivan" />
+      <p>Hello hello! I'm a fourth year in the E-School studying Computer Science with an Engineering Business minor. I grew up in the town of Swanton, Vermont and studied abroad in Auckland, New Zealand for a semester my second year. My hobbies include being an Engineering Guide, hiking, climbing, and playing basically any sport I can get my hands on, though I particularly love basketball and throwing the football on the Hereford lawn. I'm also genuinely curious to know how many people actually read these bios, so if you see me at office hours (Mondays 8-10pm), tell me a fun fact about yourself and I'll give you a special surprise!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="bill-zhang">Bill Zhang</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354405-09e25880-f523-11e9-8e0f-c7e4c3463914.jpg" alt="Bill Zhang" />
+      <p>Hi everyone! I am currently a 4th year Computer Engineering and Math double major. This is my 3rd semester TAing for this class. CS 2150 was honestly one of my favorite courses at UVa, so I hope I can help make the course just as enjoyable for all of you! Other than TAing, I also work as a research assistant and recently joined CSO. Fun fact about me is that I went axe throwing for the first time this last summer. I also have a pet cat at home!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="charles-lim">Charles Lim</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354408-09e25880-f523-11e9-98a9-97c8828f2b3f.jpg" alt="Charles Lim" />
+      <p>I would like to become a CS professor one day! I really enjoy leading other into understanding, and honestly, I live for those &quot;???...OHHH&quot; moments that we all have when we finally understand something we thought was impossible a second earlier! I will try my best to <em>point</em> you in the right direction!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="cristopher-truong">Cristopher Truong</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354403-0949c200-f523-11e9-9a14-0467c404884a.jpg" alt="Cristopher Truong" />
+      <p>Hi all, I'm a fourth year Computer Engineering major going into my third semester of TAing 2150. In my spare time I enjoy hiking, photography, and playing Smash.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="courtney-jacobs">Courtney Jacobs</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354428-0b138580-f523-11e9-9cd3-6fea2582546d.png" alt="Courtney Jacobs" />
+      <p>I'm a third year BSCS major, and this is my first semester as a CS 2150 TA. In my free time, I do research in the Link Lab, and I'm also involved in the Flying V's a cappella group, Veggies of Virginia, and my rock band, Silver Retriever.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="dalianna-vaysman">Dalianna Vaysman</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354407-09e25880-f523-11e9-8b48-5c24ee2e74b1.jpg" alt="Dalianna Vaysman" />
+      <p>Hi! I'm a fourth year double majoring in CS and Commerce with a minor in Technology Entrepreneurship. In my free time, I can be found playing tennis, listening to music, sending relatable gifs, or binge-watching a TV show that I don't have time for. A fun fact about me is that I've been to over 70 concerts. If you're interested in product management or double majoring in Comm &amp; CS, feel free to ask me any questions! Can't wait to meet you all this semester :)</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="daniel-tran">Daniel Tran</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354424-0a7aef00-f523-11e9-8f22-802f5dc7ffb7.jpg" alt="Daniel Tran" />
+      <p>Hiyo! I'm a third-year CS Major from McLean, VA. This is my first semester TAing for 2150. I started TAing for the course because of how much I loved this course when I took it and of course because of how much I love Professor Aaron Bloomfield. He is THE MAN and a CS GOD. (Professor Nguyen and Floryan are also amazing!!) Outside of doing CS and living in Thornton Stacks, I'm an active member of VSA (Vietnamese Student Association). I have too many hobbies at the moment: I play lots of volleyball, basketball, and I have recently gotten into climbing at Slaughter. You'll catch me a lot in Mem gym or the AFC because I also like to dance with the Hooligans club. If you're ever looking to play volleyball or interested in dancing, I'm your guy!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="disha-jain">Disha Jain</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354412-09e25880-f523-11e9-8a8d-5f35b053dffc.jpg" alt="Disha Jain" />
+      <p>Hey! I'm a 4th-year BSCS major, minoring in Entrepreneurship. I dance, sing, and read in my free time, and I'm co-captain of a Bollywood dance team! I'm also co-President of HooHacks, UVA largest annual hackathon. A fun fact about me is that I saw Jimmy Fallon, Seth Meyers, John Oliver, Jake Gyllenhaal, and the Jonas Brothers this summer! I love talking to people, so hmu if you have any questions about anything or just want to chat :)</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="hank-weber">Hank Weber</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/38435776/68172074-35623b80-ff44-11e9-8492-f80eaa21aa8b.jpg" alt="Hank Weber" />
+      <p>Hi, I'm a fourth year CS (BS) and Econ major with a Engineering Business minor. This is my 3rd semester TAing for 2150 and before that I was a TA for 1110. I got interested in programming to automate simple tasks such as alerting me when people get on the 2150 queue or getting basketball tickets to UVA games.</p>
+      <p>Outside of school I like to stay active (running, tennis, basketball, pretty much anything). Sadly, I also waste a lot of time playing video games (mostly PUBG and CSGO).</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="jack-schefer">Jack Schefer</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354411-09e25880-f523-11e9-8a27-94343f43997a.jpg" alt="Jack Schefer" />
+      <p>Hello! My name's Jack and I'm a third year CS/CpE double major in the E-School. I love to TA, run, cook, and rock climb in my free time . I love talking about CS, personal finance, and (of course) CS 2150! Fun fact: my left wrist has appeared on the front page of the CustomInk website.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="john-saunders">John Saunders</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354414-0a7aef00-f523-11e9-8e89-610057923707.png" alt="John Saunders" />
+      <p>Hey guys! I am a third year B.S. CS major. I love coding and problem solving which is what this class is all about. I ta for this class because I enjoyed this class and how challenging it was. It is also great because you learn so many fundamental ideas of CS. A fun fact about me is that I grew up on an Apple farm in Southern Virginia, and I used to spend my summers helping out on the farm.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="madi-flynn">Madi Flynn</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354402-0949c200-f523-11e9-934b-5e070bacabdb.png" alt="Madi Flynn" />
+      <p>Hi, I'm a 3rd year majoring in CS in the E-School! I am interested in cybersecurity and back-end development, and I want to learn more about ML and cloud. I'm a TA for 2150 because I really like helping people (especially with code) and since I used OH a lot when I took the course, I wanted to give back a little bit.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="marina-kun">Marina Kun</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354419-0a7aef00-f523-11e9-9324-e173e43e35a5.jpeg" alt="Marina Kun" />
+      <p>Hey! I'm a 3rd year in the engineering school studying computer science. This is my 2nd semester TA-ing this course. I also teach a web development course at HackCville. When I actually have free time :( I like to draw and paint! Fun fact about me is I'm really, reallyyy good at this board game called Pucket. I'm always up for a good talk about anything, and I'm definitely down for a Pucket match!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="megan-marshall">Megan Marshall</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354421-0a7aef00-f523-11e9-862b-c37b2b1eb0a1.JPG" alt="Megan Marshall" />
+      <p>Hi! I'm a third year majoring in computer science and statistics and this is my first semester as a TA. I'm from Nova and have a little sister. I am a huge (and very optimistic) college sports fan, primarily for football and basketball, and love hiking, playing various IM sports, and just being outside in general. Another fun fact is I have a cactus named Bob and I know how to knit.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="nace-plesko">Nace Plesko</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354425-0b138580-f523-11e9-92ea-8bf7a0ec9f25.jpg" alt="Nace Plesko" />
+      <p>I am fourth year student-athlete double majoring in CS and Math. In my free time I like to play League of Legends. Fun fact: Instant Pot changed my life</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="nate-strawser">Nate Strawser</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354406-09e25880-f523-11e9-8a1e-32f54dc2087d.jpg" alt="Nate Strawser" />
+      <p>I'm a 4th year Computer Science major. 2150 was one of my favorite CS courses, and I wanted to help other students love it as much as I did. Some fun facts about me: I was born in Sweden but grew up in Orlando, Florida. I've interned in Kansas City and NYC. I love all things outdoors, and I've been to Moab, Utah twice with the Outdoors Club. I can ride a unicycle and juggle, but not at the same time, and I'm taking Intro to SCUBA this semester!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="neal-patel">Neal Patel</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354422-0a7aef00-f523-11e9-8125-228f387df2e3.jpg" alt="Neal Patel" />
+      <p>Hey! I am a third-year computer science and statistics major from Richmond, Virginia. This is my first semester as a TA for 2150, and I am looking forward to working with you all! On Grounds, I am involved in CS research, the organizing team for HooHacks, and the developer team for theCourseForum.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="nick-mohammed">Nick Mohammed</h2>
+    <div class="bio">
+      <p>Hey Guys! I'm a fourth year from Bristow, Virginia, majoring in computer engineering. This is my third semester TAing for 2150, and I hope to keep my record of &quot;&quot;making 0 students cry in office hours&quot;&quot; alive. If you see me around outside of lab / office hours, I'll most likely be in the NI lab at Thornton or the Dell playing basketball. I'm always down to play so if anyone ever needs a shooting partner I'm down!</p>
+      <p>Some fun facts about me: 1) I don't have a single photo of myself on my phone, 2) I can solve a Rubiks cube in &lt; 30 seconds, 3) I love collecting sneakers.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="ramya-bhaskara">Ramya Bhaskara</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354416-0a7aef00-f523-11e9-8ac5-1573a4f8dcaa.jpeg" alt="Ramya Bhaskara" />
+      <p>I'm a second year Computer Science major and this is my first semester TAing this class! I'm really interested in data science, cooking/eating, and art. I'm also a part of SWE, A.O.E., and WiCS. I'm a TA because it can be really rewarding, and I loved CS 2150 as a student.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="sam-mcbroom">Sam McBroom</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354418-0a7aef00-f523-11e9-9a23-a45363150aeb.JPG" alt="Sam McBroom" />
+      <p>I am a third year BSCS and Physics major and this is my third semester as a TA for CS 2150. I am involved in Veggies of Virginia and swing dancing. In my free time, I like to work on side projects, cook, run, and hike.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="sam-spelsberg">Sam Spelsberg</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354423-0a7aef00-f523-11e9-9a75-06e110ea4243.jpg" alt="Sam Spelsberg" />
+      <p>I am Sam Spelsberg, third year in e-school CS, with a focus in Cyber Security. 2150 is one of my favorite classes in the CS major, and I believe that the concepts I learned in this class have been foundational to the rest of my computer science experience. I now strive to help other students learn, and get as much as possible from this course.</p>
+      <p>I love traveling, and experiencing other cultures, and I hope to travel to each continent some day. I was born in Seattle and I will always love the west coast. Social Psychology is my favorite course I've taken outside of the engineering school, and I find the studies of human behavior, philosophy, ethics, and history fascinating.</p>
+      <p>Hit me up if you ever have any questions about cyber security!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="sandy-gould">Sandy Gould</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354427-0b138580-f523-11e9-8b74-ab6cf9966fdb.jpg" alt="Sandy Gould" />
+      <p>Hi everyone, my name is Sandy Gould! I am a 4th year BSCS major, and I am from Leesburg, VA. I am also involved with Women in Computing Sciences (WiCS) and CSA. If you ever want to talk to me about CS, life at UVA, or anything really I'd love to chat! A fun fact about me is that I have done four Humpback sunrise hikes and one Humpback sunset hike since coming to UVA (and I plan on doing more this year!).</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="trent-ballard">Trent Ballard</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354404-0949c200-f523-11e9-92ce-a3c9b58cf183.PNG" alt="Trent Ballard" />
+      <p>Hey! I'm a second year studying Computer Science and pursuing a minor in Engineering Business. I am from northern Virginia and am on the club Ultimate Frisbee team here at UVA. Some fun facts about me is that I have eaten the hottest pepper in the world, am a loyal DC sports fan (sadly), and just got 20+ stitches in my right eyebrow!</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="wade-hisiro">Wade Hisiro</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67354413-09e25880-f523-11e9-971a-97ffa848abfe.jpeg" alt="Wade Hisiro" />
+      <p>Hey! I'm a fourth-year majoring in Computer Engineering from Harrisburg, PA. This will be my third semester TAing CS 2150. In my free time, you can catch me rock climbing, running, or playing intramurals like football. A fun fact about me is that I have an 18-year-old cat named Oreo.</p>
+    </div>
+  </div>
+  <div class="ta">
+    <h2 id="winston-liu">Winston Liu</h2>
+    <div class="bio">
+      <img src="https://user-images.githubusercontent.com/2766036/67355401-37c89c80-f525-11e9-87cf-c4c9601998d5.jpg" alt="Winston Liu" />
+      <p>Hey hey! I'm from Morris Plains, New Jersey and majoring in Computer Science with a minor in Spanish. I like to stay active - I absolutely love rock climbing, and I also dabble with volleyball, badminton, soccer, basketball, hiking, running, and ballroom dancing. Need a rock-climbing partner or want to learn more about it? Look no further 😁. I'm here if you want to talk about the CS curriculum, interviews and internships, TAing, residential colleges (go Hereford!), life, or anything, really :).</p>
+      <p>Fun facts! I'm ambidextrous, am weirdly good at remembering computing IDs, and have walked the last 200km of the Camino de Santiago!</p>
+    </div>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
This follows up on #36 by:
- Using a responsive grid to layout the bios
  - On screens at least 2560px wide, three columns are used to display the bios
  - On screens at least 1366px wide, two columns are used
  - Otherwise, one column is used
- Floating the image to the left of the description
  - Only if the screen is at least 768px wide
- Rotating the sideways/upside-down images

![new-design-large](https://user-images.githubusercontent.com/2766036/68238611-81aa8b80-ffd7-11e9-875d-c0cc8e5119e7.png)
![new-design-medium](https://user-images.githubusercontent.com/2766036/68238662-94bd5b80-ffd7-11e9-90f2-fa32cd414c95.png)
![new-design-small](https://user-images.githubusercontent.com/2766036/68238694-a272e100-ffd7-11e9-85c4-7e29af654b05.png)


