### PR TITLE
Try harder on macOS

### DIFF
--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -181,7 +181,17 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)<
 <li><em>Memory corruption</em> occurs when your code attempts to access some memory address that it does not have access to, for example, attempting to read or write to a previously-deleted pointer. C++ will blindly dereference a pointer without checking its validity. Clearly, this can cause your program to do unexpected things!</li>
 </ul>
 <p>These types of errors can cause your host machine to run out of memory and crash, or edit some other file that your program shouldn't have access to! We will be checking that your code does not contain any memory errors because of their potential severity.</p>
-<p>You can test for memory errors by compiling your code with special <em>sanitizers</em> enabled:</p>
+<p>To be able to test for memory errors, there are a few things you need to do first depending on your platform.</p>
+<ul>
+<li><p>Linux</p>
+<pre><code>sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-6.0 1000</code></pre></li>
+<li><p>macOS</p>
+<pre><code>/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;
+brew install llvm
+echo -e &quot;/usr/local/opt/llvm/bin\n$(cat /etc/path)&quot; &gt; /etc/path
+# Finally, close and reopen your terminal</code></pre></li>
+</ul>
+<p>Now you can compile your code with special <em>sanitizers</em> enabled:</p>
 <pre><code>clang++ List.cpp ListItr.cpp ListNode.cpp ListTest.cpp -fsanitize=address,leak -fno-omit-frame-pointer -g</code></pre>
 <p><code>-fsanitize=address,leak</code> turns on two sanitizers: <a href="https://clang.llvm.org/docs/AddressSanitizer.html">AddressSanitizer</a> and <a href="https://clang.llvm.org/docs/LeakSanitizer.html">LeakSanitizer</a>. AddressSanitizer ensures that your code never attempts to reference deleted memory or memory that you do not have access to (i.e., it checks for invalid addresses). LeakSanitizer ensures that anything that is dynamically allocated is also deallocated.</p>
 <p><code>-fno-omit-frame-pointer</code> helps us obtain better stack traces, so we include it just in case.</p>

--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -188,8 +188,9 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)<
 <li><p>macOS</p>
 <pre><code>/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;
 brew install llvm
-echo -e &quot;/usr/local/opt/llvm/bin\n$(cat /etc/path)&quot; &gt; /etc/path
-# Finally, close and reopen your terminal</code></pre></li>
+PROFILE_FILE=$(if [[ -n $ZSH_VERSION ]]; then echo ~/.zshrc; else echo ~/.bash_profile; fi)
+echo &#39;export PATH=&quot;/usr/local/opt/llvm/bin:${PATH}&quot;&#39; &gt;&gt; $PROFILE_FILE
+source $PROFILE_FILE</code></pre></li>
 </ul>
 <p>Now you can compile your code with special <em>sanitizers</em> enabled:</p>
 <pre><code>clang++ List.cpp ListItr.cpp ListNode.cpp ListTest.cpp -fsanitize=address,leak -fno-omit-frame-pointer -g</code></pre>

--- a/labs/lab02/index.md
+++ b/labs/lab02/index.md
@@ -265,7 +265,22 @@ These types of errors can cause your host machine to run out of memory and crash
 or edit some other file that your program shouldn't have access to!
 We will be checking that your code does not contain any memory errors because of their potential severity.
 
-You can test for memory errors by compiling your code with special _sanitizers_ enabled:
+To be able to test for memory errors, there are a few things you need to do first depending on your platform.
+
+- Linux
+```
+sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-6.0 1000
+```
+
+- macOS
+```
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install llvm
+echo -e "/usr/local/opt/llvm/bin\n$(cat /etc/path)" > /etc/path
+# Finally, close and reopen your terminal
+```
+
+Now you can compile your code with special _sanitizers_ enabled:
 
 ```
 clang++ List.cpp ListItr.cpp ListNode.cpp ListTest.cpp -fsanitize=address,leak -fno-omit-frame-pointer -g

--- a/labs/lab02/index.md
+++ b/labs/lab02/index.md
@@ -272,29 +272,13 @@ To be able to test for memory errors, there are a few things you need to do firs
 sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-6.0 1000
 ```
 
-- macOS (Mojave and earlier)
+- macOS
 ```
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install llvm
-vim ~<USERNAME>/.bash_profile
-# Type i
-# Paste (command + v) the following above the 'export PATH' line
-PATH="/usr/local/opt/llvm/bin:${PATH}"
-# Escape, type :wq
-# Finally, close and reopen your terminal
-```
-
-- macOS (Catalina)
-```
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-brew install llvm
-cd
-vim .zsh
-# Type i
-# Paste (command + v) the following at the bottom of the file
-export PATH="/usr/local/opt/llvm/bin:${PATH}"
-# Escape, type :wq
-# Finally, close and reopen your terminal
+PROFILE_FILE=$(if [[ -n $ZSH_VERSION ]]; then echo ~/.zshrc; else echo ~/.bash_profile; fi)
+echo 'export PATH="/usr/local/opt/llvm/bin:${PATH}"' >> $PROFILE_FILE
+source $PROFILE_FILE
 ```
 
 Now you can compile your code with special _sanitizers_ enabled:


### PR DESCRIPTION
Since the /etc/path method apparently didn't work, this approach modifies the relevant profile files directly.

@disha-jain we discussed the potential consequences of directly appending to bash_profile. I did more research and found that some commonly-used software such as nvm [does append to the profile](https://github.com/nvm-sh/nvm/blob/a1ad32e9cbc9ab2b1f955e0c7ab6e206cdfdd75c/install.sh#L378), so if they do it without issues we should be able to as well.

The issue with this approach is that if they already have customized ~/.profile or ~/.bash_login, creating a ~/.bash_profile will completely ignore those modifications.

Since I don't keep wanting to bother Disha, I've recruited some Herefordians so that I can run commands on their laptops instead :).