### PR TITLE
Fixed typo and removed dead link.

### DIFF
--- a/slides/05-trees.html
+++ b/slides/05-trees.html
@@ -595,8 +595,7 @@ Consider the postfix expression: a b + c d e + \* \*; the final expression tree 
 
 	  <section data-markdown><script type="text/template">
 ## Animation Tools
-- A good AVL tree animation tool is [here](http://www.qmatica.com/DataStructures/Trees/BST.html)
-  - A mirror that also contains the animation tool is [here](http://webdiis.unizar.es/asignaturas/EDA/AVLTree/avltree.html)
+- A good AVL tree animation tool is [here](http://webdiis.unizar.es/asignaturas/EDA/AVLTree/avltree.html)
 - We'll be using this website throughout this slide set
 	  </script></section>
 
@@ -1014,7 +1013,7 @@ unsigned int fib (unsigned int n) {
 	  <section data-markdown><script type="text/template">
 ## Recursion on trees
 ```
-void func (BinaryeNode *node) {
+void func (BinaryNode *node) {
     if ( node == NULL )
 	    return;
     func (node->left);


### PR DESCRIPTION
Looks like `qmatica.com` is dead as it redirects to the default GoDaddy parked landing page.