### PR TITLE
A few fixes to the IBCM slides

### DIFF
--- a/slides/07-ibcm.html
+++ b/slides/07-ibcm.html
@@ -283,7 +283,7 @@ store 300
 - Shifts
   - Opcode is 2
   - next 2 bits specify shift type
-  - last 5 bits specify shift amount
+  - last 4 bits specify shift amount
 - Others
   - Opcode is 3 to F (15)
   - Last 12 bits specify the address for the instruction

--- a/slides/07-ibcm.html
+++ b/slides/07-ibcm.html
@@ -185,10 +185,8 @@ store 300
 	  <section data-markdown><script type="text/template">
 ## Running IBCM programs
 - Online IBCM simulator
-  - http://pegasus.cs.virginia.edu/ibcm/
-- Mirrors (best to use in this order):
-  - http://people.virginia.edu/~asb2t/ibcm/
-  - http://libra.cs.virginia.edu/ibcm/
+  - https://pegasus.cs.virginia.edu/ibcm/
+  - https://libra.cs.virginia.edu/ibcm/
 - This program will hang your browser if it gets stuck in an infinite loop, due to how web browsers (don't) handle Javascript threads and polling of web pages
 	  </script></section>
 


### PR DESCRIPTION
Importantly, shifts only look at the last 4 bits (or at least, that's what the PDF says and what the simulator goes by).