### PR TITLE
Restructure links for 32-bit assembly labs

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -98,30 +98,23 @@
 <ul>
 <li>Lab 8: x86 (assembly), part 1: in 32-bit and 64-bit versions
 <ul>
-<li><del><a href="lab08-32bit/index.html">32-bit version of the lab</a></del>
-<ul>
-<li><del>Source code: <a href="lab08-32bit/vecsum.s.html">vecsum.s</a> (<a href="lab08-32bit/vecsum.s">src</a>), <a href="lab08-32bit/main.cpp.html">main.cpp</a> (<a href="lab08-32bit/main.cpp">src</a>), <a href="lab08-32bit/Makefile.html">Makefile</a> (<a href="lab08-32bit/Makefile">src</a>)</del></li>
-<li><del>Readings (which is also the tutorial): the two x86 book chapters: <a href="../book/x86-32bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../book/x86-32bit-ccc-chapter.pdf">The x86 C Calling Convention</a></del></li>
-</ul></li>
 <li><a href="lab08-64bit/index.html">64-bit version of the lab</a>
 <ul>
 <li>Source code: <a href="lab08-64bit/vecsum.s.html">vecsum.s</a> (<a href="lab08-64bit/vecsum.s">src</a>), <a href="lab08-64bit/main.cpp.html">main.cpp</a> (<a href="lab08-64bit/main.cpp">src</a>), <a href="lab08-64bit/Makefile.html">Makefile</a> (<a href="lab08-64bit/Makefile">src</a>), <a href="lab08-64bit/mergeSort.s.html">mergeSort.s</a> (<a href="lab08-64bit/mergeSort.s">src</a>), <a href="lab08-64bit/testMergeSort.cpp.html">testMergeSort.cpp</a> (<a href="lab08-64bit/testMergeSort.cpp">src</a>)</li>
 <li>Readings (which is also the tutorial): the C++/assembly tutorial, which consists of reading <a href="https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf">x86-64 Machine-Level Programming</a> from CMU</li>
 </ul></li>
+<li><del><a href="lab08-32bit/index.html">32-bit version of the lab, from previous years</a></del></li>
 </ul></li>
 </ul>
 <p> </p>
 <ul>
 <li>Lab 9: x86 (assembly), part 2: in 32-bit and 64-bit versions
 <ul>
-<li><del><a href="lab09-32bit/index.html">32-bit version of the lab</a></del>
-<ul>
-<li><del>Readings: the two x86 book chapters: <a href="../book/x86-32bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../book/x86-32bit-ccc-chapter.pdf">The x86 C Calling Convention</a></del></li>
-</ul></li>
 <li><a href="lab09-64bit/index.html">64-bit version of the lab</a>
 <ul>
 <li>Readings: the two x86 book chapters: <a href="../book/x86-64bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../book/x86-64bit-ccc-chapter.pdf">The x86 C Calling Convention</a></li>
 </ul></li>
+<li><del><a href="lab09-32bit/index.html">32-bit version of the lab, from previous years</a></del></li>
 <li>For both labs:
 <ul>
 <li>Source code: <a href="lab06/code/timer.cpp.html">timer.cpp</a> (<a href="lab06/code/timer.cpp">src</a>) and <a href="lab06/code/timer.h.html">timer.h</a> (<a href="lab06/code/timer.h">src</a>), both of which are from lab 6</li>

--- a/labs/index.md
+++ b/labs/index.md
@@ -70,10 +70,9 @@ The labs for this course:
 &nbsp;
 
 - Lab 9: x86 (assembly), part 2: in 32-bit and 64-bit versions
-    - ~~[32-bit version of the lab](lab09-32bit/index.html)~~
-        - ~~Readings: the two x86 book chapters: [x86 Assembly](../book/x86-32bit-asm-chapter.pdf) and [The x86 C Calling Convention](../book/x86-32bit-ccc-chapter.pdf)~~
     - [64-bit version of the lab](lab09-64bit/index.html)
         - Readings: the two x86 book chapters: [x86 Assembly](../book/x86-64bit-asm-chapter.pdf) and [The x86 C Calling Convention](../book/x86-64bit-ccc-chapter.pdf)
