### PR TITLE
Makefile for in-lab 11 shouldn't require only one target

### DIFF
--- a/labs/lab11/index.html
+++ b/labs/lab11/index.html
@@ -48,7 +48,7 @@
 <li>Implement a brute-force traveling salesperson solution, as described in the in-lab section.</li>
 <li>Create a Makefile that will fully compile your code. You should not specify the resulting executable name (i.e., no <code>-o</code> output for the final link step). It will default to a.out, which is what is desired.</li>
 <li>Document your C++ files with doxygen commands. You must <strong>ALSO</strong> include commented middleearth.h and middleearth.cpp (this should have been done in the pre-lab).</li>
-<li>Your code should compile with <code>make</code>! It should do <strong><em>TWO</em></strong> tasks: compile your code, and call <code>doxygen</code>. See the pre-lab section for more information about required make target.</li>
+<li>Your code should compile with <code>make</code>! It should do <strong><em>TWO</em></strong> tasks: compile your code, and call <code>doxygen</code>. The Makefile requirements for the in-lab are the same as those for the pre-lab.</li>
 <li>Files to download: <a href="traveling-skeleton.cpp.html">traveling-skeleton.cpp</a> (<a href="traveling-skeleton.cpp">src</a>) (which you'll have to rename to traveling.cpp), and your commented middleearth.h / middleearth.cpp code from the pre-lab</li>
 <li>Files to submit: traveling.cpp, middleearth.h, middleearth.cpp, Makefile, Doxyfile</li>
 </ol>
@@ -192,7 +192,7 @@ student@cassiopeia:~/labs/lab11$ </code></pre>
 <p>When compiled with <code>-O2</code>, the computation of a path of length 10 took 18 seconds on Linux.</p>
 <p>Your final program needs to both be able to compile and run with the specified command-line parameters.</p>
 <h3 id="makefile-1">Makefile</h3>
-<p>Your Makefile should have <strong>only one</strong> target, which you can name anything you want. This target should do <strong>two</strong> things: compile your code, and run doxygen. You can have two tabbed lines after the target specifier, which is the easiest way to accomplish this. In other words, we are just going to call <code>make</code>, and we want it to both compile your code and create your doxygen documentation. The in-lab Makefile should have the same dual-purpose target.</p>
+<p>The Makefile requirements for this in-lab are the same as those for the pre-lab.</p>
 <hr />
 <h2 id="post-lab-1">Post-lab</h2>
 <p>There are two parts to the post-lab: a complexity analysis of your code, as well as investigating acceleration techniques for the traveling salesperson problem.</p>

--- a/labs/lab11/index.md
+++ b/labs/lab11/index.md
@@ -266,7 +266,7 @@ Your final program needs to both be able to compile and run with the specified c
 
 ### Makefile ###
 
-Your Makefile should have **only one** target, which you can name anything you want.  This target should do **two** things: compile your code, and run doxygen.  You can have two tabbed lines after the target specifier, which is the easiest way to accomplish this.  In other words, we are just going to call `make`, and we want it to both compile your code and create your doxygen documentation.  The in-lab Makefile should have the same dual-purpose target.
+The Makefile requirements for this in-lab are the same as those for the pre-lab.
 
 ------------------------------------------------------------
 

--- a/labs/lab11/index.md
+++ b/labs/lab11/index.md
@@ -41,7 +41,7 @@ Procedure
 1. Implement a brute-force traveling salesperson solution, as described in the in-lab section.
 2. Create a Makefile that will fully compile your code.  You should not specify the resulting executable name (i.e., no `-o` output for the final link step).  It will default to a.out, which is what is desired.
 3. Document your C++ files with doxygen commands.  You must **ALSO** include commented middleearth.h and middleearth.cpp (this should have been done in the pre-lab).
-4. Your code should compile with `make`!  It should do ***TWO*** tasks: compile your code, and call `doxygen`.  See the pre-lab section for more information about required make target.
+4. Your code should compile with `make`!  It should do ***TWO*** tasks: compile your code, and call `doxygen`. The Makefile requirements for the in-lab are the same as those for the pre-lab.
 5. Files to download: [traveling-skeleton.cpp](traveling-skeleton.cpp.html) ([src](traveling-skeleton.cpp)) (which you'll have to rename to traveling.cpp), and your commented middleearth.h / middleearth.cpp code from the pre-lab
 6. Files to submit: traveling.cpp, middleearth.h, middleearth.cpp, Makefile, Doxyfile
 


### PR DESCRIPTION
I think that there are 2 issues with requiring the makefile to have only 1 target that compiles and links all of the .cpp and .h files:

1) It seems that every time we run `make`, it will compile all of the .cpp files instead of only the .cpp files that have changed since `make` was last run. This is almost equivalent to running `clang++ middleearth.cpp traveling.cpp` (which compiles and links both files regardless of any changes made), and so it seems that having only 1 target would defeat the purpose of a makefile.

2) The makefile will look a bit disorganized. It's more readable if the first target only links the .o files, and if the other targets create these .o files by compiling the necessary .cpp files.

Thus, I've changed the in-lab makefile requirements to match those of the pre-lab (whose makefile does not require only 1 target).