### PR TITLE
Print binary heap in tree form

### DIFF
--- a/labs/lab11/traveling-skeleton.cpp
+++ b/labs/lab11/traveling-skeleton.cpp
@@ -36,6 +36,7 @@ int main (int argc, char **argv) {
 // vector IN ORDER, and ends back at the 'start' parameter.
 float computeDistance (MiddleEarth &me, string start, vector<string> dests) {
     // YOUR CODE HERE
+    return 0;
 }
 
 // This method will print the entire route, starting and ending at the

--- a/slides/code/10-heaps-huffman/binary_heap.cpp
+++ b/slides/code/10-heaps-huffman/binary_heap.cpp
@@ -136,14 +136,42 @@ heap_node* binary_heap::createTree() {
   return nodes[1]; // return the root node of the tree
 }
 
+// Helper function to print branches of the binary tree
+void showTrunks(Trunk* p) {
+    if (p == nullptr) return;
+    showTrunks(p->prev);
+    cout << p->str;
+}
+
 void binary_heap::print() {
-    cout << "(" << heap[0] << ") ";
-    for ( int i = 1; i <= heap_size; i++ ) {
-        cout << heap[i] << " ";
-        // next line from http://tinyurl.com/mf9tbgm
-        bool isPow2 = (((i+1) & ~(i))==(i+1))? i+1 : 0;
-        if ( isPow2 )
-            cout << endl << "\t";
+  print(createTree(), NULL, false);
+}
+
+// Recursive function to print binary tree
+// It uses inorder traversal
+void binary_heap::print(heap_node* root, Trunk* prev, bool isRight) {
+    if (root == NULL) return;
+
+    string prev_str = "    ";
+    Trunk* trunk = new Trunk(prev, prev_str);
+
+    print(root->right, trunk, true);
+
+    if (!prev)
+        trunk->str = "---";
+    else if (isRight) { // github user @willzhang05 pointed out that I forgot to change this from isLeft to isRight on my first commit
+        trunk->str = ".---";
+        prev_str = "   |";
+    } else {
+        trunk->str = "`---";
+        prev->str = prev_str;
     }
-    cout << endl;
+
+    showTrunks(trunk);
+    cout << root->value << endl;
+
+    if (prev) prev->str = prev_str;
+    trunk->str = "   |";
+
+    print(root->left, trunk, false);
 }

--- a/slides/code/10-heaps-huffman/binary_heap.cpp
+++ b/slides/code/10-heaps-huffman/binary_heap.cpp
@@ -97,6 +97,44 @@ bool binary_heap::isEmpty() {
     return heap_size == 0;
 }
 
+heap_node* binary_heap::createTree() {
+  // Create all heap nodes and store them in an array
+  heap_node* nodes[heap_size+1]; // array containing all heap nodes
+  nodes[0] = NULL; // ignore the zero index
+  for (int i = 1; i <= heap_size; i++) {
+    heap_node* n = new heap_node;
+    n->value = heap[i];
+    nodes[i] = n;
+  }
+  cout << endl;
+
+  // Create the tree
+  // For every node x, we want to insert its left and right child
+  for (int i = 1; i <= heap_size; i++) {
+    heap_node* current = nodes[i];
+    int leftChildIndex = 2*i;
+    int rightChildIndex = 2*i + 1;
+
+    // If the index of the left child is larger than the number of
+    // elements in the heap, it means that the current node doesn't
+    // have a left child.
+    if (leftChildIndex >= heap_size+1)
+      current->left = NULL;
+    else
+      current->left = nodes[leftChildIndex];
+    
+    // If the index of the right child is larger than the number of
+    // elements in the heap, it means that the current node doesn't
+    // have a right child.
+    if (rightChildIndex >= heap_size+1)
+      current->right = NULL;
+    else
+      current->right = nodes[rightChildIndex];
+  }
+
+  return nodes[1]; // return the root node of the tree
+}
+
 void binary_heap::print() {
     cout << "(" << heap[0] << ") ";
     for ( int i = 1; i <= heap_size; i++ ) {

--- a/slides/code/10-heaps-huffman/binary_heap.cpp
+++ b/slides/code/10-heaps-huffman/binary_heap.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include "binary_heap.h"
+#include "heap_node.h"
 using namespace std;
 
 // default constructor

--- a/slides/code/10-heaps-huffman/binary_heap.h
+++ b/slides/code/10-heaps-huffman/binary_heap.h
@@ -6,6 +6,7 @@
 #define BINARY_HEAP_H
 
 #include <vector>
+#include "heap_node.h"
 using namespace std;
 
 class binary_heap {
@@ -20,6 +21,7 @@ public:
     unsigned int size();
     void makeEmpty();
     bool isEmpty();
+    heap_node* createTree();
     void print();
 
 private:

--- a/slides/code/10-heaps-huffman/binary_heap.h
+++ b/slides/code/10-heaps-huffman/binary_heap.h
@@ -9,6 +9,16 @@
 #include "heap_node.h"
 using namespace std;
 
+struct Trunk {
+    Trunk* prev;
+    string str;
+
+    Trunk(Trunk* prev, string str) {
+        this->prev = prev;
+        this->str = str;
+    }
+};
+
 class binary_heap {
 public:
     binary_heap();
@@ -23,6 +33,7 @@ public:
     bool isEmpty();
     heap_node* createTree();
     void print();
+    void print(heap_node* root, Trunk* prev, bool isRight);
 
 private:
     vector<int> heap;

--- a/slides/code/10-heaps-huffman/heap_node.cpp
+++ b/slides/code/10-heaps-huffman/heap_node.cpp
@@ -1,0 +1,15 @@
+// Code written by Aaron Bloomfield, 2014
+// Released under a CC BY-SA license
+// This code is part of the https://github.com/aaronbloomfield/pdr repository
+
+#include <iostream>
+#include "binary_heap.h"
+#include "heap_node.h"
+using namespace std;
+
+// default constructor
+heap_node::heap_node() {
+  this->value = 0;
+  this->left = NULL;
+  this->right = NULL;
+}

--- a/slides/code/10-heaps-huffman/heap_node.h
+++ b/slides/code/10-heaps-huffman/heap_node.h
@@ -1,0 +1,23 @@
+// Code written by Aaron Bloomfield, 2014
+// Released under a CC BY-SA license
+// This code is part of the https://github.com/aaronbloomfield/pdr repository
+
+#ifndef HEAP_NODE_H
+#define HEAP_NODE_H
+
+#include <vector>
+using namespace std;
+
+class heap_node {
+public:
+    heap_node();
+
+private:
+    int value;
+    heap_node* left;
+    heap_node* right;
+
+    friend class binary_heap;
+};
+
+#endif


### PR DESCRIPTION
This pull request improves the print() method in binary_heap.cpp by printing the heap as a tree instead of as an array, making it easier to visualize the heap.

createTree() is a helper method, which iterates through each element in the heap array to create a binary tree from the array.

Notes:
1) The print functionality itself is taken from lab 5.
2) Please ignore commit 05dc0cb, as it is a duplicate of the commit in the previous pull request.