### PR TITLE
Update Lab 2 

### DIFF
--- a/labs/lab02/index.html
+++ b/labs/lab02/index.html
@@ -275,7 +275,7 @@ The list was made empty (backward): </code></pre>
 <pre><code>/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;
 brew install llvm
 PROFILE_FILE=$(if [[ -n $ZSH_VERSION ]]; then echo ~/.zshrc; else echo ~/.bash_profile; fi)
-echo &#39;ASAN_OPTIONS=detect_leaks=1\nexport PATH=&quot;/usr/local/opt/llvm/bin:${PATH}&quot;&#39; &gt;&gt; $PROFILE_FILE
+echo &#39;export ASAN_OPTIONS=detect_leaks=1\nexport PATH=&quot;/usr/local/opt/llvm/bin:${PATH}&quot;&#39; &gt;&gt; $PROFILE_FILE
 source $PROFILE_FILE</code></pre>
 <p>Now you can compile your code with <a href="https://clang.llvm.org/docs/AddressSanitizer.html">AddressSanitizer</a> enabled:</p>
 <pre><code>clang++ List.cpp ListItr.cpp ListNode.cpp ListTest.cpp -fsanitize=address -fno-omit-frame-pointer -g</code></pre>

--- a/labs/lab02/index.md
+++ b/labs/lab02/index.md
@@ -368,7 +368,7 @@ If you are using Mac OS X (and ONLY if you are using Mac OS X), then you will ne
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install llvm
 PROFILE_FILE=$(if [[ -n $ZSH_VERSION ]]; then echo ~/.zshrc; else echo ~/.bash_profile; fi)
-echo 'ASAN_OPTIONS=detect_leaks=1\nexport PATH="/usr/local/opt/llvm/bin:${PATH}"' >> $PROFILE_FILE
+echo 'export ASAN_OPTIONS=detect_leaks=1\nexport PATH="/usr/local/opt/llvm/bin:${PATH}"' >> $PROFILE_FILE
 source $PROFILE_FILE
 ```
 


### PR DESCRIPTION
This is needed because the subprocess `clang++` needs to be able to read `ASAN_OPTIONS` and it won't get passed unless it's exported.

I used the conversion tools but it changed a ton of stuff in other `.html` files, so I only included the relevant change for the `.html`. Still a little confused on why my setup isn't correctly matching the already generated `.html` files, and I'd like to continue contributing, so if you could advise that would be helpful. I installed `pandoc`, `astyle`, and `source-highlight` with `brew`, so maybe it's installing different versions or maybe I missed a setup part.