### PR TITLE
Fixed link to memory addressing slide in lab08-64bit

### DIFF
--- a/labs/lab08-64bit/index.html
+++ b/labs/lab08-64bit/index.html
@@ -164,6 +164,6 @@ Found 2 at index 1</code></pre>
 <p>Once you have completed the in-lab, submit linearSearch.s, testLinearSearch.cpp, and your Makefile</p>
 <h3 id="hints">Hints</h3>
 <h4 id="accessing-array-elements-in-assembly">Accessing Array Elements in Assembly</h4>
-<p>Recall that C++ arrays are stored contiguously in memory. This means that if you know the start address of the array <code>&amp;a</code>, and the size of the elements that are being stored, you can find the address of an element at any index <code>i</code> with <code>&amp;a[i] = &amp;a + &lt;size_of_elements&gt;*i</code> (if the array is one-dimensional). Use this fact along with <a href="../slides/08-assembly-64bit.html#/3/8">the memory addressing slide</a> from lecture to access array elements in assembly.</p>
+<p>Recall that C++ arrays are stored contiguously in memory. This means that if you know the start address of the array <code>&amp;a</code>, and the size of the elements that are being stored, you can find the address of an element at any index <code>i</code> with <code>&amp;a[i] = &amp;a + &lt;size_of_elements&gt;*i</code> (if the array is one-dimensional). Use this fact along with <a href="../../slides/08-assembly-64bit.html#/3/8">the memory addressing slide</a> from lecture to access array elements in assembly.</p>
 </body>
 </html>

--- a/labs/lab08-64bit/index.md
+++ b/labs/lab08-64bit/index.md
@@ -213,4 +213,4 @@ Once you have completed the in-lab, submit linearSearch.s, testLinearSearch.cpp,
 
 #### Accessing Array Elements in Assembly ####
 
-Recall that C++ arrays are stored contiguously in memory. This means that if you know the start address of the array `&a`, and the size of the elements that are being stored, you can find the address of an element at any index `i` with `&a[i] = &a + <size_of_elements>*i` (if the array is one-dimensional). Use this fact along with [the memory addressing slide](../slides/08-assembly-64bit.html#/3/8) from lecture to access array elements in assembly.
+Recall that C++ arrays are stored contiguously in memory. This means that if you know the start address of the array `&a`, and the size of the elements that are being stored, you can find the address of an element at any index `i` with `&a[i] = &a + <size_of_elements>*i` (if the array is one-dimensional). Use this fact along with [the memory addressing slide](../../slides/08-assembly-64bit.html#/3/8) from lecture to access array elements in assembly.


### PR DESCRIPTION
The link to "the memory addressing slide" at the bottom of index.html for lab08-64bit began with "../slides/" instead of "../../slides/". This caused the hyperlink to direct to pdr/labs/slides which does not exist.