### PR TITLE
Add --standalone for Pandoc 2

### DIFF
--- a/utils/convert-markdown-to-html.sh
+++ b/utils/convert-markdown-to-html.sh
@@ -9,10 +9,9 @@ for infile in `find . -type f -name '*.md' | grep -v 'reveal\.js'`; do
     # calculate relative path from any file in a subdirectory to another (CSS) in the root directory
     pathprefix=`echo ${infile:2} | tr -d -c '/' | sed -r 's/\//..\//g'`
     # perform the conversion from MD to HTML, linking CSS in the process
-    pandoc -V "pagetitle:$lineone" -f markdown -c ${pathprefix}markdown.css -t html5 -o $outfile $infile
-    # remove the 'align="left"' tags that some versions of pandoc add to the <td> and <th> tags
-    sed -i s/'<td align="left">'/'<td>'/g $outfile
-    sed -i s/'<th align="left">'/'<th>'/g $outfile
+    pandoc --standalone --variable "pagetitle:$lineone" --css ${pathprefix}markdown.css\
+           --from markdown --to html5 --output $outfile $infile
 done
 
-pandoc -V"Teaching Assistants" -f markdown -c ../markdown.css -c tas.css -t html5 -o uva/tas.html uva/tas.md
+pandoc --standalone --variable "pagetitle:Teaching Assistants" --css ../markdown.css --css tas.css\
+       --from markdown --to html5 --output uva/tas.html uva/tas.md

--- a/uva/tas.html
+++ b/uva/tas.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-  <title></title>
+  <title>Teaching Assistants</title>
   <style type="text/css">code{white-space: pre;}</style>
   <link rel="stylesheet" href="../markdown.css">
   <link rel="stylesheet" href="tas.css">


### PR DESCRIPTION
I _think_ this should fix HTML generation on Pandoc 2.x, but I can't confirm because Ubuntu 18.04 only goes up to 1.19 and I haven't manually installed Pandoc 2.

Also, since we're using HTML5 now, we don't need the align stuff anymore.