+    - ~~[32-bit version of the lab, from previous years](lab09-32bit/index.html)~~
     - For both labs:
         - Source code: [timer.cpp](lab06/code/timer.cpp.html) ([src](lab06/code/timer.cpp)) and  [timer.h](lab06/code/timer.h.html) ([src](lab06/code/timer.h)), both of which are from lab 6
         - The tutorial, for the post-lab, is the [C tutorial](../tutorials/09-c/index.html); you will need to implement the linkedlist.c program.

--- a/labs/index.md
+++ b/labs/index.md
@@ -62,12 +62,10 @@ The labs for this course:
 &nbsp;
 
 - Lab 8: x86 (assembly), part 1: in 32-bit and 64-bit versions
-    - ~~[32-bit version of the lab](lab08-32bit/index.html)~~
-        - ~~Source code: [vecsum.s](lab08-32bit/vecsum.s.html) ([src](lab08-32bit/vecsum.s)), [main.cpp](lab08-32bit/main.cpp.html) ([src](lab08-32bit/main.cpp)), [Makefile](lab08-32bit/Makefile.html) ([src](lab08-32bit/Makefile))~~
-        - ~~Readings (which is also the tutorial): the two x86 book chapters: [x86 Assembly](../book/x86-32bit-asm-chapter.pdf) and [The x86 C Calling Convention](../book/x86-32bit-ccc-chapter.pdf)~~
     - [64-bit version of the lab](lab08-64bit/index.html)
         - Source code: [vecsum.s](lab08-64bit/vecsum.s.html) ([src](lab08-64bit/vecsum.s)), [main.cpp](lab08-64bit/main.cpp.html) ([src](lab08-64bit/main.cpp)), [Makefile](lab08-64bit/Makefile.html) ([src](lab08-64bit/Makefile)), [mergeSort.s](lab08-64bit/mergeSort.s.html) ([src](lab08-64bit/mergeSort.s)), [testMergeSort.cpp](lab08-64bit/testMergeSort.cpp.html) ([src](lab08-64bit/testMergeSort.cpp))
         - Readings (which is also the tutorial): the C++/assembly tutorial, which consists of reading [x86-64 Machine-Level Programming](https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf) from CMU
+    - ~~[32-bit version of the lab, from previous years](lab08-32bit/index.html)~~
 
 &nbsp;
 

--- a/labs/lab10/index.html
+++ b/labs/lab10/index.html
@@ -35,7 +35,7 @@
 <li>Implement the Huffman encoding routine discussed in the pre-lab section.</li>
 <li>Your program must compile with make!</li>
 <li>Your program should only take in one command-line parameter!</li>
-<li>Files to download: <a href="fileio.cpp.html">fileio.cpp</a> (<a href="fileio.cpp">src</a>), and the example files in the labs/lab10/examples/ directory, or as one <a href="examples.zip" class="uri">examples.zip</a> file)</li>
+<li>Files to download: <a href="fileio.cpp.html">fileio.cpp</a> (<a href="fileio.cpp">src</a>), and the example files (in the labs/lab10/examples/ directory), or as one <a href="examples.zip" class="uri">examples.zip</a> file)</li>
 <li>Files to submit: heap.cpp, heap.h, huffmanenc.cpp, Makefile (you can submit additional .cpp/.h files, if needed, as long as it compiles with <code>make</code>)</li>
 </ol>
 <h3 id="in-lab">In-lab</h3>


### PR DESCRIPTION
Because the 32-bit versions of the assembly labs have been discontinued, I think it's better to reduce the clutter by having only one link to it (instead of having links to its readings and source code).

This addresses #62.