### PR TITLE
Simplify procedures

### DIFF
--- a/labs/lab01/index.html
+++ b/labs/lab01/index.html
@@ -18,15 +18,17 @@
 <p>This is laboratory is intended to get you up to speed quickly with both C++ and Unix.</p>
 <h3 id="background">Background</h3>
 <p>There will be a lab every week, which consists of three parts: a pre-lab, an in-lab, and a post-lab. The due dates are all listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. This will all be discussed in this lab.</p>
-<h3 id="readings">Reading(s)</h3>
-<ol type="1">
-<li><a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a></li>
-<li>Optional: online sources as posted on the <a href="../../docs/readings.html">Readings page</a></li>
-</ol>
+<h3 id="tutorial">Tutorial</h3>
+<p>Most labs will have a tutorial. You are expected to complete this tutorial before beginning the lab, as the lab will use concepts from each tutorial.</p>
+<p>The tutorial for this lab is <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a>, which will help you set up your UNIX environment.</p>
+<h3 id="recommended-readings">Recommended Readings</h3>
+<p>We have attempted to compile a collection of readings that go over topics covered in this course. Readings are always optional and are there for you to use as you see fit.</p>
+<ul>
+<li>Introduction to C++ section on the <a href="../../docs/readings.html">Readings page</a></li>
+</ul>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a></li>
 <li>Write a recursive function to compute exponentiation</li>
 <li>Investigate the C++ object lifecycle</li>
 <li>Learn about the submission system</li>
@@ -49,7 +51,7 @@
 </ol>
 <hr />
 <h2 id="pre-lab-1">Pre-lab</h2>
-<p>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a> before proceeding.</p>
+<p>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a> before proceeding. Remember that you should always complete the tutorial before starting the lab.</p>
 <p>For the pre-lab, you will need to write a <strong>recursive</strong> function called <code>xton()</code> to compute <em>x^n</em> for non-negative integers <em>n</em>. Assume that <em>x^0=1</em>. Put this function in a program with a <code>main()</code> function. Your program should prompt the user for two integer values, and raise the first to the power of the second by calling your <code>xton()</code> function. To keep the code simple, you can assume that your program will only be called with valid inputs.</p>
 <p>The file should be called xToN.cpp, and should be submitted to the pre-lab 1 assignment in the submission system -- more details below.</p>
 <p>Note that your program should take in <strong>exactly two inputs and nothing else</strong>. We are going to run it through an automated grading script prior to the TAs grading it -- if your program takes in a different number of inputs, you will receive points off.</p>

--- a/labs/lab01/index.html
+++ b/labs/lab01/index.html
@@ -17,7 +17,7 @@
 <h3 id="objective">Objective</h3>
 <p>This is laboratory is intended to get you up to speed quickly with both C++ and Unix.</p>
 <h3 id="background">Background</h3>
