### PR TITLE
update readings for labs 7, 8, and 9

### DIFF
--- a/labs/lab07/index.html
+++ b/labs/lab07/index.html
@@ -21,7 +21,7 @@
 <h3 id="readings">Reading(s):</h3>
 <ol type="1">
 <li>Read the <a href="../../slides/07-ibcm.html">slides on IBCM</a></li>
-<li>Read <a href="../../book/ibcm-chapter.pdf">IBCM book chapter</a> (PDF)</li>
+<li>Read <a href="../../book/ibcm-chapter.pdf">IBCM book chapter</a> (PDF), especially sections 1.6 (Writing IBCM Programs) and 1.7 (Example Programs)</li>
 <li>Run IBCM code online <a href="http://pegasus.cs.virginia.edu/ibcm/">here</a>. The sample code in the book chapter is also in the repo: <a href="../../ibcm/summation.ibcm">summation.ibcm</a> and <a href="../../ibcm/array-summation.ibcm">array-summation.ibcm</a></li>
 </ol>
 <h2 id="procedure">Procedure</h2>

--- a/labs/lab07/index.md
+++ b/labs/lab07/index.md
@@ -14,7 +14,7 @@ IBCM (Itty Bitty Computing Machine) is a simulated computer with a minimal instr
 ### Reading(s): ###
 
 1. Read the [slides on IBCM](../../slides/07-ibcm.html)
-2. Read [IBCM book chapter](../../book/ibcm-chapter.pdf) (PDF)
+2. Read [IBCM book chapter](../../book/ibcm-chapter.pdf) (PDF), especially sections 1.6 (Writing IBCM Programs) and 1.7 (Example Programs)
 3. Run IBCM code online [here](http://pegasus.cs.virginia.edu/ibcm/).  The sample code in the book chapter is also in the repo: [summation.ibcm](../../ibcm/summation.ibcm) and [array-summation.ibcm](../../ibcm/array-summation.ibcm)
 
 Procedure

--- a/labs/lab08-64bit/index.html
+++ b/labs/lab08-64bit/index.html
@@ -23,7 +23,9 @@
 <ol type="1">
 <li>Read the <a href="../../slides/08-assembly-64bit.html">slides on 64 bit x86</a></li>
 <li>The x86 book chapters on <a href="../../book/x86-64bit-asm-chapter.pdf">x86</a> and the <a href="../../book/x86-64bit-ccc-chapter.pdf">C calling convention</a></li>
+<li>The <a href="https://www.youtube.com/watch?v=XbZQ-EonR_I">x86 Call Stack</a> introduction from the University of Washington</li>
 <li>An optional online reading is <a href="https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf">x86-64 Machine-Level Programming</a> from CMU, although they use the other assembly language format</li>
+<li>An optional <a href="https://medium.com/@connorstack/a-guide-to-x86-calling-convention-824a3236ed65">Medium article</a> stepping through the calling convention once again.</li>
 </ol>
 <h2 id="procedure">Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>

--- a/labs/lab08-64bit/index.md
+++ b/labs/lab08-64bit/index.md
@@ -17,7 +17,9 @@ The Intel x86 assembly language is currently one of the most popular assembly la
 
 1. Read the [slides on 64 bit x86](../../slides/08-assembly-64bit.html)
 2. The x86 book chapters on [x86](../../book/x86-64bit-asm-chapter.pdf) and the [C calling convention](../../book/x86-64bit-ccc-chapter.pdf)
-3. An optional online reading is [x86-64 Machine-Level Programming](https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf) from CMU, although they use the other assembly language format
+3. The [x86 Call Stack](https://www.youtube.com/watch?v=XbZQ-EonR_I) introduction from the University of Washington
+4. An optional online reading is [x86-64 Machine-Level Programming](https://www.cs.cmu.edu/~fp/courses/15213-s07/misc/asm64-handout.pdf) from CMU, although they use the other assembly language format
+5. An optional [Medium article](https://medium.com/@connorstack/a-guide-to-x86-calling-convention-824a3236ed65) stepping through the calling convention once again.
 
 
 Procedure

--- a/labs/lab09-64bit/index.html
+++ b/labs/lab09-64bit/index.html
@@ -23,6 +23,7 @@
 <ol type="1">
 <li>Read the <a href="../../slides/08-x86.html">slides on x86</a></li>
 <li>The two book chapters on x86: <a href="../../book/x86-64bit-asm-chapter.pdf">x86 Assembly</a> and <a href="../../book/x86-64bit-ccc-chapter.pdf">The x86 C Calling Convention</a>.</li>
+<li>The <a href="http://www.cs.virginia.edu/~evans/cs216/guides/x86.html">x86 Assembly Guide</a> from an older course at UVA (ignore the section on Calling Convention)</li>
 </ol>
 <h2 id="lab-procedure">Lab Procedure</h2>
 <h3 id="pre-lab">Pre-lab</h3>

--- a/labs/lab09-64bit/index.md
+++ b/labs/lab09-64bit/index.md
@@ -17,6 +17,7 @@ The Intel x86 assembly language is currently one of the most popular assembly la
 
 1. Read the [slides on x86](../../slides/08-x86.html)
 2. The two book chapters on x86: [x86 Assembly](../../book/x86-64bit-asm-chapter.pdf) and [The x86 C Calling Convention](../../book/x86-64bit-ccc-chapter.pdf).
+3. The [x86 Assembly Guide](http://www.cs.virginia.edu/~evans/cs216/guides/x86.html) from an older course at UVA (ignore the section on Calling Convention)
 
 Lab Procedure
 ---------------


### PR DESCRIPTION
The changes made:

- Lab 7: highlight specific sections of the IBCM chapter to look at
- Lab 8: add a Youtube video and a Medium article
- Lab 9: link to David Evans' old x86 assembly guide for instruction reference
