### PR TITLE
Add requirements for postlab stack

### DIFF
--- a/labs/lab03/index.html
+++ b/labs/lab03/index.html
@@ -170,15 +170,16 @@ Hint: we can check for all the operators, since there are only five of them. If 
 <p>cin takes in all input as strings, but we need to convert those to strings so that we can push them into the stack. Perhaps you should take a look at <a href="https://en.cppreference.com/w/cpp/string/basic_string">the <code>string</code> documentation</a> to see if anything can help you out.</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
-<p>For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack. This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).</p>
+<p>For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack.</p>
+<p>Your stack class must:</p>
+<ul>
+<li>Implement the <code>void push(int e)</code>, <code>void pop()</code>, <code>int top()</code>, and <code>bool empty()</code> methods to perform the same functionality as the STL stack</li>
+<li>Internally use a linked list</li>
+<li>Have no maximum capacity (we should be able to push as many elements as we'd like)</li>
+<li>Not use any STL containers</li>
+</ul>
+<p>You may modify and re-use your LinkedList code from Lab 2, or you may write your own code, as long as you satisfy the above requirements.</p>
 <p>You will also need to write up a difficulties.txt file which contains a paragraph describing any difficulties you encountered getting your code working and what you did to solve them.</p>
-<p>Your stack is only required to implement the four methods as described in the prelab: <code>push()</code>, <code>pop()</code>, <code>top()</code>, and <code>empty()</code>. It must also have no maximum capacity -- in other words, we should be able to push as many elements as we'd like.</p>
-<p>Most of you will implement your stack in one of the following ways:</p>
-<ol type="1">
-<li>Re-use your list class from lab 2. You may need to add one or two methods to it for extra convenience.</li>
-<li>Build a linked-list / pointer-based stack as discussed in lecture. Your stack class would contain a pointer to the head node of the stack, and push and pop would modify the singly-linked list accordingly.</li>
-<li>Manually implement an array-based stack. If you choose this method, your array must be able to automatically resize if the stack grows large enough to sufficiently fill the array. This is probably the most difficult of the three options.</li>
-</ol>
 <h3 id="submitting-the-stack-list-files">Submitting the stack / list files</h3>
 <p>Depending on how you implement the stack class, you may just need the stack.h/cpp files, in addition to the three postfix calculator files (postfixCalculator.h/cpp and testPostfixCalc.cpp). Or you may need stack.h/cpp and stacknode.h/cpp in addition to the three postfix calculator files. Or you may want to include the six List/ListItr/ListNode files from lab 2 as well as stack.h/cpp and the three postfix calculator files. How you do this is up to you - as long as it works, we don't really care, provided that:</p>
 <ol type="1">

--- a/labs/lab03/index.md
+++ b/labs/lab03/index.md
@@ -228,18 +228,18 @@ Perhaps you should take a look at [the `string` documentation](https://en.cppref
 Post-lab
 --------
 
-For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack.  This can be code that you write yourself, or you can re-use your List code from lab 2 (make sure it works before you re-use it, though!).
+For the post-lab, you will be implementing your own stack and then modifying your postfix calculator to use that stack instead of the STL stack.
+
+Your stack class must:
+
+- Implement the `void push(int e)`, `void pop()`, `int top()`, and `bool empty()` methods to perform the same functionality as the STL stack
+- Internally use a linked list
+- Have no maximum capacity (we should be able to push as many elements as we'd like)
+- Not use any STL containers
+
+You may modify and re-use your LinkedList code from Lab 2, or you may write your own code, as long as you satisfy the above requirements.
 
 You will also need to write up a difficulties.txt file which contains a paragraph describing any difficulties you encountered getting your code working and what you did to solve them.
-
-Your stack is only required to implement the four methods as described in the prelab: `push()`, `pop()`, `top()`, and `empty()`.
-It must also have no maximum capacity -- in other words, we should be able to push as many elements as we'd like.
-
-Most of you will implement your stack in one of the following ways:
-
-1. Re-use your list class from lab 2. You may need to add one or two methods to it for extra convenience.
-2. Build a linked-list / pointer-based stack as discussed in lecture. Your stack class would contain a pointer to the head node of the stack, and push and pop would modify the singly-linked list accordingly.
-3. Manually implement an array-based stack. If you choose this method, your array must be able to automatically resize if the stack grows large enough to sufficiently fill the array. This is probably the most difficult of the three options.
 
 ### Submitting the stack / list files ###
 


### PR DESCRIPTION
When cleaning up the procedures section, I accidentally removed the only mention against using STL containers for the postlab stack. I've added them back, but this time in the actual postlab section.

**I also removed the option to create an array-based stack** based on brief conversation with Disha after I missed the improvement staff meeting. If that's still allowable, I can easily add it back.