-<p>Every week we will have a lab meeting. Each lab will consist of three parts: a pre-lab (to be completed by Tuesday at the due time listed on the <a href="../../uva/labduedates.html">lab due dates</a> page, an in-lab (activity to be done during lab), and a post-lab. The pre-lab will typically also include a tutorial. Parts of all three of these may be required to turned in. The due dates are all listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. This will all be discussed in this lab.</p>
+<p>There will be a lab every week, which consists of three parts: a pre-lab, an in-lab, and a post-lab. The due dates are all listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. This will all be discussed in this lab.</p>
 <h3 id="readings">Reading(s)</h3>
 <ol type="1">
 <li><a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a></li>
@@ -26,37 +26,27 @@
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>If desired, the alternative readings are available on the <a href="../../docs/readings.html">Readings page</a></li>
-<li>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a>
-<ol type="a">
-<li>As part of this tutorial, you will need to decide how you want to develop in a Unix environment -- we recommend <a href="../../tutorials/01-intro-unix/virtual-box.html">VirtualBox</a>, but there are other options available</li>
-<li>If you are using VirtualBox, you will have to decide on which display manager to use</li>
-</ol></li>
-<li>Be sure to include your name, email ID, the date, and the name of the file in a header comment at the beginning of each file you submit (including text files!)</li>
-<li>Write the xToN.cpp file, as described in the pre-lab section, and submit it through the submission system.</li>
-<li>Examine the Object life-cycle code (<a href="lifecycle.cpp.html">lifecycle.cpp</a> (<a href="lifecycle.cpp">src</a>)). You may not understand everything in this program by the beginning of lab, but you should by the end of next week. We will be using this program during the in-lab activity.</li>
-<li>The due date for this lab is listed on the <a href="../../uva/labduedates.html">lab due dates</a> page -- see the pre-lab section for more details about submission deadlines.</li>
+<li>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a></li>
+<li>Write a recursive function to compute exponentiation</li>
+<li>Investigate the C++ object lifecycle</li>
+<li>Learn about the submission system</li>
 <li>Files to download: <a href="lifecycle.cpp.html">lifecycle.cpp</a> (<a href="lifecycle.cpp">src</a>)</li>
 <li>Files to submit: xToN.cpp</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
 <ol type="1">
-<li>Read through the in-lab section of this document. You should be sure to be familiar with the submission system.</li>
-<li>Clone the github repo into your lab account</li>
-<li>Complete the in-lab requirements as described in the in-lab section, below.</li>
-<li>Did you understand the part on capitalization in the in-lab section of this document?</li>
+<li>Ask the TAs if you have any questions about the pre-lab code or Unix</li>
+<li>Separate the object lifecycle code to better follow C++ conventions</li>
+<li>Investigate an example program and ask questions about it</li>
 <li>Files to download: <a href="svtest.cpp.html">svtest.cpp</a> (<a href="svtest.cpp">src</a>), <a href="svutil.cpp.html">svutil.cpp</a> (<a href="svutil.cpp">src</a>), <a href="svutil.h.html">svutil.h</a> (<a href="svutil.h">src</a>), and <a href="lifecycle.cpp.html">lifecycle.cpp</a> (<a href="lifecycle.cpp">src</a>)</li>
 <li>Files to submit: lifecycle.questions.txt, vector.questions.txt, LifeCycle.cpp, LifeCycle.h, and TestLifeCycle.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
 <ol type="1">
-<li>See details in the postlab section, below</li>
-<li>For this lab you will be submitting your code electronically. Your submission is due on the Friday of the week of the lab; the exact due time is listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. Be sure to include your name, email ID, the date, and the name of the file in a header comment at the beginning of each file you submit (including text files!).</li>
+<li>Investigate a more complicated example program and ask questions about it</li>
 <li>Files to download: <a href="list.h.html">list.h</a> (<a href="list.h">src</a>), <a href="list.cpp.html">list.cpp</a> (<a href="list.cpp">src</a>)</li>
 <li>Files to submit: postlab1.question.txt</li>
 </ol>
-<h3 id="course-tools">Course Tools</h3>
-<p>Lab submission can be found through the Course Tools tab on Collab or directly at this link: <a href="https://libra.cs.virginia.edu/~pedagogy" class="uri">https://libra.cs.virginia.edu/~pedagogy</a></p>
 <hr />
 <h2 id="pre-lab-1">Pre-lab</h2>
 <p>Complete <a href="../../tutorials/01-intro-unix/index.html">Tutorial 1: Introduction to UNIX</a> before proceeding.</p>
@@ -84,19 +74,17 @@ int main () {
 <p>Lastly, take a look at the object life-cycle code (<a href="lifecycle.cpp.html">lifecycle.cpp</a> (<a href="lifecycle.cpp">src</a>)). Use it as a mechanism for understanding how various aspects of C++ work and try stepping through it by hand. Use the <a href="../../docs/readings.html">readings</a>, the web, and any other C++ references to help you look up parts of the program you do not understand.</p>
 <h3 id="assignment-submission">Assignment submission</h3>
 <p>All assignments will be submitted through our custom submission tool which can be accessed through Collab's Course Tools link or directly at <a href="https://libra.cs.virginia.edu/~pedagogy" class="uri">https://libra.cs.virginia.edu/~pedagogy</a>.</p>
-<p>Each assignment has 3 dates: an open date (when you can start submitting the assignment), a due date (when it's due), and a close date (the last point that you can submit the assignment). The dates are listed for the week of the lab -- the lab week starts on a Sunday and ends on a Saturday. In particular, the due date for the pre-labs, as well as the open date for the in-labs and post-labs is when the first lab section starts. The close date for the post-labs is the start of Friday's lecture (the first lecture, if there are multiple lecture periods).</p>
-<p>The various dates: open dates, due dates, and close dates, are listed on the <a href="../../uva/labduedates.html">lab due dates</a> page.</p>
-<p>Please note, however, that there are a number of rules that we will strictly follow:</p>
+<p>Every file submitted, including text files, should include your name, email ID, the date, and the name of the file in a header comment at the beginning of the file.</p>
+<p>There is no check to make sure you have submitted all of the correct files -- on the 'Procedure' page (always at the top of the lab document), we clearly state which files should be submitted for each lab part. For example, for this pre-lab, you should submit just the following file for pre-lab 1: xToN.cpp.</p>
+<p>Each assignment has 3 dates: an open date (when you can start submitting the assignment), a due date (when it's due), and a close date (the last point that you can submit the assignment). The dates are listed for the week of the lab -- the lab week starts on a Sunday and ends on a Saturday. In particular, the due date for the pre-labs, as well as the open date for the in-labs and post-labs is when the first lab section starts. The due date for the post-labs is the start of Friday's first lecture.</p>
+<p>More information on open dates, due dates, and close dates can be found on the <a href="../../uva/labduedates.html">lab due dates</a> page.</p>
+<p>There are a number of rules that we will strictly follow:</p>
 <ul>
 <li>Pre-labs are due at the same time for everybody, regardless of your lab section; that time is the beginning of the FIRST Tuesday lab.</li>
 <li>In-labs are due at the end of the day on Tuesday.</li>
 <li>Any late lab part will receive 25% off (for just that part) for the first 24 hours (or part thereof) that it is late, after which no credit will be given. Note that a computer program does this deduction -- so if your lab is 1 second late, it still receives 25% off.</li>
+<li><strong>No credit will be given for a lab component which does not compile.</strong> If you are having problems with your code, you should comment out parts so that it does compile -- you will receive more credit for a compilable program that has part of the code commented out than you would for a program that does not compile. See the <a href="../../docs/compilation.html">compilation</a> for hints as to how to get your code to compile.</li>
 </ul>
-<h3 id="submitting-your-files">Submitting your files</h3>
-<p>All assignments for this course will be submitted through the lab submission tool, which is accessible either via Collab or through the link in the Procedure section above. There is no check to make sure you have submitted all of the correct files -- on the 'Procedure' page (always at the top of the lab document), we clearly state which files should be submitted for each lab part. For example, for this pre-lab, you should submit just the following file for pre-lab 1: xToN.cpp.</p>
-<p>Every file (including text files!) should include your name, email ID, the date, and the name of the file in a header comment at the beginning of the file.</p>
-<p>Lastly, you should ensure that your program compiles before you submit it. This is an advanced programming class, and there is no reason why you should submit a program that does not compile. If you are having problems with your code, you should comment out parts so that it does compile -- you will receive more credit for a compilable program that has part of the code commented out than you would for a program that does not compile. See the <a href="../../docs/compilation.html">compilation</a> for hints as to how to get your code to compile.</p>
-<p>Just to be clear: <strong>you will receive zero credit for a lab component which does not compile.</strong></p>
 <h3 id="resubmitting-your-assignment">Resubmitting your assignment</h3>
 <p>If you submit your assignment, and you realize you made a mistake (didn't submit all the files, etc.), you can resubmit your assignment as many times as you want. The date of submission is the date you re-submitted your assignment -- so if you resubmit your assignment after the due date to add one more file, the <strong>ENTIRE</strong> assignment will have the late submission date. We only look at the most recent submission.</p>
 <p><strong><em>Note that you have to bring your computer to in-lab!</em></strong></p>
@@ -104,7 +92,6 @@ int main () {
 <h2 id="in-lab-1">In-lab</h2>
 <h3 id="general-in-lab-procedure">General In-lab Procedure</h3>
 <p>The purpose of the labs is to allow you to work through the lab activity, and if you encounter questions or problems, ask for TA assistance. Be sure to include your name, email ID, the date, and the name of the file in a banner comment at the beginning of each file you submit.</p>
-<p>All of the files required for this lab are listed above (in the Procedure section), and are also listed below.</p>
 <h3 id="understanding-c">Understanding C++</h3>
 <ol type="1">
 <li>Ask the TAs if you have questions about your <em>x^n</em> function.</li>
@@ -130,6 +117,8 @@ int main () {
 <li>Write at least one question about something in this program. This question might be about something that you don't understand completely. Write your questions in a file named vector.questions.txt.</li>
 </ul></li>
 </ol>
+<h3 id="capitalization">Capitalization</h3>
+<p>Under Windows, the case of a file name is ignored -- thus, lifecycle.cpp, LifeCycle.cpp, and LIFECYCLE.CPP all refer to the same file. However, it is <strong>NOT</strong> true for Linux, which is what we will use to test and grade your code. Thus, if your file is called 'LifeCycle.h', and you have (in your TestLifeCycle.cpp file) a line that states: <code>#include &quot;lifecycle.h&quot;</code>, then your program will NOT work under Linux (since case DOES matter with file names). Since your code does not compile, you will get zero credit. So make sure your file names match!</p>
 <h3 id="troubleshooting">Troubleshooting</h3>
 <p>Does your program not compile? Here are a few things to try -- these are problems that previous students have encountered.</p>
 <ul>
@@ -139,12 +128,9 @@ int main () {
 <li>Make sure that your subroutine names (whether they be function names or method names) are consistent between the .h files and the .cpp files</li>
 <li>Have a compiler error that you don't understand? We have the translation! See the <a href="../../docs/compilation.html">compilation</a> page, which lists common compiler error messages, what they mean, and how to solve them. If you don't see yours listed there, let us know, and we'll add it.</li>
 </ul>
-<h3 id="capitalization">Capitalization</h3>
-<p>Under Windows, the case of a file name is ignored -- thus, lifecycle.cpp, LifeCycle.cpp, and LIFECYCLE.CPP all refer to the same file. However, it is <strong>NOT</strong> true for Linux, which is what we will use to test and grade your code. Thus, if your file is called 'LifeCycle.h', and you have (in your TestLifeCycle.cpp file) a line that states: <code>#include &quot;lifecycle.h&quot;</code>, then your program will NOT work under Linux (since case DOES matter with file names). Since your code does not compile, you will get zero credit. So make sure your file names match!</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
 <p>Complete the exercise below, and submit the text file described there to the submission system.</p>
-<p>For this lab you will be submitting your assignment electronically. Your submission is on the Friday of the week of the lab; the exact time is listed on the <a href="../../uva/labduedates.html">lab due dates</a> page. Be sure to include your name, email ID, the date, and the name of the file in a banner comment at the beginning of each file you submit.</p>
 <h3 id="linked-list-template-code">Linked List Template code</h3>
 <p>Download the two linked list files (<a href="list.h.html">list.h</a> (<a href="list.h">src</a>) and <a href="list.cpp.html">list.cpp</a> (<a href="list.cpp">src</a>)). Compile and run the program. The compile command is <code>clang++ list.cpp</code>. If you try to compile the list.h file, it won't work correctly.</p>
 <p>Look at list.h, which is #include'd from list.cpp -- it contains the <strong>bodies</strong> of the methods, which is not the way that it is usually done (the bodies are typically in the .cpp file only). We normally only include in .h files just the declarations (i.e., prototypes) of classes, constants, function, etc., but not definitions of C++ methods (i.e. the bodies of the methods). However, when implementing template classes, this is something that is necessary to make the class compile successfully.</p>

--- a/labs/lab01/index.md
+++ b/labs/lab01/index.md
@@ -9,7 +9,7 @@ This is laboratory is intended to get you up to speed quickly with both C++ and 
 
 ### Background ###
 
-Every week we will have a lab meeting.  Each lab will consist of three parts: a pre-lab (to be completed by Tuesday at the due time listed on the [lab due dates](../../uva/labduedates.html) page, an in-lab (activity to be done during lab), and a post-lab.  The pre-lab will typically also include a tutorial.  Parts of all three of these may be required to turned in.  The due dates are all listed on the [lab due dates](../../uva/labduedates.html) page. This will all be discussed in this lab.
+There will be a lab every week, which consists of three parts: a pre-lab, an in-lab, and a post-lab.  The due dates are all listed on the [lab due dates](../../uva/labduedates.html) page. This will all be discussed in this lab.
 
 ### Reading(s) ###
 
@@ -20,33 +20,24 @@ Procedure
 ---------
 
 ### Pre-lab ###
-1. If desired, the alternative readings are available on the [Readings page](../../docs/readings.html)
-2. Complete [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html)
-    a. As part of this tutorial, you will need to decide how you want to develop in a Unix environment -- we recommend [VirtualBox](../../tutorials/01-intro-unix/virtual-box.html), but there are other options available
-    b. If you are using VirtualBox, you will have to decide on which display manager to use
-3. Be sure to include your name, email ID, the date, and the name of the file in a header comment at the beginning of each file you submit (including text files!)
-4. Write the xToN.cpp file, as described in the pre-lab section, and submit it through the submission system.
-5. Examine the Object life-cycle code ([lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))).  You may not understand everything in this program by the beginning of lab, but you should by the end of next week.  We will be using this program during the in-lab activity.
-6. The due date for this lab is listed on the [lab due dates](../../uva/labduedates.html) page -- see the pre-lab section for more details about submission deadlines.
-7. Files to download: [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
-8. Files to submit: xToN.cpp
+1. Complete [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html)
+2. Write a recursive function to compute exponentiation
+3. Investigate the C++ object lifecycle
+4. Learn about the submission system
+5. Files to download: [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
+6. Files to submit: xToN.cpp
 
 ### In-lab ###
-1. Read through the in-lab section of this document.  You should be sure to be familiar with the submission system.
-2. Clone the github repo into your lab account
-3. Complete the in-lab requirements as described in the in-lab section, below.
-5. Did you understand the part on capitalization in the in-lab section of this document?
-6. Files to download: [svtest.cpp](svtest.cpp.html) ([src](svtest.cpp)), [svutil.cpp](svutil.cpp.html) ([src](svutil.cpp)), [svutil.h](svutil.h.html) ([src](svutil.h)), and [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
-7. Files to submit: lifecycle.questions.txt, vector.questions.txt, LifeCycle.cpp, LifeCycle.h, and TestLifeCycle.cpp
+1. Ask the TAs if you have any questions about the pre-lab code or Unix
+2. Separate the object lifecycle code to better follow C++ conventions
+3. Investigate an example program and ask questions about it
+4. Files to download: [svtest.cpp](svtest.cpp.html) ([src](svtest.cpp)), [svutil.cpp](svutil.cpp.html) ([src](svutil.cpp)), [svutil.h](svutil.h.html) ([src](svutil.h)), and [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
+5. Files to submit: lifecycle.questions.txt, vector.questions.txt, LifeCycle.cpp, LifeCycle.h, and TestLifeCycle.cpp
 
 ### Post-lab ###
-1. See details in the postlab section, below
-2. For this lab you will be submitting your code electronically. Your submission is due on the Friday of the week of the lab; the exact due time is listed on the [lab due dates](../../uva/labduedates.html) page.  Be sure to include your name, email ID, the date, and the name of the file in a header comment at the beginning of each file you submit (including text files!).
-3. Files to download: [list.h](list.h.html) ([src](list.h)), [list.cpp](list.cpp.html) ([src](list.cpp))
-4. Files to submit: postlab1.question.txt
-
-### Course Tools ###
-Lab submission can be found through the Course Tools tab on Collab or directly at this link: [https://libra.cs.virginia.edu/~pedagogy](https://libra.cs.virginia.edu/~pedagogy)
+1. Investigate a more complicated example program and ask questions about it
+2. Files to download: [list.h](list.h.html) ([src](list.h)), [list.cpp](list.cpp.html) ([src](list.cpp))
+3. Files to submit: postlab1.question.txt
 
 ------------------------------------------------------------
 
@@ -89,25 +80,20 @@ Lastly, take a look at the object life-cycle code ([lifecycle.cpp](lifecycle.cpp
 
 All assignments will be submitted through our custom submission tool which can be accessed through Collab's Course Tools link or directly at [https://libra.cs.virginia.edu/~pedagogy](https://libra.cs.virginia.edu/~pedagogy).
 
-Each assignment has 3 dates: an open date (when you can start submitting the assignment), a due date (when it's due), and a close date (the last point that you can submit the assignment).  The dates are listed for the week of the lab -- the lab week starts on a Sunday and ends on a Saturday.  In particular, the due date for the pre-labs, as well as the open date for the in-labs and post-labs is when the first lab section starts.  The close date for the post-labs is the start of Friday's lecture (the first lecture, if there are multiple lecture periods).
+Every file submitted, including text files, should include your name, email ID, the date, and the name of the file in a header comment at the beginning of the file.
 
-The various dates: open dates, due dates, and close dates, are listed on the [lab due dates](../../uva/labduedates.html) page.
+There is no check to make sure you have submitted all of the correct files -- on the 'Procedure' page (always at the top of the lab document), we clearly state which files should be submitted for each lab part.  For example, for this pre-lab, you should submit just the following file for pre-lab 1: xToN.cpp.
 
-Please note, however, that there are a number of rules that we will strictly follow:
+Each assignment has 3 dates: an open date (when you can start submitting the assignment), a due date (when it's due), and a close date (the last point that you can submit the assignment).  The dates are listed for the week of the lab -- the lab week starts on a Sunday and ends on a Saturday.  In particular, the due date for the pre-labs, as well as the open date for the in-labs and post-labs is when the first lab section starts.  The due date for the post-labs is the start of Friday's first lecture.
+
+More information on open dates, due dates, and close dates can be found on the [lab due dates](../../uva/labduedates.html) page.
+
+There are a number of rules that we will strictly follow:
 
 - Pre-labs are due at the same time for everybody, regardless of your lab section; that time is the beginning of the FIRST Tuesday lab.
 - In-labs are due at the end of the day on Tuesday.
 - Any late lab part will receive 25% off (for just that part) for the first 24 hours (or part thereof) that it is late, after which no credit will be given.  Note that a computer program does this deduction -- so if your lab is 1 second late, it still receives 25% off.
-
-### Submitting your files ###
-
-All assignments for this course will be submitted through the lab submission tool, which is accessible either via Collab or through the link in the Procedure section above.  There is no check to make sure you have submitted all of the correct files -- on the 'Procedure' page (always at the top of the lab document), we clearly state which files should be submitted for each lab part.  For example, for this pre-lab, you should submit just the following file for pre-lab 1: xToN.cpp.
-
-Every file (including text files!) should include your name, email ID, the date, and the name of the file in a header comment at the beginning of the file.
-
-Lastly, you should ensure that your program compiles before you submit it.  This is an advanced programming class, and there is no reason why you should submit a program that does not compile.  If you are having problems with your code, you should comment out parts so that it does compile -- you will receive more credit for a compilable program that has part of the code commented out than you would for a program that does not compile.  See the [compilation](../../docs/compilation.html) for hints as to how to get your code to compile.
-
-Just to be clear: **you will receive zero credit for a lab component which does not compile.**
+- **No credit will be given for a lab component which does not compile.**  If you are having problems with your code, you should comment out parts so that it does compile -- you will receive more credit for a compilable program that has part of the code commented out than you would for a program that does not compile.  See the [compilation](../../docs/compilation.html) for hints as to how to get your code to compile.
 
 ### Resubmitting your assignment ###
 
@@ -123,8 +109,6 @@ In-lab
 ### General In-lab Procedure ###
 
 The purpose of the labs is to allow you to work through the lab activity, and if you encounter questions or problems, ask for TA assistance.  Be sure to include your name, email ID, the date, and the name of the file in a banner comment at the beginning of each file you submit.
-
-All of the files required for this lab are listed above (in the Procedure section), and are also listed below.
 
 ### Understanding C++ ###
 
@@ -145,6 +129,10 @@ All of the files required for this lab are listed above (in the Procedure sectio
      - Now undo what you did in the previous step, but now comment out the `using namespace std;` in svutil.h, and rebuild the program. Was there an error?  What objects are now undeclared and why?
      - Write at least one question about something in this program.  This question might be about something that you don't understand completely. Write your questions in a file named vector.questions.txt.
 
+### Capitalization ###
+
+Under Windows, the case of a file name is ignored -- thus, lifecycle.cpp, LifeCycle.cpp, and LIFECYCLE.CPP all refer to the same file.  However, it is **NOT** true for Linux, which is what we will use to test and grade your code.  Thus, if your file is called 'LifeCycle.h', and you have (in your TestLifeCycle.cpp file) a line that states: `#include "lifecycle.h"`, then your program will NOT work under Linux (since case DOES matter with file names).  Since your code does not compile, you will get zero credit.  So make sure your file names match!
+
 ### Troubleshooting ###
 
 Does your program not compile?  Here are a few things to try -- these are problems that previous students have encountered.
@@ -155,18 +143,12 @@ Does your program not compile?  Here are a few things to try -- these are proble
 - Make sure that your subroutine names (whether they be function names or method names) are consistent between the .h files and the .cpp files
 - Have a compiler error that you don't understand?  We have the translation!  See the [compilation](../../docs/compilation.html) page, which lists common compiler error messages, what they mean, and how to solve them.  If you don't see yours listed there, let us know, and we'll add it.
 
-### Capitalization ###
-
-Under Windows, the case of a file name is ignored -- thus, lifecycle.cpp, LifeCycle.cpp, and LIFECYCLE.CPP all refer to the same file.  However, it is **NOT** true for Linux, which is what we will use to test and grade your code.  Thus, if your file is called 'LifeCycle.h', and you have (in your TestLifeCycle.cpp file) a line that states: `#include "lifecycle.h"`, then your program will NOT work under Linux (since case DOES matter with file names).  Since your code does not compile, you will get zero credit.  So make sure your file names match!
-
 ------------------------------------------------------------
 
 Post-lab
 --------
 
 Complete the exercise below, and submit the text file described there to the submission system.
-
-For this lab you will be submitting your assignment electronically.  Your submission is on the Friday of the week of the lab; the exact time is listed on the [lab due dates](../../uva/labduedates.html) page.  Be sure to include your name, email ID, the date, and the name of the file in a banner comment at the beginning of each file you submit.
 
 ### Linked List Template code ###
 

--- a/labs/lab01/index.md
+++ b/labs/lab01/index.md
@@ -11,23 +11,35 @@ This is laboratory is intended to get you up to speed quickly with both C++ and 
 
 There will be a lab every week, which consists of three parts: a pre-lab, an in-lab, and a post-lab.  The due dates are all listed on the [lab due dates](../../uva/labduedates.html) page. This will all be discussed in this lab.
 
-### Reading(s) ###
+### Tutorial ###
 
-1. [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html)
-2. Optional: online sources as posted on the [Readings page](../../docs/readings.html)
+Most labs will have a tutorial.
+You are expected to complete this tutorial before beginning the lab,
+as the lab will use concepts from each tutorial.
+
+The tutorial for this lab is [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html),
+which will help you set up your UNIX environment.
+
+### Recommended Readings ###
+
+We have attempted to compile a collection of readings that go over topics covered in this course.
+Readings are always optional and are there for you to use as you see fit.
+
+- Introduction to C++ section on the [Readings page](../../docs/readings.html)
 
 Procedure
 ---------
 
 ### Pre-lab ###
-1. Complete [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html)
-2. Write a recursive function to compute exponentiation
-3. Investigate the C++ object lifecycle
-4. Learn about the submission system
-5. Files to download: [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
-6. Files to submit: xToN.cpp
+
+1. Write a recursive function to compute exponentiation
+2. Investigate the C++ object lifecycle
+3. Learn about the submission system
+4. Files to download: [lifecycle.cpp](lifecycle.cpp.html) ([src](lifecycle.cpp))
+5. Files to submit: xToN.cpp
 
 ### In-lab ###
+
 1. Ask the TAs if you have any questions about the pre-lab code or Unix
 2. Separate the object lifecycle code to better follow C++ conventions
 3. Investigate an example program and ask questions about it
@@ -35,6 +47,7 @@ Procedure
 5. Files to submit: lifecycle.questions.txt, vector.questions.txt, LifeCycle.cpp, LifeCycle.h, and TestLifeCycle.cpp
 
 ### Post-lab ###
+
 1. Investigate a more complicated example program and ask questions about it
 2. Files to download: [list.h](list.h.html) ([src](list.h)), [list.cpp](list.cpp.html) ([src](list.cpp))
 3. Files to submit: postlab1.question.txt
@@ -45,6 +58,7 @@ Pre-lab
 -------
 
 Complete [Tutorial 1: Introduction to UNIX](../../tutorials/01-intro-unix/index.html) before proceeding.
+Remember that you should always complete the tutorial before starting the lab.
 
 For the pre-lab, you will need to write a **recursive** function called `xton()` to compute *x^n* for non-negative integers *n*.  Assume that *x^0=1*.  Put this function in a program with a `main()` function.  Your program should prompt the user for two integer values, and raise the first to the power of the second by calling your `xton()` function.  To keep the code simple, you can assume that your program will only be called with valid inputs.
 

--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -18,30 +18,26 @@
 <p>This laboratory introduces you to some advanced class development in C++, creating and using iterators, manipulating pointers, and linked data structures. It also addresses some issues involving testing and software development.</p>
 <h3 id="background">Background</h3>
 <p>The linked list is a basic data structure from which one can implement stacks, queues, sets, and many other data structures. Lists may be singly- or doubly-linked. In this lab we will implement a doubly-linked list.</p>
-<h3 id="readings">Reading(s)</h3>
-<ol type="1">
-<li>Readings on <a href="../../docs/readings.html">Readings</a> page.</li>
-<li><a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> <strong><em>OR</em></strong> <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a>; see below as to which one to choose.</li>
-<li>For the in-lab, some articles on debugging</li>
-</ol>
-<h3 id="debugger-choice">Debugger Choice</h3>
-<p>In this lab, you will have to make a choice as to which debugger to use; this will affect which tutorial you carry out. You can choose the lldb debugger (you would then complete <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a>) or the gdb debugger (you would then complete <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a>). The source code provided for each tutorial is exactly the same, and the deliverable (i.e., what you turn in) is likewise the exact same.</p>
-<p>The lldb debugger is preferred as it was built with the <code>clang++</code> compiler that we are using; however, the gdb tutorial is offered if lldb doesn't work for you.</p>
+<h3 id="tutorial">Tutorial</h3>
+<p>In this lab, you will have to make a choice as to which debugger to use; this will affect which tutorial you carry out. You can choose the LLDB debugger (you would then complete <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a>) or the GDB debugger (you would then complete <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a>). The source code provided for each tutorial is exactly the same, and the deliverable (i.e., what you turn in) is likewise the exact same.</p>
+<p>The LLDB debugger is preferred as it was built with the <code>clang++</code> compiler that we are using; however, the GDB tutorial is offered if LLDB doesn't work for you.</p>
 <p>Just remember which one you choose, as you will end up using that debugger throughout this course. And if you ever have to switch between them, you can use our <a href="../../docs/gdb_vs_lldb.html">GDB vs LLDB</a> page to see the (relatively few) commands that are different between the two.</p>
-<p>Ultimately, this is a low stress choice. Choose lldb, and only switch over to gdb if you run into issues.</p>
+<p>Ultimately, this is a low stress choice. Choose LLDB, and only switch over to GDB if you run into issues.</p>
+<h3 id="recommend-readings">Recommend Readings</h3>
+<ul>
+<li>Pointers and Linked Lists sections on the <a href="../../docs/readings.html">Readings</a> page</li>
+<li>The <a href="http://umich.edu/~eecs381/generalFAQ/Debugging.html">Debugging FAQ from UMich</a></li>
+</ul>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Consider one of the online alternative readings shown on the <a href="../../docs/readings.html">Readings</a> page</li>
 <li>Make significant progress on implementing a doubly-linked linked list</li>
 <li>Files to download: <a href="List.h.html">List.h</a> (<a href="List.h">src</a>), <a href="ListNode.h.html">ListNode.h</a> (<a href="ListNode.h">src</a>), <a href="ListItr.h.html">ListItr.h</a> (<a href="ListItr.h">src</a>), <a href="ListTest.cpp.html">ListTest.cpp</a> (<a href="ListTest.cpp">src</a>)</li>
 <li>Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
 <ol type="1">
-<li>Ensure you are familiar with debugging. You should look over the <a href="http://umich.edu/~eecs381/generalFAQ/Debugging.html">Debugging FAQ from UMich</a>, which is a good introduction</li>
-<li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers</li>
-<li>Use the debugger to find and correct the errors in debug.cpp in the debugger tutorial</li>
+<li>Use the debugger to find and correct the errors in debug.cpp in part II of the debugger tutorial</li>
 <li>Continue to work on your List and debug any issues with the debugger as necessary</li>
 <li>Files to download: <a href="../../tutorials/02-lldb/prog1.cpp.html">prog1.cpp</a> (<a href="../../tutorials/02-lldb/prog1.cpp">src</a>), <a href="../../tutorials/02-lldb/debug.cpp.html">debug.cpp</a> (<a href="../../tutorials/02-lldb/debug.cpp">src</a>)</li>
 <li>Files to submit: debug.cpp</li>
@@ -69,7 +65,7 @@
 <figure>
 <img src="list-diagram.png" alt="UML diagram" /><figcaption>UML diagram</figcaption>
 </figure>
-<p>This diagram shows a list containing two elements, the integers 3 and 7. Note that there are more methods in the List and ListItr classes than what is shown above. The head and tail pointers in the List class point to dummy nodes -- they are put there to make inserting elements into the list easier. It doesn't matter what the value of the dummy notes is set to, as it won't be used. Each ListNode points to the nodes before and after it (although the dummy nodes each have one pointer pointing to NULL).</p>
+<p>This diagram shows a list containing two elements, the integers 3 and 7. Note that there are more methods in the List and ListItr classes than what is shown above. The head and tail pointers in the List class point to dummy nodes -- they are put there to make inserting elements into the list easier. It doesn't matter what the value of the dummy nodes is set to, as it won't be used. Each ListNode points to the nodes before and after it (although the dummy nodes each have one pointer pointing to NULL).</p>
 <p>Thus, our doubly linked list will have only one List object and many ListNode objects (2 more than the number of elements in the list). A ListItr is a separate object, which points to one element in the list (possibly a dummy node). As you call the various methods in ListItr to move the iterator forward and backward, the node that it points to will change.</p>
 <h3 id="listnode">ListNode</h3>
 <p>A ListNode contains an integer value, as well as next and previous pointers to other ListNodes. View the <a href="ListNode.h.html">ListNode.h</a> (<a href="ListNode.h">src</a>) code for details.</p>
@@ -172,9 +168,8 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)<
 </ul>
 <hr />
 <h2 id="in-lab-1">In-lab</h2>
-<p>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</p>
-<p>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</p>
-<p>Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp. Remember the standard identifying header information.</p>
+<p>Complete Part II of the tutorial for this lab and submit your debugged version of debug.cpp; we are not submitting prog1.cpp. Remember the standard identifying header information.</p>
+<p>Going forward, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</p>
 <p>Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about. If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation. Consult with a TA if you have questions.</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>

--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -14,11 +14,11 @@
 <body>
 <h1 id="pdr-laboratory-2-linked-lists">PDR: Laboratory 2: Linked Lists</h1>
 <p><a href="../index.html">Go up to the Labs table of contents page</a></p>
-<h3 id="objective">Objective:</h3>
+<h3 id="objective">Objective</h3>
 <p>This laboratory introduces you to some advanced class development in C++, creating and using iterators, manipulating pointers, and linked data structures. It also addresses some issues involving testing and software development.</p>
-<h3 id="background">Background:</h3>
+<h3 id="background">Background</h3>
 <p>The linked list is a basic data structure from which one can implement stacks, queues, sets, and many other data structures. Lists may be singly- or doubly-linked. In this lab we will implement a doubly-linked list.</p>
-<h3 id="readings">Reading(s):</h3>
+<h3 id="readings">Reading(s)</h3>
 <ol type="1">
 <li>Readings on <a href="../../docs/readings.html">Readings</a> page.</li>
 <li><a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> <strong><em>OR</em></strong> <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a>; see below as to which one to choose.</li>
@@ -32,42 +32,23 @@
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Consider one of the online alternative readings shown on the <a href="../../docs/readings.html">Readings</a> page.</li>
-<li>Implement the three classes as described below: ListNode, TestListNode, and ListItr. You should have most, if not all, of the code working <strong><em>before</em></strong> coming to lab. TAs will be available to help in lab if you still have questions. Note that it is okay to not have the code perfectly working prior to lab -- for the pre-lab grade, we are going to be looking to see if you have made significant progress, not that it is fully working (that's the post-lab).</li>
-<li>If there is a particular method that is causing you a lot of trouble (i.e. you can't get it working), don't spend inordinate amounts of time on it -- move on, and come back to that one during the in-lab.</li>
-<li><strong>Making the implementation phase less frustrating:</strong> develop in small chunks, then <strong>test/debug incrementally. It is much easier to debug this way!</strong> (And also less frustrating and confusing.) Here is a sample process for implementing ListNode.cpp:
-<ol type="1">
-<li>Implement the ListNode constructor in ListNode.cpp</li>
-<li>Write a short test harness, TestListNode.cpp, which has a main(). The body of main should test the ListNode constructor. In other words, create some ListNodes in main() using the constructor.</li>
-<li>Build and run the test program you just wrote to see if it produces the results you expect. Some items you will want to check are the initialization of the next and previous pointers and the initial value of value</li>
-<li>Use this same general process for List and for ListItr. For List and ListItr, implement the member functions one at a time and test. To do this, you will still need to provide &quot;dummy&quot; versions of the other member functions in your .cpp file as placeholders so that the code will build. <strong>You will need to create a list of test cases to use to test your classes.</strong> The TAs may ask you to test more cases during lab.</li>
-</ol></li>
-<li>Read through the remainder of this document before coming to lab. Also read the tutorial on Unix debugging, as we will be using that during the in-lab.</li>
-<li>Make sure you submit all 7 files listed below! Your code will not compile unless all 7 files are submitted. Also, if your code does not compile, and you cannot figure out why, comment out the erroneous code until it does compile. And make sure you have the right file name capitalization!</li>
+<li>Consider one of the online alternative readings shown on the <a href="../../docs/readings.html">Readings</a> page</li>
+<li>Make significant progress on implementing a doubly-linked linked list</li>
 <li>Files to download: <a href="List.h.html">List.h</a> (<a href="List.h">src</a>), <a href="ListNode.h.html">ListNode.h</a> (<a href="ListNode.h">src</a>), <a href="ListItr.h.html">ListItr.h</a> (<a href="ListItr.h">src</a>), <a href="ListTest.cpp.html">ListTest.cpp</a> (<a href="ListTest.cpp">src</a>)</li>
 <li>Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
 <ol type="1">
-<li>Ensure you are familiar with debugging. You should look over the <a href="http://umich.edu/~eecs381/generalFAQ/Debugging.html">Debugging FAQ from UMich</a>, which is a good introduction.</li>
-<li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</li>
-<li>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</li>
-<li>Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp. Remember the standard identifying header information.</li>
-<li>Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about. If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation. You should do this by using the simple test cases that you used in the pre-lab. Consult with a TA if you have questions.</li>
+<li>Ensure you are familiar with debugging. You should look over the <a href="http://umich.edu/~eecs381/generalFAQ/Debugging.html">Debugging FAQ from UMich</a>, which is a good introduction</li>
+<li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers</li>
+<li>Use the debugger to find and correct the errors in debug.cpp in the debugger tutorial</li>
+<li>Continue to work on your List and debug any issues with the debugger as necessary</li>
 <li>Files to download: <a href="../../tutorials/02-lldb/prog1.cpp.html">prog1.cpp</a> (<a href="../../tutorials/02-lldb/prog1.cpp">src</a>), <a href="../../tutorials/02-lldb/debug.cpp.html">debug.cpp</a> (<a href="../../tutorials/02-lldb/debug.cpp">src</a>)</li>
 <li>Files to submit: debug.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
 <ol type="1">
-<li>For this lab you will be submitting your code electronically via online grading system to postlab2. Your fully functional code must contain the following 7 files:
-<ol type="1">
-<li>List.h and List.cpp</li>
-<li>ListNode.h and ListNode.cpp</li>
-<li>ListItr.h and ListItr.cpp</li>
-<li>and the test harness, ListTest.cpp</li>
-</ol></li>
-<li><em>Be sure you submit all 7 files!</em> If you don't, then your code will not compile properly, and you will lose points!</li>
-<li>It is due on the Friday of the week of the lab, at the time listed on the <a href="../../uva/labduedates.html">Lab due dates page</a>. Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit.</li>
+<li>Finish the implementation of your List and ensure it is free of any memory errors</li>
 <li>Files to download: no additional files beyond the pre-lab and in-lab</li>
 <li>Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp</li>
 </ol>
@@ -82,10 +63,7 @@
 <li>List</li>
 <li>ListItr</li>
 </ul>
-<p>For simplicity we will just create a list that holds integers (your code could easily later be templated (i.e. made generic) to allow it to contain objects of other types). <strong><em>You must use the method names listed below in your code.</em></strong></p>
-<p>Below are the class definitions for each, which should be kept in header files with the respective file names.</p>
-<h3 id="test-harness">Test Harness</h3>
-<p>We have provided a test harness for testing your whole implementation: <a href="ListTest.cpp.html">ListTest.cpp</a> (<a href="ListTest.cpp">src</a>) <strong><em>The classes you implement must work with this test harness.</em></strong></p>
+<p>For simplicity we will just create a list that holds integers (your code could easily later be templated (i.e. made generic) to allow it to contain objects of other types). You must not modify any of the provided declarations in the header files, though you may add onto the header files as you see fit.</p>
 <h3 id="uml-diagram">UML Diagram</h3>
 <p>Below is a UML diagram showing how these classes interact with each other.</p>
 <figure>
@@ -98,11 +76,13 @@
 <h3 id="list">List</h3>
 <p>This class represents the list data structure containing ListNodes. It has a pointer to the first (head) and last (tail) ListNodes of the list, as well as a count of the number of ListNodes in the List. View the <a href="List.h.html">List.h</a> (<a href="List.h">src</a>) code for details.</p>
 <h3 id="listitr">ListItr</h3>
-<p>Your ListItr should maintain a pointer to a current position in a List. Your iterator class should look like the class definition in the source code. See the <a href="ListItr.h.html">ListItr.h</a> (<a href="ListItr.h">src</a>) code for details.</p>
+<p>A ListItr maintains a pointer to a current position in a List to allow for easy traversal through the List. View the <a href="ListItr.h.html">ListItr.h</a> (<a href="ListItr.h">src</a>) code for details.</p>
+<h3 id="test-harness">Test Harness</h3>
+<p>We have provided a test harness for testing your whole implementation: <a href="ListTest.cpp.html">ListTest.cpp</a> (<a href="ListTest.cpp">src</a>) <strong><em>Your List must work with this test harness.</em></strong></p>
 <h3 id="hints">Hints</h3>
 <p>There are a few things that always cause students some headache. We've tried to explain some of them here, in an effort to lessen the frustration it causes.</p>
 <h4 id="getting-started">Getting started</h4>
-<p>To start, create all three .cpp files (List.cpp, ListNode.cpp, ListItr.cpp) and include the relevant .h files. Fill the files with empty method bodies (with a dummy return value for non-<code>void</code> methods) and get that to compile. Then start implementing one method at a time, testing as you go.</p>
+<p>To start, create all three .cpp files (List.cpp, ListNode.cpp, ListItr.cpp) and include the relevant .h files. Fill the files with empty method bodies (with a dummy return value for non-<code>void</code> methods) and get that to compile. Then start implementing <em>one method at a time, testing as you go</em>.</p>
 <p>Here is the minimum amount of functions you need to have implemented in order to start using the ListTest harness, as well as suggested implementation order:</p>
 <ol type="1">
 <li>All of ListNode (so...the constructor)</li>
@@ -192,15 +172,10 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)<
 </ul>
 <hr />
 <h2 id="in-lab-1">In-lab</h2>
-<p>These are the same steps from the lab procedure section, above.</p>
-<ol type="1">
-<li>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</li>
-<li>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</li>
-<li>Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp. Remember the standard identifying header information.</li>
-<li>Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about. If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation. You should do this by using the simple test cases that you used in the pre-lab. Consult with a TA if you have questions.</li>
-<li>Files to download: <a href="../../tutorials/02-lldb/prog1.cpp.html">prog1.cpp</a> (<a href="../../tutorials/02-lldb/prog1.cpp">src</a>), <a href="../../tutorials/02-lldb/debug.cpp.html">debug.cpp</a> (<a href="../../tutorials/02-lldb/debug.cpp">src</a>)</li>
-<li>Files to submit: debug.cpp</li>
-</ol>
+<p>Carry out <a href="../../tutorials/02-lldb/index.html">Tutorial 2: LLDB</a> OR <a href="../../tutorials/02-gdb/index.html">Tutorial 2: GDB</a> on how to use Unix debuggers. The debugger is an important tool that you will use extensively throughout the semester to debug your code. You will need to download the prog1.cpp and debug.cpp files for the tutorial.</p>
+<p>In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this. So make sure you understand the tutorial!</p>
+<p>Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp. Remember the standard identifying header information.</p>
+<p>Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about. If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation. Consult with a TA if you have questions.</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
 <p>For the post-lab, your goal is to submit a fully-functional version of your doubly-linked list. Finish any methods that you haven't completed yet, and then move on to checking for memory errors.</p>

--- a/labs/lab02/index.md
+++ b/labs/lab02/index.md
@@ -3,15 +3,15 @@ PDR: Laboratory 2: Linked Lists
 
 [Go up to the Labs table of contents page](../index.html)
 
-### Objective: ###
+### Objective ###
 
 This laboratory introduces you to some advanced class development in C++, creating and using iterators, manipulating pointers, and linked data structures.  It also addresses some issues involving testing and software development.
 
-### Background: ###
+### Background ###
 
 The linked list is a basic data structure from which one can implement stacks, queues, sets, and many other data structures.  Lists may be singly- or doubly-linked.  In this lab we will implement a doubly-linked list.
 
-### Reading(s): ###
+### Reading(s) ###
 
 1. Readings on [Readings](../../docs/readings.html) page.
 2. [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) ***OR*** [Tutorial 2: GDB](../../tutorials/02-gdb/index.html); see below as to which one to choose.
@@ -32,40 +32,25 @@ Procedure
 
 ### Pre-lab ###
 
-1. Consider one of the online alternative readings shown on the [Readings](../../docs/readings.html) page.
-2. Implement the three classes as described below: ListNode, TestListNode, and ListItr.  You should have most, if not all, of the code working ***before*** coming to lab.  TAs will be available to help in lab if you still have questions.  Note that it is okay to not have the code perfectly working prior to lab -- for the pre-lab grade, we are going to be looking to see if you have made significant progress, not that it is fully working (that's the post-lab).
-3. If there is a particular method that is causing you a lot of trouble (i.e. you can't get it working), don't spend inordinate amounts of time on it -- move on, and come back to that one during the in-lab.
-4. **Making the implementation phase less frustrating:** develop in small chunks, then **test/debug incrementally.  It is much easier to debug this way!** (And also less frustrating and confusing.) Here is a sample process for implementing ListNode.cpp:
-    1. Implement the ListNode constructor in ListNode.cpp
-    2. Write a short test harness, TestListNode.cpp, which has a main().  The body of main should test the ListNode constructor. In other words, create some ListNodes in main() using the constructor.
-    3. Build and run the test program you just wrote to see if it produces the results you expect.  Some items you will want to check are the initialization of the next and previous pointers and the initial value of value
-    4. Use this same general process for List and for ListItr.  For List and ListItr, implement the member functions one at a time and test.  To do this, you will still need to provide "dummy" versions of the other member functions in your .cpp file as placeholders so that the code will build.  **You will need to create a list of test cases to use to test your classes.** The TAs may ask you to test more cases during lab.
-5. Read through the remainder of this document before coming to lab.  Also read the tutorial on Unix debugging, as we will be using that during the in-lab.
-6. Make sure you submit all 7 files listed below!  Your code will not compile unless all 7 files are submitted.  Also, if your code does not compile, and you cannot figure out why, comment out the erroneous code until it does compile.  And make sure you have the right file name capitalization!
-7. Files to download: [List.h](List.h.html) ([src](List.h)), [ListNode.h](ListNode.h.html) ([src](ListNode.h)), [ListItr.h](ListItr.h.html) ([src](ListItr.h)), [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp))
-8. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
+1. Consider one of the online alternative readings shown on the [Readings](../../docs/readings.html) page
+2. Make significant progress on implementing a doubly-linked linked list
+3. Files to download: [List.h](List.h.html) ([src](List.h)), [ListNode.h](ListNode.h.html) ([src](ListNode.h)), [ListItr.h](ListItr.h.html) ([src](ListItr.h)), [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp))
+4. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
 
 ### In-lab ###
 
-1. Ensure you are familiar with debugging.  You should look over the [Debugging FAQ from UMich](http://umich.edu/~eecs381/generalFAQ/Debugging.html), which is a good introduction.
-2. Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers.  The debugger is an important tool that you will use extensively throughout the semester to debug your code.  You will need to download the prog1.cpp and debug.cpp files for the tutorial.
-3. In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this.  So make sure you understand the tutorial!
-4. Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp.  Remember the standard identifying header information.
-5. Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about.  If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation.  You should do this by using the simple test cases that you used in the pre-lab.  Consult with a TA if you have questions.
-6. Files to download: [prog1.cpp](../../tutorials/02-lldb/prog1.cpp.html) ([src](../../tutorials/02-lldb/prog1.cpp)), [debug.cpp](../../tutorials/02-lldb/debug.cpp.html) ([src](../../tutorials/02-lldb/debug.cpp))
-7. Files to submit: debug.cpp
+1. Ensure you are familiar with debugging.  You should look over the [Debugging FAQ from UMich](http://umich.edu/~eecs381/generalFAQ/Debugging.html), which is a good introduction
+2. Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers
+3. Use the debugger to find and correct the errors in debug.cpp in the debugger tutorial
+4. Continue to work on your List and debug any issues with the debugger as necessary
+5. Files to download: [prog1.cpp](../../tutorials/02-lldb/prog1.cpp.html) ([src](../../tutorials/02-lldb/prog1.cpp)), [debug.cpp](../../tutorials/02-lldb/debug.cpp.html) ([src](../../tutorials/02-lldb/debug.cpp))
+6. Files to submit: debug.cpp
 
 ### Post-lab ###
 
-1. For this lab you will be submitting your code electronically via online grading system to postlab2.  Your fully functional code must contain the following 7 files:
-    1. List.h and List.cpp
-    2. ListNode.h and ListNode.cpp
-    3. ListItr.h and ListItr.cpp
-    4. and the test harness, ListTest.cpp
-2. *Be sure you submit all 7 files!* If you don't, then your code will not compile properly, and you will lose points!
-3. It is due on the Friday of the week of the lab, at the time listed on the [Lab due dates page](../../uva/labduedates.html).  Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit.
-4. Files to download: no additional files beyond the pre-lab and in-lab
-5. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
+1. Finish the implementation of your List and ensure it is free of any memory errors
+2. Files to download: no additional files beyond the pre-lab and in-lab
+3. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
 
 ------------------------------------------------------------
 
@@ -84,13 +69,7 @@ For this lab you will need to implement three classes:
 - List
 - ListItr
 
-For simplicity we will just create a list that holds integers (your code could easily later be templated (i.e. made generic) to allow it to contain objects of other types).  ***You must use the method names listed below in your code.***
-
-Below are the class definitions for each, which should be kept in header files with the respective file names.
-
-### Test Harness ###
-
-We have provided a test harness for testing your whole implementation: [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp)) ***The classes you implement must work with this test harness.***
+For simplicity we will just create a list that holds integers (your code could easily later be templated (i.e. made generic) to allow it to contain objects of other types).  You must not modify any of the provided declarations in the header files, though you may add onto the header files as you see fit.
 
 ### UML Diagram ###
 
@@ -112,16 +91,23 @@ This class represents the list data structure containing ListNodes.  It has a po
 
 ### ListItr ###
 
-Your ListItr should maintain a pointer to a current position in a List.  Your iterator class should look like the class definition in the source code.  See the [ListItr.h](ListItr.h.html) ([src](ListItr.h)) code for details.
+A ListItr maintains a pointer to a current position in a List to allow for easy traversal through the List.  View the [ListItr.h](ListItr.h.html) ([src](ListItr.h)) code for details.
+
+### Test Harness ###
+
+We have provided a test harness for testing your whole implementation: [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp)) ***Your List must work with this test harness.***
 
 ### Hints ###
 
 There are a few things that always cause students some headache.  We've tried to explain some of them here, in an effort to lessen the frustration it causes.
 
 #### Getting started ####
-To start, create all three .cpp files (List.cpp, ListNode.cpp, ListItr.cpp) and include the relevant .h files. Fill the files with empty method bodies (with a dummy return value for non-`void` methods) and get that to compile.  Then start implementing one method at a time, testing as you go.
+To start, create all three .cpp files (List.cpp, ListNode.cpp, ListItr.cpp) and include the relevant .h files.
+Fill the files with empty method bodies (with a dummy return value for non-`void` methods) and get that to compile.
+Then start implementing _one method at a time, testing as you go_.
 
-Here is the minimum amount of functions you need to have implemented in order to start using the ListTest harness, as well as suggested implementation order:
+Here is the minimum amount of functions you need to have implemented in order to start using the ListTest harness,
+as well as suggested implementation order:
 
 1. All of ListNode (so...the constructor)
 2. List constructor
@@ -254,14 +240,13 @@ The one in ListItr must be a mistake!
 In-lab
 ------
 
-These are the same steps from the lab procedure section, above.
+Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers.  The debugger is an important tool that you will use extensively throughout the semester to debug your code.  You will need to download the prog1.cpp and debug.cpp files for the tutorial.
 
-1. Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers.  The debugger is an important tool that you will use extensively throughout the semester to debug your code.  You will need to download the prog1.cpp and debug.cpp files for the tutorial.
-2. In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this.  So make sure you understand the tutorial!
-3. Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp.  Remember the standard identifying header information.
-4. Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about.  If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation.  You should do this by using the simple test cases that you used in the pre-lab.  Consult with a TA if you have questions.
-5. Files to download: [prog1.cpp](../../tutorials/02-lldb/prog1.cpp.html) ([src](../../tutorials/02-lldb/prog1.cpp)), [debug.cpp](../../tutorials/02-lldb/debug.cpp.html) ([src](../../tutorials/02-lldb/debug.cpp))
-6. Files to submit: debug.cpp
+In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this.  So make sure you understand the tutorial!
+
+Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp.  Remember the standard identifying header information.
+
+Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about.  If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation.  Consult with a TA if you have questions.
 
 ------------------------------------------------------------
 

--- a/labs/lab02/index.md
+++ b/labs/lab02/index.md
@@ -11,40 +11,36 @@ This laboratory introduces you to some advanced class development in C++, creati
 
 The linked list is a basic data structure from which one can implement stacks, queues, sets, and many other data structures.  Lists may be singly- or doubly-linked.  In this lab we will implement a doubly-linked list.
 
-### Reading(s) ###
+### Tutorial ###
 
-1. Readings on [Readings](../../docs/readings.html) page.
-2. [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) ***OR*** [Tutorial 2: GDB](../../tutorials/02-gdb/index.html); see below as to which one to choose.
-3. For the in-lab, some articles on debugging
+In this lab, you will have to make a choice as to which debugger to use; this will affect which tutorial you carry out.  You can choose the LLDB debugger (you would then complete [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html)) or the GDB debugger (you would then complete [Tutorial 2: GDB](../../tutorials/02-gdb/index.html)).  The source code provided for each tutorial is exactly the same, and the deliverable (i.e., what you turn in) is likewise the exact same.
 
-### Debugger Choice ###
-
-In this lab, you will have to make a choice as to which debugger to use; this will affect which tutorial you carry out.  You can choose the lldb debugger (you would then complete [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html)) or the gdb debugger (you would then complete [Tutorial 2: GDB](../../tutorials/02-gdb/index.html)).  The source code provided for each tutorial is exactly the same, and the deliverable (i.e., what you turn in) is likewise the exact same.
-
-The lldb debugger is preferred as it was built with the `clang++` compiler that we are using; however, the gdb tutorial is offered if lldb doesn't work for you.
+The LLDB debugger is preferred as it was built with the `clang++` compiler that we are using; however, the GDB tutorial is offered if LLDB doesn't work for you.
 
 Just remember which one you choose, as you will end up using that debugger throughout this course.  And if you ever have to switch between them, you can use our [GDB vs LLDB](../../docs/gdb_vs_lldb.html) page to see the (relatively few) commands that are different between the two.
 
-Ultimately, this is a low stress choice.  Choose lldb, and only switch over to gdb if you run into issues.
+Ultimately, this is a low stress choice.  Choose LLDB, and only switch over to GDB if you run into issues.
+
+### Recommend Readings ###
+
+- Pointers and Linked Lists sections on the [Readings](../../docs/readings.html) page
+- The [Debugging FAQ from UMich](http://umich.edu/~eecs381/generalFAQ/Debugging.html)
 
 Procedure
 ---------
 
 ### Pre-lab ###
 
-1. Consider one of the online alternative readings shown on the [Readings](../../docs/readings.html) page
-2. Make significant progress on implementing a doubly-linked linked list
-3. Files to download: [List.h](List.h.html) ([src](List.h)), [ListNode.h](ListNode.h.html) ([src](ListNode.h)), [ListItr.h](ListItr.h.html) ([src](ListItr.h)), [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp))
-4. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
+1. Make significant progress on implementing a doubly-linked linked list
+2. Files to download: [List.h](List.h.html) ([src](List.h)), [ListNode.h](ListNode.h.html) ([src](ListNode.h)), [ListItr.h](ListItr.h.html) ([src](ListItr.h)), [ListTest.cpp](ListTest.cpp.html) ([src](ListTest.cpp))
+3. Files to submit: ListNode.h/cpp, ListItr.h/cpp, List.h/cpp, ListTest.cpp
 
 ### In-lab ###
 
-1. Ensure you are familiar with debugging.  You should look over the [Debugging FAQ from UMich](http://umich.edu/~eecs381/generalFAQ/Debugging.html), which is a good introduction
-2. Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers
-3. Use the debugger to find and correct the errors in debug.cpp in the debugger tutorial
-4. Continue to work on your List and debug any issues with the debugger as necessary
-5. Files to download: [prog1.cpp](../../tutorials/02-lldb/prog1.cpp.html) ([src](../../tutorials/02-lldb/prog1.cpp)), [debug.cpp](../../tutorials/02-lldb/debug.cpp.html) ([src](../../tutorials/02-lldb/debug.cpp))
-6. Files to submit: debug.cpp
+1. Use the debugger to find and correct the errors in debug.cpp in part II of the debugger tutorial
+2. Continue to work on your List and debug any issues with the debugger as necessary
+3. Files to download: [prog1.cpp](../../tutorials/02-lldb/prog1.cpp.html) ([src](../../tutorials/02-lldb/prog1.cpp)), [debug.cpp](../../tutorials/02-lldb/debug.cpp.html) ([src](../../tutorials/02-lldb/debug.cpp))
+4. Files to submit: debug.cpp
 
 ### Post-lab ###
 
@@ -77,7 +73,7 @@ Below is a UML diagram showing how these classes interact with each other.
 
 ![UML diagram](list-diagram.png)
 
-This diagram shows a list containing two elements, the integers 3 and 7.  Note that there are more methods in the List and ListItr classes than what is shown above.  The head and tail pointers in the List class point to dummy nodes -- they are put there to make inserting elements into the list easier.  It doesn't matter what the value of the dummy notes is set to, as it won't be used.  Each ListNode points to the nodes before and after it (although the dummy nodes each have one pointer pointing to NULL).
+This diagram shows a list containing two elements, the integers 3 and 7.  Note that there are more methods in the List and ListItr classes than what is shown above.  The head and tail pointers in the List class point to dummy nodes -- they are put there to make inserting elements into the list easier.  It doesn't matter what the value of the dummy nodes is set to, as it won't be used.  Each ListNode points to the nodes before and after it (although the dummy nodes each have one pointer pointing to NULL).
 
 Thus, our doubly linked list will have only one List object and many ListNode objects (2 more than the number of elements in the list).  A ListItr is a separate object, which points to one element in the list (possibly a dummy node).  As you call the various methods in ListItr to move the iterator forward and backward, the node that it points to will change.
 
@@ -240,11 +236,9 @@ The one in ListItr must be a mistake!
 In-lab
 ------
 
-Carry out [Tutorial 2: LLDB](../../tutorials/02-lldb/index.html) OR [Tutorial 2: GDB](../../tutorials/02-gdb/index.html) on how to use Unix debuggers.  The debugger is an important tool that you will use extensively throughout the semester to debug your code.  You will need to download the prog1.cpp and debug.cpp files for the tutorial.
+Complete Part II of the tutorial for this lab and submit your debugged version of debug.cpp; we are not submitting prog1.cpp.  Remember the standard identifying header information.
 
-In the future, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this.  So make sure you understand the tutorial!
-
-Submit your debugged version of debug.cpp to inlab2; we are not submitting prog1.cpp.  Remember the standard identifying header information.
+Going forward, if you have a post-compilation problem with your program (crash, etc.), the TAs will not help you until you have run it through the debugger and learned all that can be learned from this.  So make sure you understand the tutorial!
 
 Verify to yourself that your methods are working properly with your linked list code using the debugger that you just learned about.  If you have not yet completed your linked list implementation, use the debugger to help you identify the issues/problems with parts of your current implementation.  Consult with a TA if you have questions.
 

--- a/labs/lab03/index.html
+++ b/labs/lab03/index.html
@@ -14,11 +14,11 @@
 <body>
 <h1 id="pdr-laboratory-3-stacks">PDR: Laboratory 3: Stacks</h1>
 <p><a href="../index.html">Go up to the Labs table of contents page</a></p>
-<h3 id="objective">Objective:</h3>
+<h3 id="objective">Objective</h3>
 <p>To understand the workings of a stack as well as postfix notation, and to be introduced to the C++ Standard Template Library (STL).</p>
-<h3 id="background">Background:</h3>
+<h3 id="background">Background</h3>
 <p>A stack is a basic data structure similar in use to a physical stack of papers. You can add to the top (push) and take from the top (pop), but you are not allowed to access the middle or bottom. A stack adheres to the <a href="http://en.wikipedia.org/wiki/LIFO_%28computing%29">LIFO</a> property.</p>
-<h3 id="readings">Reading(s):</h3>
+<h3 id="readings">Reading(s)</h3>
 <ol type="1">
 <li>Readings can be found online on the <a href="../../docs/readings.html">Readings</a> page</li>
 <li>The <a href="http://en.wikipedia.org/wiki/Reverse_Polish_notation">Wikipedia article on Reverse Polish notation</a>, which is another name for postfix notation, has a good description along with a sample calculation.</li>
@@ -26,53 +26,25 @@
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Read this entire lab document before coming to lab.</li>
-<li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 3: Unix, part 1</a>, which is the introduction and sections 1-4. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You should complete the introductory part and sections 1-4. You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the <a href="../../tutorials/01-intro-unix/index.html">Unix tutorial from the first lab</a>. The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested.</li>
-<li>Write up at least one question that you still have on Unix (or things you are still confused about) into unix.questions.txt.</li>
-<li>Your code for the pre-lab will use the pre-existing standard library <code>stack</code> class. The standard library includes a collection of useful routines analogous to the routines in Java's SDK, albeit much smaller (it contains a vector class, for example).
-<ul>
-<li>To use the stack class, just put <code>#include &lt;stack&gt;</code> at the top of your C++ file.</li>
-<li>Documentation on the standard library routines can be found at <a href="https://en.cppreference.com" class="uri">https://en.cppreference.com</a>. The stack class's documentation can be found <a href="https://en.cppreference.com/w/cpp/container/stack">here</a>.</li>
-</ul></li>
-<li>Implement a simple postfix stack calculator for integers using your stack.
-<ul>
-<li><strong>You should use the standard library stack class</strong>, rather than implement your own.</li>
-<li>An online description of postfix calculators can be found <a href="https://en.wikipedia.org/wiki/Reverse_Polish_notation">on Wikipedia</a> -- you will need to implement this into postfixCalculator.h and postfixCalculator.cpp</li>
-<li>Create a simple test driver, testPostfixCalc.cpp, which will be used to demonstrate your calculator (i.e., it will have the <code>main()</code> function). This file should have hard-coded values for input; handling keyboard input is the in-lab.</li>
-<li>The bottom of this document has some sample test cases you can use.</li>
-</ul></li>
-<li>Your code must compile!</li>
-<li>Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit.</li>
+<li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 3: Unix, part 1</a>, which is the introduction and sections 1-4. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You should complete the introductory part and sections 1-4. You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the <a href="../../tutorials/01-intro-unix/index.html">Unix tutorial from the first lab</a>. The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested</li>
+<li>Write up at least one question that you still have on Unix (or things you are still confused about)</li>
+<li>Implement a postfix stack calculator for integers using the C++ STL stack</li>
+<li>Create a simple program to test your calculator</li>
 <li>Files to download: none</li>
 <li>Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, unix.questions.txt</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>
 <ol type="1">
-<li>Come to class with a <em>working prelab</em>.</li>
-<li>Run your postfix calculator on the test sequences at the very bottom of this page. Since your code only can handle hard-coded values, this will require a code modification and a recompilation to test each case. If your program does not calculate the correct result, use the debugger to find the errors and correct them. These modifications will be submitted to the in-lab.
-<ul>
-<li>Be sure you are able to explain how all parts your code work. You will be responsible for this material for the midterms and final exam.</li>
-</ul></li>
-<li>You need to expand your pre-lab code to handle keyboard input. See the specifications in the in-lab section for how to handle the input.</li>
-<li>The files you submit should be a FULLY WORKING postfix calculator, which still uses the standard library's stack class.</li>
-<li>Start working on the post-lab (implementing your own stack class) if you get your calculator fully working before lab ends.</li>
+<li>Ensure your postfix calculator works on all the provided test cases</li>
+<li>Expand your test program to handle keyboard input</li>
 <li>Files to download: none (just your pre-lab source code)</li>
 <li>Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp</li>
 </ol>
 <h3 id="post-lab">Post-lab</h3>
 <ol type="1">
-<li>Implement a stack class (into files stack.h and stack.cpp). <strong>You can NOT use a standard library container class (<code>list</code>, <code>vector</code>, <code>stack</code>, etc.) for this</strong>, but you can use the standard library's <code>string</code> class. You should use either your List class from the last lab (if it works), or write up new stack class based on either the lecture notes or the textbook pages on stacks. Your stack class can use a linked-list/pointer-based implementation, or an array-based implementation. Note that your stack class can contain a LinkedList object, and a stack class method can just pass the value onto the appropriate method in the LinkedList class. You don't need to implement all possible stack methods (in particular, you can ignore the copy constructor, <code>operator=()</code>, etc.) -- just the four mentioned in the pre-lab (push(), top(), pop(), and empty()). After this lab, it is expected that you will be able to implement a stack class in C++.</li>
-<li>Modify your postfix calculator to use the stack class that you have implemented.</li>
-<li>Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit. Your submission must contain the following code:
-<ol type="1">
-<li>Your stack code. This will likely be stack.h/cpp, and may (or may not; your choice) include all of the List.h/cpp, ListItr.h/cpp, ListNode.h/cpp files from lab 2
-<ul>
-<li>For your stack code, you are welcome to submit it in many files, as long as it will compile with <code>clang++ *.cpp</code>, and as long as the total number of files submitted does not exceed 11 files (you can submit 12 files total, but you need to submit a text file, described below, as well)</li>
-</ul></li>
-<li>A listing of your in-lab calculator code and your calculator test code: postfixCalculator.h/cpp, testPostfixCalc.cpp</li>
-</ol></li>
-<li>Submit, in addition to your code, a paragraph (in a file called difficulties.txt) describing what difficulties you encountered getting your code working and what you did to solve them.</li>
-<li>The files you submit should be a FULLY WORKING postfix calculator. Your code must compile! Even if it doesn't work perfectly, make sure it compiles. In particular, make sure that the capitalization case of the #includes (i.e. <code>#include &quot;Stack.h&quot;</code> versus <code>#include &quot;stack.h&quot;</code>) is correct.</li>
+<li>Implement a stack class</li>
+<li>Modify your postfix calculator to use your stack rather than the STL stack</li>
+<li>Describe any difficulties you encountered getting your code working and what you did to solve them</li>
 <li>Files to download: none (just your in-lab source code)</li>
 <li>Files to submit: stack.h, stack.cpp, postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, difficulties.txt - You may submit additional stack/list files as well, if you want</li>
 </ol>
@@ -110,6 +82,21 @@
 <p>Often, the <code>top()</code> and <code>pop()</code> functionality are joined as an <code>int pop()</code> function, but in this lab, it is beneficial to separate them, as that is what the STL stack does.</p>
 <p>If <code>pop()</code> or <code>top()</code> are called on an empty stack, terminate the program with the function call <code>exit(-1)</code>, which is from the <code>&lt;cstdlib&gt;</code> library.</p>
 <p>For this lab, you will use a stack of <code>int</code> values.</p>
+<h3 id="stack-calculator-implementation">Stack Calculator Implementation</h3>
+<p>We will be using the C++ STL stack to implement our postfix calculator. The stack class's documentation can be found <a href="https://en.cppreference.com/w/cpp/container/stack">here</a>.</p>
+<p>Your calculator must implement the following arithmetic operations:</p>
+<ul>
+<li><code>+</code> : addition</li>
+<li><code>-</code> : subtraction</li>
+<li><code>*</code> : multiplication</li>
+<li><code>/</code> : division</li>
+<li><code>~</code> : unary negation</li>
+</ul>
+<p>Notes:</p>
+<ul>
+<li>We use the tilde (~) as the unary negation operator -- this negates the top element of the stack, and (unlike the other four operators) does not use a second number from the stack. Do not confuse this operator with the tilde operator in C++, which performs bitwise negation. Negative numbers still use a regular minus sign (i.e. '-3') and just pushes the negative number on the stack. But, if you want to do negation (which involves popping the top value, negating it, and pushing that new value back on the stack), then you would use the tilde.</li>
+<li>For the non-commutative operators (operators where the order of the numbers matters, such as minus and divide), the first value you pop we'll call x, the second value you pop we'll call y; the result <strong>must</strong> be <em>y-x</em> or <em>y/x</em> -- in other words, the &quot;lower&quot; value in the stack minus/divided by the &quot;higher&quot; one in the stack.</li>
+</ul>
 <h3 id="input">Input</h3>
 <p>For this part of the lab, you will not deal with keyboard input (that's in the in-lab) -- thus, your submitted program will always compute the exact same value each time it is run. You will need to hard-code your postfix expressions into the <code>main()</code> method. Make sure your tests in main demonstrate the functionality of all operators!</p>
 <p>A sample <code>main()</code> function that might work is as follows -- this should be modified for your particular situation (i.e. how you declare your class, your method names, etc.). This <code>main()</code> function uses the first sample input given at the very end of this document.</p>
@@ -128,21 +115,6 @@
     return 0;
 }</code></pre>
 <p>Keep in mind that you can type up a few of the blocks, and comment them out with the <code>/* ... */</code> comment syntax that you are familiar with from Java -- this will allow you to easily switch between the different hard-coded input test cases.</p>
-<h3 id="stack-calculator-implementation">Stack Calculator Implementation</h3>
-<p>Your calculator must implement the following arithmetic operations:</p>
-<ul>
-<li><code>+</code> : addition</li>
-<li><code>-</code> : subtraction</li>
-<li><code>*</code> : multiplication</li>
-<li><code>/</code> : division</li>
-<li><code>~</code> : unary negation</li>
-</ul>
-<p>Notes:</p>
-<ul>
-<li>We use the tilde (~) as the unary negation operator -- this negates the top element of the stack, and (unlike the other four operators) does not use a second number from the stack. Do not confuse this operator with the tilde operator in C++, which performs bitwise negation. Negative numbers still use a regular minus sign (i.e. '-3') and just pushes the negative number on the stack. But, if you want to do negation (which involves popping the top value, negating it, and pushing that new value back on the stack), then you would use the tilde.<br />
-</li>
-<li>For the non-commutative operators (operators where the order of the numbers matters, such as minus and divide), the first value you pop we'll call x, the second value you pop we'll call y; the result <strong>must</strong> be <em>y-x</em> or <em>y/x</em> -- in other words, the &quot;lower&quot; value in the stack minus/divided by the &quot;higher&quot; one in the stack.</li>
-</ul>
 <h3 id="postfix-notation">Postfix Notation</h3>
 <p>Postfix notation (also known as reverse Polish notation) involves writing the operators after the operands. Note how parentheses are unnecessary in postfix notation.</p>
 <ul>
@@ -198,8 +170,8 @@ Hint: we can check for all the operators, since there are only five of them. If 
 <p>To convert input that represents numbers into their integer form, <code>&lt;cstdlib&gt;</code> provides the <code>int atoi(char* s)</code> function. Unfortunately, <code>atoi</code> requires C-style strings -- perhaps you should take a look at <a href="https://en.cppreference.com/w/cpp/string/basic_string">the <code>string</code> documentation</a> to see if anything can help you out.</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
-<p>For the post-lab, you will be implementing your own stack. This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).</p>
-<p>You will also have to write up the difficulties.txt file, as described above in the lab procedure section.</p>
+<p>For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack. This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).</p>
+<p>You will also need to write up a difficulties.txt file which contains a paragraph describing any difficulties you encountered getting your code working and what you did to solve them.</p>
 <p>Your stack is only required to implement the four methods as described in the prelab: <code>push()</code>, <code>pop()</code>, <code>top()</code>, and <code>empty()</code>. It must also have no maximum capacity -- in other words, we should be able to push as many elements as we'd like.</p>
 <p>Most of you will implement your stack in one of the following ways:</p>
 <ol type="1">

--- a/labs/lab03/index.html
+++ b/labs/lab03/index.html
@@ -18,15 +18,15 @@
 <p>To understand the workings of a stack as well as postfix notation, and to be introduced to the C++ Standard Template Library (STL).</p>
 <h3 id="background">Background</h3>
 <p>A stack is a basic data structure similar in use to a physical stack of papers. You can add to the top (push) and take from the top (pop), but you are not allowed to access the middle or bottom. A stack adheres to the <a href="http://en.wikipedia.org/wiki/LIFO_%28computing%29">LIFO</a> property.</p>
-<h3 id="readings">Reading(s)</h3>
-<ol type="1">
-<li>Readings can be found online on the <a href="../../docs/readings.html">Readings</a> page</li>
-<li>The <a href="http://en.wikipedia.org/wiki/Reverse_Polish_notation">Wikipedia article on Reverse Polish notation</a>, which is another name for postfix notation, has a good description along with a sample calculation.</li>
-</ol>
+<h3 id="tutorial">Tutorial</h3>
+<p>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 3: Unix, part 1</a>, which is the introduction and sections 1-4. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You should complete the introductory part and sections 1-4. You should already be somewhat familiar with some of the materials in the first few of these tutorials, as they were covered in the <a href="../../tutorials/01-intro-unix/index.html">Unix tutorial from the first lab</a>. The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested.</p>
+<h3 id="recommended-readings">Recommended Readings</h3>
+<ul>
+<li>Postfix Calculation and Stacks and Queues sections on the <a href="../../docs/readings.html">Readings</a> page</li>
+</ul>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 3: Unix, part 1</a>, which is the introduction and sections 1-4. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You should complete the introductory part and sections 1-4. You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the <a href="../../tutorials/01-intro-unix/index.html">Unix tutorial from the first lab</a>. The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested</li>
 <li>Write up at least one question that you still have on Unix (or things you are still confused about)</li>
 <li>Implement a postfix stack calculator for integers using the C++ STL stack</li>
 <li>Create a simple program to test your calculator</li>

--- a/labs/lab03/index.md
+++ b/labs/lab03/index.md
@@ -3,15 +3,15 @@ PDR: Laboratory 3: Stacks
 
 [Go up to the Labs table of contents page](../index.html)
 
-### Objective: ###
+### Objective ###
 
 To understand the workings of a stack as well as postfix notation, and to be introduced to the C++ Standard Template Library (STL).
 
-### Background: ###
+### Background ###
 
 A stack is a basic data structure similar in use to a physical stack of papers.  You can add to the top (push) and take from the top (pop), but you are not allowed to access the middle or bottom.  A stack adheres to the [LIFO](http://en.wikipedia.org/wiki/LIFO_%28computing%29) property.
 
-### Reading(s): ###
+### Reading(s) ###
 
 1. Readings can be found online on the [Readings](../../docs/readings.html) page
 2. The [Wikipedia article on Reverse Polish notation](http://en.wikipedia.org/wiki/Reverse_Polish_notation), which is another name for postfix notation, has a good description along with a sample calculation.
@@ -21,46 +21,25 @@ Procedure
 
 ### Pre-lab ###
 
-1. Read this entire lab document before coming to lab.
-2. Go through [Tutorial 3: Unix, part 1](../../tutorials/03-04-more-unix/index.html), which is the introduction and sections 1-4.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You should complete the introductory part and sections 1-4.  You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the [Unix tutorial from the first lab](../../tutorials/01-intro-unix/index.html).  The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested.
-3. Write up at least one question that you still have on Unix (or things you are still confused about) into unix.questions.txt.
-4. Your code for the pre-lab will use the pre-existing standard library `stack` class.  The standard library includes a collection of useful routines analogous to the routines in Java's SDK, albeit much smaller (it contains a vector class, for example).
-    - To use the stack class, just put `#include <stack>` at the top of your C++ file.
-    - Documentation on the standard library routines can be found at [https://en.cppreference.com](https://en.cppreference.com). The stack class's documentation can be found [here](https://en.cppreference.com/w/cpp/container/stack).
-5. Implement a simple postfix stack calculator for integers using your stack.
-    - **You should use the standard library stack class**, rather than implement your own.
-    - An online description of postfix calculators can be found [on Wikipedia](https://en.wikipedia.org/wiki/Reverse_Polish_notation) -- you will need to implement this into postfixCalculator.h and postfixCalculator.cpp
-    - Create a simple test driver, testPostfixCalc.cpp, which will be used to demonstrate your calculator (i.e., it will have the `main()` function).  This file should have hard-coded values for input; handling keyboard input is the in-lab.
-    - The bottom of this document has some sample test cases you can use.
-6. Your code must compile!
-7. Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit.
-7. Files to download: none
-8. Files to submit: postfixCalculator.h, postfixCalculator.cpp,
-   testPostfixCalc.cpp, unix.questions.txt
-
+1. Go through [Tutorial 3: Unix, part 1](../../tutorials/03-04-more-unix/index.html), which is the introduction and sections 1-4.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You should complete the introductory part and sections 1-4.  You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the [Unix tutorial from the first lab](../../tutorials/01-intro-unix/index.html).  The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested
+2. Write up at least one question that you still have on Unix (or things you are still confused about)
+3. Implement a postfix stack calculator for integers using the C++ STL stack
+4. Create a simple program to test your calculator
+5. Files to download: none
+6. Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, unix.questions.txt
 
 ### In-lab ###
 
-1. Come to class with a *working prelab*.
-2. Run your postfix calculator on the test sequences at the very bottom of this page.  Since your code only can handle hard-coded values, this will require a code modification and a recompilation to test each case.  If your program does not calculate the correct result, use the debugger to find the errors and correct them.  These modifications will be submitted to the in-lab.
-    - Be sure you are able to explain how all parts your code work. You will be responsible for this material for the midterms and final exam.
-3. You need to expand your pre-lab code to handle keyboard input.  See the specifications in the in-lab section for how to handle the input.
-4. The files you submit should be a FULLY WORKING postfix calculator, which still uses the standard library's stack class.
-5. Start working on the post-lab (implementing your own stack class) if you get your calculator fully working before lab ends.
-6. Files to download: none (just your pre-lab source code)
-7. Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp
-
+1. Ensure your postfix calculator works on all the provided test cases
+2. Expand your test program to handle keyboard input
+3. Files to download: none (just your pre-lab source code)
+4. Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp
 
 ### Post-lab ###
 
-1. Implement a stack class (into files stack.h and stack.cpp).  **You can NOT use a standard library container class (`list`, `vector`, `stack`, etc.) for this**, but you can use the standard library's `string` class.  You should use either your List class from the last lab (if it works), or write up new stack class based on either the lecture notes or the textbook pages on stacks.  Your stack class can use a linked-list/pointer-based implementation, or an array-based implementation. Note that your stack class can contain a LinkedList object, and a stack class method can just pass the value onto the appropriate method in the LinkedList class.  You don't need to implement all possible stack methods (in particular, you can ignore the copy constructor, `operator=()`, etc.) -- just the four mentioned in the pre-lab (push(), top(), pop(), and empty()).  After this lab, it is expected that you will be able to implement a stack class in C++.
-2. Modify your postfix calculator to use the stack class that you have implemented.
-3. Be sure to include: your name, the date, and the name of the file in a banner comment at the beginning of each file you submit.  Your submission must contain the following code:
-    1. Your stack code.  This will likely be stack.h/cpp, and may (or may not; your choice) include all of the List.h/cpp, ListItr.h/cpp, ListNode.h/cpp files from lab 2
-        - For your stack code, you are welcome to submit it in many files, as long as it will compile with `clang++ *.cpp`, and as long as the total number of files submitted does not exceed 11 files (you can submit 12 files total, but you need to submit a text file, described below, as well)
-    2. A listing of your in-lab calculator code and your calculator test code: postfixCalculator.h/cpp, testPostfixCalc.cpp
-4. Submit, in addition to your code, a paragraph (in a file called difficulties.txt) describing what difficulties you encountered getting your code working and what you did to solve them.
-5. The files you submit should be a FULLY WORKING postfix calculator.  Your code must compile!  Even if it doesn't work perfectly, make sure it compiles.  In particular, make sure that the capitalization case of the #includes (i.e. `#include "Stack.h"` versus `#include "stack.h"`) is correct.
+1. Implement a stack class
+2. Modify your postfix calculator to use your stack rather than the STL stack
+3. Describe any difficulties you encountered getting your code working and what you did to solve them
 6. Files to download: none (just your in-lab source code)
 7. Files to submit: stack.h, stack.cpp, postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, difficulties.txt - You may submit additional stack/list files as well, if you want
 
@@ -103,6 +82,23 @@ If `pop()` or `top()` are called on an empty stack, terminate the program with t
 
 For this lab, you will use a stack of `int` values.
 
+### Stack Calculator Implementation ###
+
+We will be using the C++ STL stack to implement our postfix calculator.  The stack class's documentation can be found [here](https://en.cppreference.com/w/cpp/container/stack).
+
+Your calculator must implement the following arithmetic operations:
+
+  - `+` : addition
+  - `-` : subtraction
+  - `*` : multiplication
+  - `/` : division
+  - `~` : unary negation
+
+Notes:
+
+  - We use the tilde (~) as the unary negation operator -- this negates the top element of the stack, and (unlike the other four operators) does not use a second number from the stack.  Do not confuse this operator with the tilde operator in C++, which performs bitwise negation.  Negative numbers still use a regular minus sign (i.e. '-3') and just pushes the negative number on the stack.  But, if you want to do negation (which involves popping the top value, negating it, and pushing that new value back on the stack), then you would use the tilde.
+  - For the non-commutative operators (operators where the order of the numbers matters, such as minus and divide), the first value you pop we'll call x, the second value you pop we'll call y; the result **must** be *y-x* or *y/x* -- in other words, the "lower" value in the stack minus/divided by the "higher" one in the stack.
+
 ### Input ###
 
 For this part of the lab, you will not deal with keyboard input (that's in the in-lab) -- thus, your submitted program will always compute the exact same value each time it is run.  You will need to hard-code your postfix expressions into the `main()` method. Make sure your tests in main demonstrate the functionality of all operators!
@@ -127,21 +123,6 @@ int main() {
 ```
 
 Keep in mind that you can type up a few of the blocks, and comment them out with the `/* ... */` comment syntax that you are familiar with from Java -- this will allow you to easily switch between the different hard-coded input test cases.
-
-### Stack Calculator Implementation ###
-
-Your calculator must implement the following arithmetic operations: 
-
-  - `+` : addition
-  - `-` : subtraction
-  - `*` : multiplication
-  - `/` : division
-  - `~` : unary negation
-
-Notes: 
-
-  - We use the tilde (~) as the unary negation operator -- this negates the top element of the stack, and (unlike the other four operators) does not use a second number from the stack.  Do not confuse this operator with the tilde operator in C++, which performs bitwise negation.  Negative numbers still use a regular minus sign (i.e. '-3') and just pushes the negative number on the stack.  But, if you want to do negation (which involves popping the top value, negating it, and pushing that new value back on the stack), then you would use the tilde.  
-  - For the non-commutative operators (operators where the order of the numbers matters, such as minus and divide), the first value you pop we'll call x, the second value you pop we'll call y; the result **must** be *y-x* or *y/x* -- in other words, the "lower" value in the stack minus/divided by the "higher" one in the stack.
 
 ### Postfix Notation ###
 
@@ -246,9 +227,9 @@ Unfortunately, `atoi` requires C-style strings -- perhaps you should take a look
 Post-lab
 --------
 
-For the post-lab, you will be implementing your own stack.  This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).
+For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack.  This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).
 
-You will also have to write up the difficulties.txt file, as described above in the lab procedure section.
+You will also need to write up a difficulties.txt file which contains a paragraph describing any difficulties you encountered getting your code working and what you did to solve them.
 
 Your stack is only required to implement the four methods as described in the prelab: `push()`, `pop()`, `top()`, and `empty()`.
 It must also have no maximum capacity -- in other words, we should be able to push as many elements as we'd like.

--- a/labs/lab03/index.md
+++ b/labs/lab03/index.md
@@ -11,22 +11,24 @@ To understand the workings of a stack as well as postfix notation, and to be int
 
 A stack is a basic data structure similar in use to a physical stack of papers.  You can add to the top (push) and take from the top (pop), but you are not allowed to access the middle or bottom.  A stack adheres to the [LIFO](http://en.wikipedia.org/wiki/LIFO_%28computing%29) property.
 
-### Reading(s) ###
+### Tutorial ###
 
-1. Readings can be found online on the [Readings](../../docs/readings.html) page
-2. The [Wikipedia article on Reverse Polish notation](http://en.wikipedia.org/wiki/Reverse_Polish_notation), which is another name for postfix notation, has a good description along with a sample calculation.
+Go through [Tutorial 3: Unix, part 1](../../tutorials/03-04-more-unix/index.html), which is the introduction and sections 1-4.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You should complete the introductory part and sections 1-4.  You should already be somewhat familiar with some of the materials in the first few of these tutorials, as they were covered in the [Unix tutorial from the first lab](../../tutorials/01-intro-unix/index.html).  The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested.
+
+### Recommended Readings ###
+
+- Postfix Calculation and Stacks and Queues sections on the [Readings](../../docs/readings.html) page
 
 Procedure
 ---------
 
 ### Pre-lab ###
 
-1. Go through [Tutorial 3: Unix, part 1](../../tutorials/03-04-more-unix/index.html), which is the introduction and sections 1-4.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You should complete the introductory part and sections 1-4.  You should already be somewhat familiar with some of the materials in the first few of these tutorials, as it was in the [Unix tutorial from the first lab](../../tutorials/01-intro-unix/index.html).  The rest of the tutorial (sections 5-8) are for next week's lab, but feel free to go through it this week, if you are interested
-2. Write up at least one question that you still have on Unix (or things you are still confused about)
-3. Implement a postfix stack calculator for integers using the C++ STL stack
-4. Create a simple program to test your calculator
-5. Files to download: none
-6. Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, unix.questions.txt
+1. Write up at least one question that you still have on Unix (or things you are still confused about)
+2. Implement a postfix stack calculator for integers using the C++ STL stack
+3. Create a simple program to test your calculator
+4. Files to download: none
+5. Files to submit: postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, unix.questions.txt
 
 ### In-lab ###
 
@@ -40,8 +42,8 @@ Procedure
 1. Implement a stack class
 2. Modify your postfix calculator to use your stack rather than the STL stack
 3. Describe any difficulties you encountered getting your code working and what you did to solve them
-6. Files to download: none (just your in-lab source code)
-7. Files to submit: stack.h, stack.cpp, postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, difficulties.txt - You may submit additional stack/list files as well, if you want
+4. Files to download: none (just your in-lab source code)
+5. Files to submit: stack.h, stack.cpp, postfixCalculator.h, postfixCalculator.cpp, testPostfixCalc.cpp, difficulties.txt - You may submit additional stack/list files as well, if you want
 
 ------------------------------------------------------------
 

--- a/labs/lab04/index.html
+++ b/labs/lab04/index.html
@@ -18,14 +18,15 @@
 <p>To become familiar with the underlying representation of various data types, and to learn how to examine these representations in the debugger.</p>
 <h3 id="background">Background</h3>
 <p>In class we discussed how various data types -- integers, characters, and floating point numbers -- were represented in computers. In this lab we will use the debugger to examine some of these representations.</p>
-<h3 id="readings">Reading(s)</h3>
-<ol type="1">
-<li>Any of the optional readings on the <a href="../../docs/readings.html">Readings</a> page, in particular, those on arrays and unions, if you feel you need a bit more background.</li>
-</ol>
+<h3 id="tutorial">Tutorial</h3>
+<p>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 4: Unix, part 2</a>, which is sections 5-8. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You went through sections 1-4 in the last tutorial; this lab has you completing sections 5-8.</p>
+<h3 id="recommended-readings">Recommended Readings</h3>
+<ul>
+<li>Structs and Unions and Arrays sections on the <a href="../../docs/readings.html">Readings</a> page</li>
+</ul>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>
 <ol type="1">
-<li>Go through <a href="../../tutorials/03-04-more-unix/index.html">Tutorial 4: Unix, part 2</a>, which is sections 5-8. This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online <a href="http://www.ee.surrey.ac.uk/Teaching/Unix/">here</a>. You went through sections 1-4 in the last tutorial; this lab has you completing sections 5-8.</li>
 <li>Convert a floating point number to binary, and a binary number to floating point</li>
 <li>In prelab4.cpp:
 <ul>

--- a/labs/lab04/index.md
+++ b/labs/lab04/index.md
@@ -11,23 +11,26 @@ To become familiar with the underlying representation of various data types, and
 
 In class we discussed how various data types -- integers, characters, and floating point numbers -- were represented in computers.  In this lab we will use the debugger to examine some of these representations.
 
-### Reading(s) ###
+### Tutorial ###
 
-1. Any of the optional readings on the [Readings](../../docs/readings.html) page, in particular, those on arrays and unions, if you feel you need a bit more background.
+Go through [Tutorial 4: Unix, part 2](../../tutorials/03-04-more-unix/index.html), which is sections 5-8.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You went through sections 1-4 in the last tutorial; this lab has you completing sections 5-8.
+
+### Recommended Readings ###
+
+- Structs and Unions and Arrays sections on the [Readings](../../docs/readings.html) page
 
 Procedure
 ---------
 
 ### Pre-lab ###
 
-1. Go through [Tutorial 4: Unix, part 2](../../tutorials/03-04-more-unix/index.html), which is sections 5-8.  This tutorial is originally from the department of Electrical Engineering at the University of Surrey, and is available online [here](http://www.ee.surrey.ac.uk/Teaching/Unix/).  You went through sections 1-4 in the last tutorial; this lab has you completing sections 5-8.
-2. Convert a floating point number to binary, and a binary number to floating point
-3. In prelab4.cpp:
+1. Convert a floating point number to binary, and a binary number to floating point
+2. In prelab4.cpp:
     - Write a `sizeOfTest()` function to view the sizes of various types
     - Write an `outputBinary()` function to display the binary representation of integers
     - Write an `overflow()` function to investigate how C++ handles integer overflow
-4. Files to download: none
-5. Files to submit: floatingpoint.pdf, prelab4.cpp
+3. Files to download: none
+4. Files to submit: floatingpoint.pdf, prelab4.cpp
 
 ### In-lab ###
 

--- a/tutorials/02-lldb/index.html
+++ b/tutorials/02-lldb/index.html
@@ -146,6 +146,7 @@ int main() {
 <p>Again, a programmer must know how to use a debugger just like an accountant must know how to use a spreadsheet program or a calculator. Your professors and your boss will expect it of you. Remember this before you go see your instructor about a run-time bug next time! The time you spend now to learn how to use a debugger will save you hours in the future.</p>
 <hr />
 <h2 id="part-ii-lldb-lab-exercise">Part II: LLDB Lab Exercise</h2>
+<p>Part II of this tutorial is designed to complement Lab 2's in-lab. You can stop here for now and return when you are working on the in-lab.</p>
 <h3 id="the-source-code">The Source Code</h3>
 <p>We will be using the <a href="debug.cpp.html">debug.cpp</a> (<a href="debug.cpp">src</a>) source code. There are a few errors in the code, but don't fix them! We'll use the debugger to find them.</p>
 <h3 id="running-the-debugger">Running the Debugger</h3>

--- a/tutorials/02-lldb/index.md
+++ b/tutorials/02-lldb/index.md
@@ -389,7 +389,10 @@ in the future.
 ------------------------------------------------------------
 
 Part II: LLDB Lab Exercise
--------------------------
+--------------------------
+
+Part II of this tutorial is designed to complement Lab 2's in-lab.
+You can stop here for now and return when you are working on the in-lab.
 
 ### The Source Code ###
 


### PR DESCRIPTION
In #59, I shrunk the procedure section considerably and made it a _very_ high-level "this is what you're going to be doing" rather than "...plus a lot of supporting information". We might even consider renaming Procedure to Overview instead.

This PR just expands that change to the other labs I edited to bring the new structure to labs 1-4.

To accommodate this change, I've extracted the tutorial into its own top-level Tutorial section.
...and there were a few slight changes to the Reading(s) section as well (notably, a rename to Recommended Readings).

Finally, there were a few additional edits made to Labs 1-3. Nothing major, though.